### PR TITLE
Refactor ChannelFactory to reduce code duplication and connection leak

### DIFF
--- a/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/springboot/autoconfigure/grpc/client/AbstractChannelFactory.java
+++ b/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/springboot/autoconfigure/grpc/client/AbstractChannelFactory.java
@@ -1,0 +1,144 @@
+package net.devh.springboot.autoconfigure.grpc.client;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+
+import javax.annotation.PreDestroy;
+import javax.annotation.concurrent.GuardedBy;
+
+import com.google.common.collect.Lists;
+
+import io.grpc.Channel;
+import io.grpc.ClientInterceptor;
+import io.grpc.ClientInterceptors;
+import io.grpc.LoadBalancer;
+import io.grpc.ManagedChannel;
+import io.grpc.NameResolver;
+import io.grpc.netty.NettyChannelBuilder;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * This abstract channel factory contains some shared code for other {@link GrpcChannelFactory}s.
+ * This class utilizes connection pooling and thus needs to be {@link #close() closed} after usage.
+ *
+ * @author Michael (yidongnan@gmail.com)
+ * @author Daniel Theuke (daniel.theuke@heuboe.de)
+ * @since 5/17/16
+ */
+@Slf4j
+public abstract class AbstractChannelFactory implements GrpcChannelFactory {
+
+    private final GrpcChannelsProperties properties;
+    private final LoadBalancer.Factory loadBalancerFactory;
+    private final NameResolver.Factory nameResolverFactory;
+    private final GlobalClientInterceptorRegistry globalClientInterceptorRegistry;
+    /**
+     * According to <a href="https://groups.google.com/forum/#!topic/grpc-io/-jA_JCiugM8">Thread safety
+     * in Grpc java clients</a>: {@link ManagedChannel}s should be reused to allow connection reuse.
+     */
+    @GuardedBy("this")
+    private final Map<String, ManagedChannel> channels = new ConcurrentHashMap<>();
+    private boolean shutdown = false;
+
+    public AbstractChannelFactory(final GrpcChannelsProperties properties,
+            final LoadBalancer.Factory loadBalancerFactory,
+            final NameResolver.Factory nameResolverFactory,
+            final GlobalClientInterceptorRegistry globalClientInterceptorRegistry) {
+        this.properties = properties;
+        this.loadBalancerFactory = loadBalancerFactory;
+        this.nameResolverFactory = nameResolverFactory;
+        this.globalClientInterceptorRegistry = globalClientInterceptorRegistry;
+    }
+    
+    @SuppressWarnings("unchecked")
+    public <T extends AbstractChannelFactory> AbstractChannelFactory(final GrpcChannelsProperties properties,
+            final LoadBalancer.Factory loadBalancerFactory,
+            final Function<T, NameResolver.Factory> nameResolverFactoryCreator,
+            final GlobalClientInterceptorRegistry globalClientInterceptorRegistry) {
+        this.properties = properties;
+        this.loadBalancerFactory = loadBalancerFactory;
+        this.nameResolverFactory = nameResolverFactoryCreator.apply((T) this);
+        this.globalClientInterceptorRegistry = globalClientInterceptorRegistry;
+    }
+
+    @Override
+    public Channel createChannel(final String name) {
+        return createChannel(name, Collections.emptyList());
+    }
+
+    @Override
+    public Channel createChannel(final String name, final List<ClientInterceptor> interceptors) {
+        final Channel channel;
+        synchronized (this) {
+            if (this.shutdown) {
+                throw new IllegalStateException("GrpcChannelFactory is already closed!");
+            }
+            channel = this.channels.computeIfAbsent(name, this::newManagedChannel);
+        }
+
+        final List<ClientInterceptor> globalInterceptorList =
+                this.globalClientInterceptorRegistry.getClientInterceptors();
+        final Collection<ClientInterceptor> interceptorSet = Lists.newArrayList();
+        if (!globalInterceptorList.isEmpty()) {
+            interceptorSet.addAll(globalInterceptorList);
+        }
+        if (!interceptors.isEmpty()) {
+            interceptorSet.addAll(interceptors);
+        }
+        return ClientInterceptors.intercept(channel, Lists.newArrayList(interceptorSet));
+    }
+
+    private ManagedChannel newManagedChannel(final String name) {
+        final GrpcChannelProperties channelProperties = this.properties.getChannel(name);
+        final NettyChannelBuilder builder = NettyChannelBuilder.forTarget(name)
+                .loadBalancerFactory(this.loadBalancerFactory)
+                .nameResolverFactory(this.nameResolverFactory);
+        builder.negotiationType(channelProperties.getNegotiationType());
+        if (channelProperties.isEnableKeepAlive()) {
+            builder.keepAliveWithoutCalls(channelProperties.isKeepAliveWithoutCalls())
+                    .keepAliveTime(channelProperties.getKeepAliveTime(), TimeUnit.SECONDS)
+                    .keepAliveTimeout(channelProperties.getKeepAliveTimeout(), TimeUnit.SECONDS);
+        }
+        if (channelProperties.getMaxInboundMessageSize() >= 0) {
+            builder.maxInboundMessageSize(channelProperties.getMaxInboundMessageSize());
+        } else if (channelProperties.getMaxInboundMessageSize() == -1) {
+            builder.maxInboundMessageSize(Integer.MAX_VALUE);
+        }
+        if (channelProperties.isFullStreamDecompression()) {
+            builder.enableFullStreamDecompression();
+        }
+        return builder.build();
+    }
+
+    /**
+     * Closes this channel factory and the channels created by this instance. The shutdown happens in
+     * two phases, first an orderly shutdown is initiated on all channels and then the method waits for
+     * all channels to terminate.
+     */
+    @Override
+    @PreDestroy
+    public synchronized void close() throws InterruptedException {
+        if (this.shutdown) {
+            return;
+        }
+        this.shutdown = true;
+        for (final ManagedChannel channel : this.channels.values()) {
+            channel.shutdown();
+        }
+        for (final ManagedChannel channel : this.channels.values()) {
+            int i = 0;
+            do {
+                log.debug("Awaiting channel shutdown: {} ({}s)", channel, i++);
+            } while (!channel.awaitTermination(1, TimeUnit.SECONDS));
+        }
+        final int channelCount = this.channels.size();
+        this.channels.clear();
+        log.debug("GrpcCannelFactory closed (including {} channels)", channelCount);
+    }
+
+}

--- a/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/springboot/autoconfigure/grpc/client/AddressChannelFactory.java
+++ b/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/springboot/autoconfigure/grpc/client/AddressChannelFactory.java
@@ -1,70 +1,22 @@
 package net.devh.springboot.autoconfigure.grpc.client;
 
-import com.google.common.collect.Lists;
-import com.google.common.collect.Sets;
-
-import java.util.List;
-import java.util.Set;
-import java.util.concurrent.TimeUnit;
-
-import io.grpc.Channel;
-import io.grpc.ClientInterceptor;
-import io.grpc.ClientInterceptors;
 import io.grpc.LoadBalancer;
-import io.grpc.NameResolver;
-import io.grpc.netty.NettyChannelBuilder;
 
 /**
- * User: Michael
- * Email: yidongnan@gmail.com
- * Date: 5/17/16
+ * This channel factory creates new Channels based on {@link GrpcChannelProperties} that can be
+ * configured via application properties. This class utilizes connection pooling and thus needs to
+ * be {@link #close() closed} after usage.
+ *
+ * @author Michael (yidongnan@gmail.com)
+ * @since 5/17/16
  */
-public class AddressChannelFactory implements GrpcChannelFactory {
-    private final GrpcChannelsProperties properties;
-    private final LoadBalancer.Factory loadBalancerFactory;
-    private final NameResolver.Factory nameResolverFactory;
-    private final GlobalClientInterceptorRegistry globalClientInterceptorRegistry;
+public class AddressChannelFactory extends AbstractChannelFactory {
 
-    public AddressChannelFactory(GrpcChannelsProperties properties, LoadBalancer.Factory loadBalancerFactory, GlobalClientInterceptorRegistry globalClientInterceptorRegistry) {
-        this.properties = properties;
-        this.loadBalancerFactory = loadBalancerFactory;
-        this.nameResolverFactory = new AddressChannelResolverFactory(properties);
-        this.globalClientInterceptorRegistry = globalClientInterceptorRegistry;
+    public AddressChannelFactory(final GrpcChannelsProperties properties,
+            final LoadBalancer.Factory loadBalancerFactory,
+            final GlobalClientInterceptorRegistry globalClientInterceptorRegistry) {
+        super(properties, loadBalancerFactory, new AddressChannelResolverFactory(properties),
+                globalClientInterceptorRegistry);
     }
 
-    @Override
-    public Channel createChannel(String name) {
-        return this.createChannel(name, null);
-    }
-
-    @Override
-    public Channel createChannel(String name, List<ClientInterceptor> interceptors) {
-        GrpcChannelProperties channelProperties = properties.getChannel(name);
-        NettyChannelBuilder builder = NettyChannelBuilder.forTarget(name)
-                .loadBalancerFactory(loadBalancerFactory)
-                .nameResolverFactory(nameResolverFactory);
-        builder.negotiationType(channelProperties.getNegotiationType());
-        if (channelProperties.isEnableKeepAlive()) {
-            builder.keepAliveWithoutCalls(channelProperties.isKeepAliveWithoutCalls())
-                    .keepAliveTime(channelProperties.getKeepAliveTime(), TimeUnit.SECONDS)
-                    .keepAliveTimeout(channelProperties.getKeepAliveTimeout(), TimeUnit.SECONDS);
-        }
-        if(channelProperties.getMaxInboundMessageSize() > 0) {
-        	builder.maxInboundMessageSize(channelProperties.getMaxInboundMessageSize());
-        }
-        if (channelProperties.isFullStreamDecompression()) {
-            builder.enableFullStreamDecompression();
-        }
-        Channel channel = builder.build();
-
-        List<ClientInterceptor> globalInterceptorList = globalClientInterceptorRegistry.getClientInterceptors();
-        Set<ClientInterceptor> interceptorSet = Sets.newHashSet();
-        if (globalInterceptorList != null && !globalInterceptorList.isEmpty()) {
-            interceptorSet.addAll(globalInterceptorList);
-        }
-        if (interceptors != null && !interceptors.isEmpty()) {
-            interceptorSet.addAll(interceptors);
-        }
-        return ClientInterceptors.intercept(channel, Lists.newArrayList(interceptorSet));
-    }
 }

--- a/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/springboot/autoconfigure/grpc/client/DiscoveryClientChannelFactory.java
+++ b/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/springboot/autoconfigure/grpc/client/DiscoveryClientChannelFactory.java
@@ -1,89 +1,49 @@
 package net.devh.springboot.autoconfigure.grpc.client;
 
-import com.google.common.collect.Lists;
-import com.google.common.collect.Sets;
-import io.grpc.Channel;
-import io.grpc.ClientInterceptor;
-import io.grpc.ClientInterceptors;
-import io.grpc.LoadBalancer;
-import io.grpc.netty.NettyChannelBuilder;
+import java.util.List;
+
 import org.springframework.cloud.client.discovery.DiscoveryClient;
 import org.springframework.cloud.client.discovery.event.HeartbeatEvent;
 import org.springframework.cloud.client.discovery.event.HeartbeatMonitor;
 import org.springframework.context.event.EventListener;
 
-import java.util.List;
-import java.util.Set;
-import java.util.concurrent.TimeUnit;
+import com.google.common.collect.Lists;
+
+import io.grpc.LoadBalancer;
 
 /**
- * User: Michael
- * Email: yidongnan@gmail.com
- * Date: 5/17/16
+ * This channel factory creates new Channels using a {@link DiscoveryClient service discovery}. This
+ * class utilizes connection pooling and thus needs to be {@link #close() closed} after usage.
+ *
+ * @author Michael (yidongnan@gmail.com)
+ * @since 5/17/16
  */
-public class DiscoveryClientChannelFactory implements GrpcChannelFactory {
-    private final GrpcChannelsProperties properties;
-    private final DiscoveryClient client;
-    private final LoadBalancer.Factory loadBalancerFactory;
-    private final GlobalClientInterceptorRegistry globalClientInterceptorRegistry;
-    private HeartbeatMonitor monitor = new HeartbeatMonitor();
+public class DiscoveryClientChannelFactory extends AbstractChannelFactory {
 
-    public DiscoveryClientChannelFactory(GrpcChannelsProperties properties, DiscoveryClient client, LoadBalancer.Factory loadBalancerFactory,
-                                         GlobalClientInterceptorRegistry globalClientInterceptorRegistry) {
-        this.properties = properties;
-        this.client = client;
-        this.loadBalancerFactory = loadBalancerFactory;
-        this.globalClientInterceptorRegistry = globalClientInterceptorRegistry;
+    private final HeartbeatMonitor monitor = new HeartbeatMonitor();
+    private final List<DiscoveryClientNameResolver> discoveryClientNameResolvers = Lists.newArrayList();
+
+    public DiscoveryClientChannelFactory(final GrpcChannelsProperties properties,
+            final LoadBalancer.Factory loadBalancerFactory,
+            final DiscoveryClient client,
+            final GlobalClientInterceptorRegistry globalClientInterceptorRegistry) {
+        <DiscoveryClientChannelFactory>super(properties,
+                loadBalancerFactory,
+                thiz -> new DiscoveryClientResolverFactory(client, thiz),
+                globalClientInterceptorRegistry);
     }
 
-    private List<DiscoveryClientNameResolver> discoveryClientNameResolvers = Lists.newArrayList();
-
-    public void addDiscoveryClientNameResolver(DiscoveryClientNameResolver discoveryClientNameResolver) {
-        discoveryClientNameResolvers.add(discoveryClientNameResolver);
+    public void addDiscoveryClientNameResolver(final DiscoveryClientNameResolver discoveryClientNameResolver) {
+        this.discoveryClientNameResolvers.add(discoveryClientNameResolver);
     }
 
     @EventListener(HeartbeatEvent.class)
-    public void heartbeat(HeartbeatEvent event) {
+    public void heartbeat(final HeartbeatEvent event) {
         if (this.monitor.update(event.getValue())) {
-            for (DiscoveryClientNameResolver discoveryClientNameResolver : discoveryClientNameResolvers) {
+            for (final DiscoveryClientNameResolver discoveryClientNameResolver : this.discoveryClientNameResolvers) {
                 discoveryClientNameResolver.refresh();
             }
         }
     }
 
-    @Override
-    public Channel createChannel(String name) {
-        return this.createChannel(name, null);
-    }
-
-    @Override
-    public Channel createChannel(String name, List<ClientInterceptor> interceptors) {
-        GrpcChannelProperties channelProperties = properties.getChannel(name);
-        NettyChannelBuilder builder = NettyChannelBuilder.forTarget(name)
-                .loadBalancerFactory(loadBalancerFactory)
-                .nameResolverFactory(new DiscoveryClientResolverFactory(client, this));
-        builder.negotiationType(channelProperties.getNegotiationType());
-        if (channelProperties.isEnableKeepAlive()) {
-            builder.keepAliveWithoutCalls(channelProperties.isKeepAliveWithoutCalls())
-                    .keepAliveTime(channelProperties.getKeepAliveTime(), TimeUnit.SECONDS)
-                    .keepAliveTimeout(channelProperties.getKeepAliveTimeout(), TimeUnit.SECONDS);
-        }
-        if(channelProperties.getMaxInboundMessageSize() > 0) {
-        	builder.maxInboundMessageSize(channelProperties.getMaxInboundMessageSize());
-        }
-        if (channelProperties.isFullStreamDecompression()) {
-            builder.enableFullStreamDecompression();
-        }
-        Channel channel = builder.build();
-
-        List<ClientInterceptor> globalInterceptorList = globalClientInterceptorRegistry.getClientInterceptors();
-        Set<ClientInterceptor> interceptorSet = Sets.newHashSet();
-        if (globalInterceptorList != null && !globalInterceptorList.isEmpty()) {
-            interceptorSet.addAll(globalInterceptorList);
-        }
-        if (interceptors != null && !interceptors.isEmpty()) {
-            interceptorSet.addAll(interceptors);
-        }
-        return ClientInterceptors.intercept(channel, Lists.newArrayList(interceptorSet));
-    }
 }

--- a/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/springboot/autoconfigure/grpc/client/GrpcChannelFactory.java
+++ b/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/springboot/autoconfigure/grpc/client/GrpcChannelFactory.java
@@ -4,15 +4,50 @@ import java.util.List;
 
 import io.grpc.Channel;
 import io.grpc.ClientInterceptor;
+import io.grpc.ManagedChannel;
 
 /**
- * User: Michael
- * Email: yidongnan@gmail.com
- * Date: 5/17/16
+ * This factory creates grpc {@link Channel}s for a given service name. Implementations are
+ * encouraged to utilize connection pooling and thus {@link #close() close} should be called before
+ * disposing it.
+ *
+ * @author Michael (yidongnan@gmail.com)
+ * @since 5/17/16
  */
-public interface GrpcChannelFactory {
+public interface GrpcChannelFactory extends AutoCloseable {
 
+    /**
+     * Creates a new channel for the given service name. The returned channel will use all globally
+     * registered {@link ClientInterceptor}s.
+     *
+     * <p>
+     * <b>Note:</b> The underlying implementation might reuse existing {@link ManagedChannel}s allow
+     * connection reuse.
+     * </p>
+     *
+     * @param name The name of the service.
+     * @return The newly created channel for the given service.
+     */
     Channel createChannel(String name);
 
+    /**
+     * Creates a new channel for the given service name. The returned channel will use all globally
+     * registered {@link ClientInterceptor}s.
+     *
+     * <p>
+     * <b>Note:</b> The underlying implementation might reuse existing {@link ManagedChannel}s allow
+     * connection reuse.
+     * </p>
+     *
+     * <p>
+     * <b>Note:</b> The given interceptors will be applied after the global interceptors. But the
+     * interceptors that were applied last, will be called first.
+     * </p>
+     *
+     * @param name The name of the service.
+     * @param interceptors A list of additional client interceptors that should be added to the channel.
+     * @return The newly created channel for the given service.
+     */
     Channel createChannel(String name, List<ClientInterceptor> interceptors);
+
 }

--- a/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/springboot/autoconfigure/grpc/client/GrpcClientAutoConfiguration.java
+++ b/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/springboot/autoconfigure/grpc/client/GrpcClientAutoConfiguration.java
@@ -44,9 +44,12 @@ public class GrpcClientAutoConfiguration {
         return RoundRobinLoadBalancerFactory.getInstance();
     }
 
-    @ConditionalOnMissingBean(value = GrpcChannelFactory.class, type = "org.springframework.cloud.client.discovery.DiscoveryClient")
+    @ConditionalOnMissingBean(value = GrpcChannelFactory.class,
+            type = "org.springframework.cloud.client.discovery.DiscoveryClient")
     @Bean
-    public GrpcChannelFactory addressChannelFactory(GrpcChannelsProperties channels, LoadBalancer.Factory loadBalancerFactory, GlobalClientInterceptorRegistry globalClientInterceptorRegistry) {
+    public GrpcChannelFactory addressChannelFactory(final GrpcChannelsProperties channels,
+            final LoadBalancer.Factory loadBalancerFactory,
+            final GlobalClientInterceptorRegistry globalClientInterceptorRegistry) {
         return new AddressChannelFactory(channels, loadBalancerFactory, globalClientInterceptorRegistry);
     }
 
@@ -62,9 +65,11 @@ public class GrpcClientAutoConfiguration {
 
         @ConditionalOnMissingBean
         @Bean
-        public GrpcChannelFactory discoveryClientChannelFactory(GrpcChannelsProperties channels, DiscoveryClient discoveryClient, LoadBalancer.Factory loadBalancerFactory,
-            GlobalClientInterceptorRegistry globalClientInterceptorRegistry) {
-            return new DiscoveryClientChannelFactory(channels, discoveryClient, loadBalancerFactory, globalClientInterceptorRegistry);
+        public GrpcChannelFactory discoveryClientChannelFactory(final GrpcChannelsProperties channels,
+                final LoadBalancer.Factory loadBalancerFactory, final DiscoveryClient discoveryClient,
+                final GlobalClientInterceptorRegistry globalClientInterceptorRegistry) {
+            return new DiscoveryClientChannelFactory(channels, loadBalancerFactory, discoveryClient,
+                    globalClientInterceptorRegistry);
         }
     }
 


### PR DESCRIPTION
* ManagedChannels should be reused
* ManagedChannels needs to be closed/shutdown, otherwise warnings are shown in the logs (especially during tests, because the JVM does not shutdown immediately)
* Fix interceptor sets not retaining the order

Feel free to request changes or discuss changes. I already detected that my formatter is slightly different from yours. Is there a formatter template or something that I can use?