### PR TITLE
Improvements and javadocs

### DIFF
--- a/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/springboot/autoconfigure/grpc/client/AddressChannelNameResolver.java
+++ b/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/springboot/autoconfigure/grpc/client/AddressChannelNameResolver.java
@@ -52,19 +52,13 @@ public class AddressChannelNameResolver extends NameResolver {
     @Override
     public final synchronized void start(Listener listener) {
         Preconditions.checkState(this.listener == null, "already started");
-        this.listener = listener;
         executor = SharedResourceHolder.get(executorResource);
         this.listener = Preconditions.checkNotNull(listener, "listener");
         resolve();
     }
 
-    @SuppressWarnings("unchecked")
-    private void replace(List list, int max, Object defaultValue) {
-        for (int i = 0; i < list.size(); i++) {
-            if (list.get(i) == null) {
-                list.set(i, defaultValue);
-            }
-        }
+    private <T> void replace(final List<T> list, final int max, final T defaultValue) {
+        list.replaceAll(e -> e == null ? defaultValue : e);
         for (int i = list.size(); i < max; i++) {
             list.add(defaultValue);
         }

--- a/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/springboot/autoconfigure/grpc/client/DiscoveryClientNameResolver.java
+++ b/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/springboot/autoconfigure/grpc/client/DiscoveryClientNameResolver.java
@@ -69,7 +69,6 @@ public class DiscoveryClientNameResolver extends NameResolver {
     public final synchronized void start(Listener listener) {
         Preconditions.checkState(this.listener == null, "already started");
         timerService = SharedResourceHolder.get(timerServiceResource);
-        this.listener = listener;
         executor = SharedResourceHolder.get(executorResource);
         this.listener = Preconditions.checkNotNull(listener, "listener");
         resolve();

--- a/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/springboot/autoconfigure/grpc/client/GrpcChannelProperties.java
+++ b/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/springboot/autoconfigure/grpc/client/GrpcChannelProperties.java
@@ -1,42 +1,43 @@
 package net.devh.springboot.autoconfigure.grpc.client;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
+import io.grpc.internal.GrpcUtil;
 import io.grpc.netty.NegotiationType;
 import lombok.Data;
 
 /**
- * User: Michael
- * Email: yidongnan@gmail.com
- * Date: 5/17/16
+ * The channel properties for a single named grpc channel or service reference.
+ *
+ * @author Michael (yidongnan@gmail.com)
+ * @since 5/17/16
  */
 @Data
 public class GrpcChannelProperties {
 
     public static final String DEFAULT_HOST = "127.0.0.1";
     public static final Integer DEFAULT_PORT = 9090;
+    private static final List<String> DEFAULT_HOSTS = Arrays.asList(DEFAULT_HOST);
+    private static final List<Integer> DEFAULT_PORTS = Arrays.asList(DEFAULT_PORT);
 
     public static final GrpcChannelProperties DEFAULT = new GrpcChannelProperties();
 
-    private List<String> host = new ArrayList<String>() {
-        private static final long serialVersionUID = -8367871342050560040L;
-
-        {
-            add(DEFAULT_HOST);
-        }
-    };
-    private List<Integer> port = new ArrayList<Integer>() {
-        private static final long serialVersionUID = 4705083089654936515L;
-
-        {
-            add(DEFAULT_PORT);
-        }
-    };
+    /**
+     * A list of hosts to connect to. These entries should be kept in tandem with the port entries.
+     * Defaults to {@link #DEFAULT_HOST}.
+     */
+    private List<String> host = new ArrayList<>(DEFAULT_HOSTS);
 
     /**
-     * Setting to enable keepalive.
-     * Default to {@code false}
+     * A list of ports to connect to. These entries should be kept in tandem with the host entries.
+     * Defaults to {@link #DEFAULT_PORT}.
+     */
+    private List<Integer> port = new ArrayList<>(DEFAULT_PORTS);
+
+    /**
+     * Setting to enable keepalive. Default to {@code false}.
      */
     private boolean enableKeepAlive = false;
 
@@ -47,23 +48,29 @@ public class GrpcChannelProperties {
     private boolean keepAliveWithoutCalls = false;
 
     /**
-     * The default delay in seconds before we send a keepalive.
-     * Defaults to {@code 180}
+     * The default delay in seconds before we send a keepalive. Defaults to {@code 60}.
      */
-    private long keepAliveTime = 180;
+    private long keepAliveTime = 60;
 
     /**
-     * The default timeout in seconds for a keepalive ping request.
-     * Defaults to {@code 20}
+     * The default timeout in seconds for a keepalive ping request. Defaults to {@code 20}.
      */
     private long keepAliveTimeout = 20;
-    
+
     /**
-     * The maximum message size allowed to be received on the channel.
+     * The maximum message size in bytes allowed to be received on the channel. If not set (<tt>-2</tt>)
+     * then it will default to {@link GrpcUtil#DEFAULT_MAX_MESSAGE_SIZE DEFAULT_MAX_MESSAGE_SIZE}. If
+     * set to <tt>-1</tt> then it will use {@link Integer#MAX_VALUE} as limit.
      */
-    private int maxInboundMessageSize;
+    private int maxInboundMessageSize = -2;
 
     private boolean fullStreamDecompression = false;
 
-    private NegotiationType negotiationType = NegotiationType.PLAINTEXT;
+    /**
+     * The negotiation type to use on the connection. Either of {@link NegotiationType#TLS TLS}
+     * (recommended), {@link NegotiationType#PLAINTEXT_UPGRADE PLAINTEXT_UPGRADE} or
+     * {@link NegotiationType#PLAINTEXT PLAINTEXT}. Defaults to TLS.
+     */
+    private NegotiationType negotiationType = NegotiationType.TLS;
+
 }

--- a/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/springboot/autoconfigure/grpc/client/GrpcChannelsProperties.java
+++ b/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/springboot/autoconfigure/grpc/client/GrpcChannelsProperties.java
@@ -22,10 +22,7 @@ public class GrpcChannelsProperties {
     private Map<String, GrpcChannelProperties> client = Maps.newHashMap();
 
     public GrpcChannelProperties getChannel(String name) {
-        GrpcChannelProperties grpcChannelProperties = client.get(name);
-        if (grpcChannelProperties == null) {
-            grpcChannelProperties = GrpcChannelProperties.DEFAULT;
-        }
-        return grpcChannelProperties;
+        return client.getOrDefault(name, GrpcChannelProperties.DEFAULT);
     }
+
 }

--- a/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/springboot/autoconfigure/grpc/client/GrpcClient.java
+++ b/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/springboot/autoconfigure/grpc/client/GrpcClient.java
@@ -7,12 +7,25 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+import javax.inject.Inject;
+
+import org.springframework.beans.factory.annotation.Autowired;
+
+import io.grpc.Channel;
 import io.grpc.ClientInterceptor;
+import io.grpc.stub.AbstractStub;
 
 /**
- * User: Michael
- * Email: yidongnan@gmail.com
- * Date: 2016/12/7
+ * An annotation for fields of type {@link Channel} or subclasses of {@link AbstractStub}/gRPC
+ * client services. Annotated fields will be automatically populated by Spring.
+ *
+ * <p>
+ * <b>Note:</b> Fields that are annotated with this annotation should NOT be annotated with
+ * {@link Autowired} or {@link Inject} (conflict).
+ * </p>
+ *
+ * @author Michael (yidongnan@gmail.com)
+ * @since 2016/12/7
  */
 @Target({ElementType.FIELD})
 @Retention(RetentionPolicy.RUNTIME)
@@ -20,7 +33,31 @@ import io.grpc.ClientInterceptor;
 @Inherited
 public @interface GrpcClient {
 
+    /**
+     * The name of the grpc client. This name will be used to get the {@link GrpcChannelProperties
+     * config options} for this client.
+     *
+     * <p>
+     * <b>Example:</b> <code>@GrpcClient("myClient")</code> &lt;-&gt;
+     * <tt>grpc.client.myClient.port=9090</tt>
+     * </p>
+     *
+     * @return The name of the grpc client.
+     */
     String value();
 
+    /**
+     * A list of {@link ClientInterceptor}s that should be used with this client in addition to the
+     * globally defined ones. If a bean of the given type exists, it will be used; otherwise a new
+     * instance of that class will be created via no-args constructor.
+     *
+     * <p>
+     * <b>Note:</b> These interceptors will be applied after the global interceptors. But the
+     * interceptors that were applied last, will be called first.
+     * </p>
+     *
+     * @return A list of ClientInterceptors that should be used.
+     */
     Class<? extends ClientInterceptor>[] interceptors() default {};
+
 }

--- a/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/springboot/autoconfigure/grpc/server/AnnotationGrpcServiceDiscoverer.java
+++ b/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/springboot/autoconfigure/grpc/server/AnnotationGrpcServiceDiscoverer.java
@@ -3,15 +3,12 @@ package net.devh.springboot.autoconfigure.grpc.server;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
-import java.util.Set;
 
-import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.BeanCreationException;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
 
 import com.google.common.collect.Lists;
-import com.google.common.collect.Sets;
 
 import io.grpc.BindableService;
 import io.grpc.Codec;
@@ -33,8 +30,7 @@ public class AnnotationGrpcServiceDiscoverer implements ApplicationContextAware,
     private ApplicationContext applicationContext;
 
     @Override
-    public void setApplicationContext(ApplicationContext applicationContext)
-            throws BeansException {
+    public void setApplicationContext(ApplicationContext applicationContext) {
         this.applicationContext = applicationContext;
     }
 
@@ -69,8 +65,8 @@ public class AnnotationGrpcServiceDiscoverer implements ApplicationContextAware,
     }
 
     private ServerServiceDefinition bindInterceptors(ServerServiceDefinition serviceDefinition, GrpcService grpcServiceAnnotation, List<ServerInterceptor> globalInterceptorList) {
-        Set<ServerInterceptor> interceptorSet = Sets.newHashSet();
-        interceptorSet.addAll(globalInterceptorList);
+        Collection<ServerInterceptor> interceptors = Lists.newArrayList();
+        interceptors.addAll(globalInterceptorList);
         for (Class<? extends ServerInterceptor> serverInterceptorClass : grpcServiceAnnotation.interceptors()) {
             ServerInterceptor serverInterceptor;
             if (applicationContext.getBeanNamesForType(serverInterceptorClass).length > 0) {
@@ -82,8 +78,8 @@ public class AnnotationGrpcServiceDiscoverer implements ApplicationContextAware,
                     throw new BeanCreationException("Failed to create interceptor instance", e);
                 }
             }
-            interceptorSet.add(serverInterceptor);
+            interceptors.add(serverInterceptor);
         }
-        return ServerInterceptors.intercept(serviceDefinition, Lists.newArrayList(interceptorSet));
+        return ServerInterceptors.intercept(serviceDefinition, Lists.newArrayList(interceptors));
     }
 }

--- a/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/springboot/autoconfigure/grpc/server/GrpcServerAutoConfiguration.java
+++ b/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/springboot/autoconfigure/grpc/server/GrpcServerAutoConfiguration.java
@@ -49,15 +49,16 @@ public class GrpcServerAutoConfiguration {
         return new HealthStatusManager();
     }
 
-    @ConditionalOnMissingBean
+    @ConditionalOnMissingBean(GrpcServerFactory.class)
     @ConditionalOnClass(Channel.class)
     @Bean
-    public NettyGrpcServerFactory nettyGrpcServiceFactory(GrpcServerProperties properties, GrpcServiceDiscoverer discoverer) {
-        NettyGrpcServerFactory factory = new NettyGrpcServerFactory(properties);
-        for (GrpcCodecDefinition codec : discoverer.findGrpcCodec()) {
+    public NettyGrpcServerFactory nettyGrpcServiceFactory(final GrpcServerProperties properties,
+            final GrpcServiceDiscoverer discoverer) {
+        final NettyGrpcServerFactory factory = new NettyGrpcServerFactory(properties);
+        for (final GrpcCodecDefinition codec : discoverer.findGrpcCodec()) {
             factory.addCodec(codec);
         }
-        for (GrpcServiceDefinition service : discoverer.findGrpcServices()) {
+        for (final GrpcServiceDefinition service : discoverer.findGrpcServices()) {
             factory.addService(service);
         }
 
@@ -66,7 +67,7 @@ public class GrpcServerAutoConfiguration {
 
     @ConditionalOnMissingBean
     @Bean
-    public GrpcServerLifecycle grpcServerLifecycle(GrpcServerFactory factory) {
+    public GrpcServerLifecycle grpcServerLifecycle(final GrpcServerFactory factory) {
         return new GrpcServerLifecycle(factory);
     }
 


### PR DESCRIPTION
* Remove some useless/confusing assignments.
* And simplify the code using inbuilt features.
* Minor improvements for the server
  * Retain the order of ServerInterceptors
  * Only create NettyGrpcServerFactory if there is no GrpcServerFactory
* Minor improvements and javadocs for the client
  * Switch back to the grpc and secure default TLS
  * Change keep alive timeout to grpc default (which works better with firewalls)

Feel free to request or discuss the changes.