### PR TITLE
Add maxInboundMessageSize property in GrpcChannelProperties

### DIFF
--- a/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/springboot/autoconfigure/grpc/client/AddressChannelFactory.java
+++ b/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/springboot/autoconfigure/grpc/client/AddressChannelFactory.java
@@ -49,6 +49,9 @@ public class AddressChannelFactory implements GrpcChannelFactory {
                     .keepAliveTime(channelProperties.getKeepAliveTime(), TimeUnit.SECONDS)
                     .keepAliveTimeout(channelProperties.getKeepAliveTimeout(), TimeUnit.SECONDS);
         }
+        if(channelProperties.getMaxInboundMessageSize() > 0) {
+        	builder.maxInboundMessageSize(channelProperties.getMaxInboundMessageSize());
+        }
         Channel channel = builder.build();
 
         List<ClientInterceptor> globalInterceptorList = globalClientInterceptorRegistry.getClientInterceptors();

--- a/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/springboot/autoconfigure/grpc/client/DiscoveryClientChannelFactory.java
+++ b/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/springboot/autoconfigure/grpc/client/DiscoveryClientChannelFactory.java
@@ -68,6 +68,9 @@ public class DiscoveryClientChannelFactory implements GrpcChannelFactory {
                     .keepAliveTime(channelProperties.getKeepAliveTime(), TimeUnit.SECONDS)
                     .keepAliveTimeout(channelProperties.getKeepAliveTimeout(), TimeUnit.SECONDS);
         }
+        if(channelProperties.getMaxInboundMessageSize() > 0) {
+        	builder.maxInboundMessageSize(channelProperties.getMaxInboundMessageSize());
+        }
         Channel channel = builder.build();
 
         List<ClientInterceptor> globalInterceptorList = globalClientInterceptorRegistry.getClientInterceptors();

--- a/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/springboot/autoconfigure/grpc/client/GrpcChannelProperties.java
+++ b/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/springboot/autoconfigure/grpc/client/GrpcChannelProperties.java
@@ -58,4 +58,9 @@ public class GrpcChannelProperties {
      * Defaults to {@code 20}
      */
     private long keepAliveTimeout = 20;
+    
+    /**
+     * The maximum message size allowed to be received on the channel.
+     */
+    private int maxInboundMessageSize;
 }


### PR DESCRIPTION
Add maxInboundMessageSize property in GrpcChannelProperties, And allow to set it in AddressChannelFactory and DiscoveryClientChannelFactory.