### PR TITLE
use heartbeat listener to update serviceInstance list

### DIFF
--- a/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/springboot/autoconfigure/grpc/client/DiscoveryClientNameResolver.java
+++ b/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/springboot/autoconfigure/grpc/client/DiscoveryClientNameResolver.java
@@ -2,28 +2,23 @@ package net.devh.springboot.autoconfigure.grpc.client;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
-
+import io.grpc.Attributes;
+import io.grpc.EquivalentAddressGroup;
+import io.grpc.NameResolver;
+import io.grpc.Status;
+import io.grpc.internal.SharedResourceHolder;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections.CollectionUtils;
 import org.springframework.cloud.client.ServiceInstance;
 import org.springframework.cloud.client.discovery.DiscoveryClient;
 
+import javax.annotation.concurrent.GuardedBy;
 import java.net.InetSocketAddress;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
-import java.util.concurrent.TimeUnit;
-
-import javax.annotation.concurrent.GuardedBy;
-
-import io.grpc.Attributes;
-import io.grpc.EquivalentAddressGroup;
-import io.grpc.NameResolver;
-import io.grpc.Status;
-import io.grpc.internal.LogExceptionRunnable;
-import io.grpc.internal.SharedResourceHolder;
-import lombok.extern.slf4j.Slf4j;
 
 /**
  * User: Michael
@@ -75,13 +70,15 @@ public class DiscoveryClientNameResolver extends NameResolver {
         executor = SharedResourceHolder.get(executorResource);
         this.listener = Preconditions.checkNotNull(listener, "listener");
         resolve();
-        timerService.scheduleWithFixedDelay(new LogExceptionRunnable(resolutionRunnableOnExecutor), 1, 1, TimeUnit.MINUTES);
+        //timerService.scheduleWithFixedDelay(new LogExceptionRunnable(resolutionRunnableOnExecutor), 1, 1, TimeUnit.MINUTES);
     }
 
     @Override
     public final synchronized void refresh() {
-        Preconditions.checkState(listener != null, "not started");
-        resolve();
+        //Preconditions.checkState(listener != null, "not started");
+        if (listener != null) {
+            resolve();
+        }
     }
 
     private final Runnable resolutionRunnable = new Runnable() {

--- a/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/springboot/autoconfigure/grpc/client/DiscoveryClientResolverFactory.java
+++ b/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/springboot/autoconfigure/grpc/client/DiscoveryClientResolverFactory.java
@@ -1,15 +1,13 @@
 package net.devh.springboot.autoconfigure.grpc.client;
 
-import org.springframework.cloud.client.discovery.DiscoveryClient;
-
-import java.net.URI;
-
-import javax.annotation.Nullable;
-
 import io.grpc.Attributes;
 import io.grpc.NameResolver;
 import io.grpc.NameResolverProvider;
 import io.grpc.internal.GrpcUtil;
+import org.springframework.cloud.client.discovery.DiscoveryClient;
+
+import javax.annotation.Nullable;
+import java.net.URI;
 
 /**
  * User: Michael
@@ -18,15 +16,19 @@ import io.grpc.internal.GrpcUtil;
  */
 public class DiscoveryClientResolverFactory extends NameResolverProvider {
     private final DiscoveryClient client;
+    private DiscoveryClientChannelFactory discoveryClientChannelFactory;
 
-    public DiscoveryClientResolverFactory(DiscoveryClient client) {
+    public DiscoveryClientResolverFactory(DiscoveryClient client, DiscoveryClientChannelFactory discoveryClientChannelFactory) {
         this.client = client;
+        this.discoveryClientChannelFactory = discoveryClientChannelFactory;
     }
 
     @Nullable
     @Override
     public NameResolver newNameResolver(URI targetUri, Attributes params) {
-        return new DiscoveryClientNameResolver(targetUri.toString(), client, params, GrpcUtil.TIMER_SERVICE, GrpcUtil.SHARED_CHANNEL_EXECUTOR);
+        DiscoveryClientNameResolver discoveryClientNameResolver = new DiscoveryClientNameResolver(targetUri.toString(), client, params, GrpcUtil.TIMER_SERVICE, GrpcUtil.SHARED_CHANNEL_EXECUTOR);
+        discoveryClientChannelFactory.addDiscoveryClientNameResolver(discoveryClientNameResolver);
+        return discoveryClientNameResolver;
     }
 
     @Override


### PR DESCRIPTION
```java
timerService.scheduleWithFixedDelay(new LogExceptionRunnable(resolutionRunnableOnExecutor), 1, 1, TimeUnit.MINUTES);
```
我觉得DiscoveryClient本身就有一个订时任务去更新本地缓存的service信息，没必要自己去创建一个，而且时间配置也写死了。所以用监听HeartbeatEvent的方法去更新服务信息比较好。

我硬生生的改了点代码。可以优化下。

