### PR TITLE
Add default value to GrpcService#value() and deprecate it

### DIFF
--- a/examples/cloud-grpc-server/src/main/java/net/devh/examples/grpc/cloud/GrpcServerService.java
+++ b/examples/cloud-grpc-server/src/main/java/net/devh/examples/grpc/cloud/GrpcServerService.java
@@ -14,7 +14,7 @@ import io.grpc.stub.StreamObserver;
  * Date: 2016/11/8
  */
 
-@GrpcService(SimpleGrpc.class)
+@GrpcService
 public class GrpcServerService extends SimpleGrpc.SimpleImplBase {
 
     @Override

--- a/examples/local-grpc-server/src/main/java/net/devh/examples/grpc/local/GrpcServerService.java
+++ b/examples/local-grpc-server/src/main/java/net/devh/examples/grpc/local/GrpcServerService.java
@@ -14,7 +14,7 @@ import io.grpc.stub.StreamObserver;
  * Date: 2016/11/8
  */
 
-@GrpcService(SimpleGrpc.class)
+@GrpcService
 public class GrpcServerService extends SimpleGrpc.SimpleImplBase {
 
     @Override

--- a/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/springboot/autoconfigure/grpc/server/GrpcService.java
+++ b/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/springboot/autoconfigure/grpc/server/GrpcService.java
@@ -1,27 +1,44 @@
 package net.devh.springboot.autoconfigure.grpc.server;
 
-import org.springframework.stereotype.Service;
-
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+import org.springframework.stereotype.Service;
+
 import io.grpc.ServerInterceptor;
 
 /**
- * User: Michael
- * Email: yidongnan@gmail.com
- * Date: 5/17/16
+ * Annotation that marks gRPC services that should be registered with a gRPC server. If
+ * spring-boot's auto configuration is used, then the server will be created automatically.
+ *
+ * @author Michael (yidongnan@gmail.com)
+ * @since 5/17/16
  */
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
 @Service
 public @interface GrpcService {
+    
+    // Unused - Should be removed
+    @Deprecated
+    Class<?> value() default void.class;
 
-    Class<?> value();
-
+    /**
+     * A list of {@link ServerInterceptor} that should be applied to only this service. If a bean of the
+     * given type exists, it will be used; otherwise a new instance of that class will be created via
+     * no-args constructor.
+     *
+     * <p>
+     * <b>Note:</b> These interceptors will be applied after the global interceptors. But the
+     * interceptors that were applied last, will be called first.
+     * </p>
+     *
+     * @return A list of ServerInterceptors that should be used.
+     */
     Class<? extends ServerInterceptor>[] interceptors() default {};
+
 }


### PR DESCRIPTION
The value from that field is never used and the content of it could be anything, so it cannot be used for anything meaningful.

Feel free to request changes or discuss changes. I already detected that my formatter is slightly different from yours. Is there a formatter template or something that I can use?