### PR TITLE
Add interceptor annotations

### DIFF
--- a/examples/cloud-grpc-client/src/main/java/net/devh/examples/grpc/cloud/GlobalClientInterceptorConfiguration.java
+++ b/examples/cloud-grpc-client/src/main/java/net/devh/examples/grpc/cloud/GlobalClientInterceptorConfiguration.java
@@ -1,26 +1,19 @@
 package net.devh.examples.grpc.cloud;
 
-import net.devh.springboot.autoconfigure.grpc.client.GlobalClientInterceptorConfigurerAdapter;
-import net.devh.springboot.autoconfigure.grpc.client.GlobalClientInterceptorRegistry;
-
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
+
+import net.devh.springboot.autoconfigure.grpc.client.GlobalClientInterceptorConfigurer;
 
 @Order(Ordered.LOWEST_PRECEDENCE)
 @Configuration
 public class GlobalClientInterceptorConfiguration {
 
     @Bean
-    public GlobalClientInterceptorConfigurerAdapter globalInterceptorConfigurerAdapter() {
-        return new GlobalClientInterceptorConfigurerAdapter() {
-
-            @Override
-            public void addClientInterceptors(GlobalClientInterceptorRegistry registry) {
-                registry.addClientInterceptors(new LogGrpcInterceptor());
-            }
-        };
+    public GlobalClientInterceptorConfigurer globalInterceptorConfigurerAdapter() {
+        return registry -> registry.addClientInterceptors(new LogGrpcInterceptor());
     }
 
 }

--- a/examples/cloud-grpc-server/src/main/java/net/devh/examples/grpc/cloud/GlobalInterceptorConfiguration.java
+++ b/examples/cloud-grpc-server/src/main/java/net/devh/examples/grpc/cloud/GlobalInterceptorConfiguration.java
@@ -1,22 +1,16 @@
 package net.devh.examples.grpc.cloud;
 
-import net.devh.springboot.autoconfigure.grpc.server.GlobalServerInterceptorConfigurerAdapter;
-import net.devh.springboot.autoconfigure.grpc.server.GlobalServerInterceptorRegistry;
-
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+
+import net.devh.springboot.autoconfigure.grpc.server.GlobalServerInterceptorConfigurer;
 
 @Configuration
 public class GlobalInterceptorConfiguration {
 
     @Bean
-    public GlobalServerInterceptorConfigurerAdapter globalInterceptorConfigurerAdapter() {
-        return new GlobalServerInterceptorConfigurerAdapter() {
-            @Override
-            public void addServerInterceptors(GlobalServerInterceptorRegistry registry) {
-                registry.addServerInterceptors(new LogGrpcInterceptor());
-            }
-        };
+    public GlobalServerInterceptorConfigurer globalInterceptorConfigurerAdapter() {
+        return registry -> registry.addServerInterceptors(new LogGrpcInterceptor());
     }
 
 }

--- a/examples/local-grpc-client/src/main/java/net/devh/examples/grpc/local/GlobalClientInterceptorConfiguration.java
+++ b/examples/local-grpc-client/src/main/java/net/devh/examples/grpc/local/GlobalClientInterceptorConfiguration.java
@@ -1,26 +1,19 @@
 package net.devh.examples.grpc.local;
 
-import net.devh.springboot.autoconfigure.grpc.client.GlobalClientInterceptorConfigurerAdapter;
-import net.devh.springboot.autoconfigure.grpc.client.GlobalClientInterceptorRegistry;
-
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
+
+import net.devh.springboot.autoconfigure.grpc.client.GlobalClientInterceptorConfigurer;
 
 @Order(Ordered.LOWEST_PRECEDENCE)
 @Configuration
 public class GlobalClientInterceptorConfiguration {
 
     @Bean
-    public GlobalClientInterceptorConfigurerAdapter globalInterceptorConfigurerAdapter() {
-        return new GlobalClientInterceptorConfigurerAdapter() {
-
-            @Override
-            public void addClientInterceptors(GlobalClientInterceptorRegistry registry) {
-                registry.addClientInterceptors(new LogGrpcInterceptor());
-            }
-        };
+    public GlobalClientInterceptorConfigurer globalInterceptorConfigurerAdapter() {
+        return registry -> registry.addClientInterceptors(new LogGrpcInterceptor());
     }
 
 }

--- a/examples/local-grpc-server/src/main/java/net/devh/examples/grpc/local/GlobalInterceptorConfiguration.java
+++ b/examples/local-grpc-server/src/main/java/net/devh/examples/grpc/local/GlobalInterceptorConfiguration.java
@@ -1,6 +1,6 @@
 package net.devh.examples.grpc.local;
 
-import net.devh.springboot.autoconfigure.grpc.server.GlobalServerInterceptorConfigurerAdapter;
+import net.devh.springboot.autoconfigure.grpc.server.GlobalServerInterceptorConfigurer;
 import net.devh.springboot.autoconfigure.grpc.server.GlobalServerInterceptorRegistry;
 
 import org.springframework.context.annotation.Bean;
@@ -10,8 +10,8 @@ import org.springframework.context.annotation.Configuration;
 public class GlobalInterceptorConfiguration {
 
     @Bean
-    public GlobalServerInterceptorConfigurerAdapter globalInterceptorConfigurerAdapter() {
-        return new GlobalServerInterceptorConfigurerAdapter() {
+    public GlobalServerInterceptorConfigurer globalInterceptorConfigurerAdapter() {
+        return new GlobalServerInterceptorConfigurer() {
             @Override
             public void addServerInterceptors(GlobalServerInterceptorRegistry registry) {
                 registry.addServerInterceptors(new LogGrpcInterceptor());

--- a/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/springboot/autoconfigure/grpc/client/AnnotationGlobalClientInterceptorConfigurer.java
+++ b/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/springboot/autoconfigure/grpc/client/AnnotationGlobalClientInterceptorConfigurer.java
@@ -1,0 +1,31 @@
+package net.devh.springboot.autoconfigure.grpc.client;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+
+import io.grpc.ClientInterceptor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Automatically find and configure {@link GrpcGlobalClientInterceptor annotated} global
+ * {@link ClientInterceptor}s.
+ *
+ * @author Daniel Theuke (daniel.theuke@heuboe.de)
+ */
+@Slf4j
+public class AnnotationGlobalClientInterceptorConfigurer implements GlobalClientInterceptorConfigurer {
+
+    @Autowired
+    private ApplicationContext context;
+
+    @Override
+    public void addClientInterceptors(final GlobalClientInterceptorRegistry registry) {
+        final String[] names = this.context.getBeanNamesForAnnotation(GrpcGlobalClientInterceptor.class);
+        for (final String name : names) {
+            final ClientInterceptor interceptor = this.context.getBean(name, ClientInterceptor.class);
+            log.debug("Registering GlobalClientInterceptor: {} ({})", name, interceptor);
+            registry.addClientInterceptors(interceptor);
+        }
+    }
+
+}

--- a/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/springboot/autoconfigure/grpc/client/GlobalClientInterceptorConfigurer.java
+++ b/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/springboot/autoconfigure/grpc/client/GlobalClientInterceptorConfigurer.java
@@ -1,0 +1,19 @@
+package net.devh.springboot.autoconfigure.grpc.client;
+
+import io.grpc.ClientInterceptor;
+
+/**
+ * This configurer can be used to register new global {@link ClientInterceptor}s.
+ *
+ * @author Daniel Theuke (daniel.theuke@heuboe.de)
+ */
+public interface GlobalClientInterceptorConfigurer {
+
+    /**
+     * Adds the {@link ClientInterceptor}s that should be registered globally to the given registry.
+     *
+     * @param registry The registry the interceptors should be added to.
+     */
+    void addClientInterceptors(GlobalClientInterceptorRegistry registry);
+
+}

--- a/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/springboot/autoconfigure/grpc/client/GlobalClientInterceptorConfigurerAdapter.java
+++ b/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/springboot/autoconfigure/grpc/client/GlobalClientInterceptorConfigurerAdapter.java
@@ -1,13 +1,18 @@
 package net.devh.springboot.autoconfigure.grpc.client;
 
 /**
- * User: Michael
- * Email: yidongnan@gmail.com
- * Date: 2016/12/6
+ * Abstract class to register client interceptors globally.
+ *
+ * @author Michael (yidongnan@gmail.com)
+ * @since 2016/12/6
+ * @deprecated Use {@link GlobalClientInterceptorConfigurer} instead.
  */
-public abstract class GlobalClientInterceptorConfigurerAdapter {
+@Deprecated
+public abstract class GlobalClientInterceptorConfigurerAdapter implements GlobalClientInterceptorConfigurer {
 
-    public void addClientInterceptors(GlobalClientInterceptorRegistry registry) {
+    @Override
+    public void addClientInterceptors(final GlobalClientInterceptorRegistry registry) {
 
     }
+
 }

--- a/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/springboot/autoconfigure/grpc/client/GlobalClientInterceptorRegistry.java
+++ b/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/springboot/autoconfigure/grpc/client/GlobalClientInterceptorRegistry.java
@@ -2,43 +2,54 @@ package net.devh.springboot.autoconfigure.grpc.client;
 
 import java.util.List;
 import java.util.Map;
+
 import javax.annotation.PostConstruct;
 
-import org.springframework.beans.BeansException;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
 
 import com.google.common.collect.Lists;
 
+import io.grpc.Channel;
 import io.grpc.ClientInterceptor;
 import lombok.Getter;
 
 /**
- * User: Michael
- * Email: yidongnan@gmail.com
- * Date: 5/17/16
+ * The global client interceptor registry keeps references to all {@link ClientInterceptor}s that
+ * should be registered globally. The interceptors will be applied in the same order they are added
+ * to this registry.
+ *
+ * <p>
+ * <b>Note:</b> The ClientInterceptors that were applied last to a {@link Channel} will be called
+ * first.
+ * </p>
+ *
+ * @author Michael (yidongnan@gmail.com)
+ * @since 5/17/16
  */
-@Getter
 public class GlobalClientInterceptorRegistry implements ApplicationContextAware {
 
+    @Getter
     private final List<ClientInterceptor> clientInterceptors = Lists.newArrayList();
     private ApplicationContext applicationContext;
 
+    @Override
+    public void setApplicationContext(final ApplicationContext applicationContext) {
+        this.applicationContext = applicationContext;
+    }
+
     @PostConstruct
     public void init() {
-        Map<String, GlobalClientInterceptorConfigurerAdapter> map = applicationContext.getBeansOfType(GlobalClientInterceptorConfigurerAdapter.class);
-        for (GlobalClientInterceptorConfigurerAdapter globalClientInterceptorConfigurerAdapter : map.values()) {
+        final Map<String, GlobalClientInterceptorConfigurer> map =
+                this.applicationContext.getBeansOfType(GlobalClientInterceptorConfigurer.class);
+        for (final GlobalClientInterceptorConfigurer globalClientInterceptorConfigurerAdapter : map.values()) {
             globalClientInterceptorConfigurerAdapter.addClientInterceptors(this);
         }
     }
 
-    public GlobalClientInterceptorRegistry addClientInterceptors(ClientInterceptor interceptor) {
-        clientInterceptors.add(interceptor);
+    public GlobalClientInterceptorRegistry addClientInterceptors(final ClientInterceptor interceptor) {
+        this.clientInterceptors.add(interceptor);
         return this;
     }
 
-    @Override
-    public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
-        this.applicationContext = applicationContext;
-    }
 }

--- a/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/springboot/autoconfigure/grpc/client/GlobalClientInterceptorRegistry.java
+++ b/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/springboot/autoconfigure/grpc/client/GlobalClientInterceptorRegistry.java
@@ -42,8 +42,8 @@ public class GlobalClientInterceptorRegistry implements ApplicationContextAware 
     public void init() {
         final Map<String, GlobalClientInterceptorConfigurer> map =
                 this.applicationContext.getBeansOfType(GlobalClientInterceptorConfigurer.class);
-        for (final GlobalClientInterceptorConfigurer globalClientInterceptorConfigurerAdapter : map.values()) {
-            globalClientInterceptorConfigurerAdapter.addClientInterceptors(this);
+        for (final GlobalClientInterceptorConfigurer globalClientInterceptorConfigurer : map.values()) {
+            globalClientInterceptorConfigurer.addClientInterceptors(this);
         }
     }
 

--- a/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/springboot/autoconfigure/grpc/client/GrpcClientAutoConfiguration.java
+++ b/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/springboot/autoconfigure/grpc/client/GrpcClientAutoConfiguration.java
@@ -17,9 +17,11 @@ import io.grpc.LoadBalancer;
 import io.grpc.util.RoundRobinLoadBalancerFactory;
 
 /**
- * User: Michael
- * Email: yidongnan@gmail.com
- * Date: 5/17/16
+ * The auto configuration used by Spring-Boot that contains all beans to create and inject grpc
+ * clients into beans.
+ *
+ * @author Michael (yidongnan@gmail.com)
+ * @since 5/17/16
  */
 @Configuration
 @EnableConfigurationProperties
@@ -36,6 +38,11 @@ public class GrpcClientAutoConfiguration {
     @Bean
     public GlobalClientInterceptorRegistry globalClientInterceptorRegistry() {
         return new GlobalClientInterceptorRegistry();
+    }
+
+    @Bean
+    public AnnotationGlobalClientInterceptorConfigurer annotationGlobalClientInterceptorConfigurer() {
+        return new AnnotationGlobalClientInterceptorConfigurer();
     }
 
     @ConditionalOnMissingBean
@@ -85,15 +92,11 @@ public class GrpcClientAutoConfiguration {
         }
 
         @Bean
-        public GlobalClientInterceptorConfigurerAdapter globalTraceClientInterceptorConfigurerAdapter(final GrpcTracing grpcTracing) {
-            return new GlobalClientInterceptorConfigurerAdapter() {
-
-                @Override
-                public void addClientInterceptors(GlobalClientInterceptorRegistry registry) {
-                    registry.addClientInterceptors(grpcTracing.newClientInterceptor());
-                }
-            };
+        public GlobalClientInterceptorConfigurer globalTraceClientInterceptorConfigurerAdapter(
+                final GrpcTracing grpcTracing) {
+            return registry -> registry.addClientInterceptors(grpcTracing.newClientInterceptor());
         }
+
     }
 
 }

--- a/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/springboot/autoconfigure/grpc/client/GrpcGlobalClientInterceptor.java
+++ b/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/springboot/autoconfigure/grpc/client/GrpcGlobalClientInterceptor.java
@@ -1,0 +1,23 @@
+package net.devh.springboot.autoconfigure.grpc.client;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.springframework.stereotype.Component;
+
+import io.grpc.ClientInterceptor;
+
+/**
+ * Annotation for gRPC {@link ClientInterceptor}s to apply them globally.
+ *
+ * @author Daniel Theuke (daniel.theuke@heuboe.de)
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Component
+public @interface GrpcGlobalClientInterceptor {
+}

--- a/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/springboot/autoconfigure/grpc/server/AnnotationGlobalServerInterceptorConfigurer.java
+++ b/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/springboot/autoconfigure/grpc/server/AnnotationGlobalServerInterceptorConfigurer.java
@@ -1,0 +1,31 @@
+package net.devh.springboot.autoconfigure.grpc.server;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+
+import io.grpc.ServerInterceptor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Automatically find and configure {@link GrpcGlobalServerInterceptor annotated} global
+ * {@link ServerInterceptor}s.
+ *
+ * @author Daniel Theuke (daniel.theuke@heuboe.de)
+ */
+@Slf4j
+public class AnnotationGlobalServerInterceptorConfigurer implements GlobalServerInterceptorConfigurer {
+
+    @Autowired
+    private ApplicationContext context;
+
+    @Override
+    public void addServerInterceptors(final GlobalServerInterceptorRegistry registry) {
+        final String[] names = this.context.getBeanNamesForAnnotation(GrpcGlobalServerInterceptor.class);
+        for (final String name : names) {
+            final ServerInterceptor interceptor = this.context.getBean(name, ServerInterceptor.class);
+            log.debug("Registering GlobalServerInterceptor: {} ({})", name, interceptor);
+            registry.addServerInterceptors(interceptor);
+        }
+    }
+
+}

--- a/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/springboot/autoconfigure/grpc/server/GlobalServerInterceptorConfigurer.java
+++ b/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/springboot/autoconfigure/grpc/server/GlobalServerInterceptorConfigurer.java
@@ -1,0 +1,19 @@
+package net.devh.springboot.autoconfigure.grpc.server;
+
+import io.grpc.ServerInterceptor;
+
+/**
+ * This configurer can be used to register new global {@link ServerInterceptor}s.
+ *
+ * @author Daniel Theuke (daniel.theuke@heuboe.de)
+ */
+public interface GlobalServerInterceptorConfigurer {
+
+    /**
+     * Adds the {@link ServerInterceptor}s that should be registered globally to the given registry.
+     *
+     * @param registry The registry the interceptors should be added to.
+     */
+    void addServerInterceptors(GlobalServerInterceptorRegistry registry);
+
+}

--- a/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/springboot/autoconfigure/grpc/server/GlobalServerInterceptorConfigurerAdapter.java
+++ b/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/springboot/autoconfigure/grpc/server/GlobalServerInterceptorConfigurerAdapter.java
@@ -1,13 +1,18 @@
 package net.devh.springboot.autoconfigure.grpc.server;
 
 /**
- * User: Michael
- * Email: yidongnan@gmail.com
- * Date: 2016/12/6
+ * Abstract class to register server interceptors globally.
+ *
+ * @author Michael (yidongnan@gmail.com)
+ * @since 2016/12/6
+ * @deprecated Use {@link GlobalServerInterceptorConfigurer} instead.
  */
-public abstract class GlobalServerInterceptorConfigurerAdapter {
+@Deprecated
+public abstract class GlobalServerInterceptorConfigurerAdapter implements GlobalServerInterceptorConfigurer {
 
-    public void addServerInterceptors(GlobalServerInterceptorRegistry registry) {
+    @Override
+    public void addServerInterceptors(final GlobalServerInterceptorRegistry registry) {
 
     }
+
 }

--- a/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/springboot/autoconfigure/grpc/server/GlobalServerInterceptorRegistry.java
+++ b/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/springboot/autoconfigure/grpc/server/GlobalServerInterceptorRegistry.java
@@ -2,9 +2,9 @@ package net.devh.springboot.autoconfigure.grpc.server;
 
 import java.util.List;
 import java.util.Map;
+
 import javax.annotation.PostConstruct;
 
-import org.springframework.beans.BeansException;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
 
@@ -13,16 +13,16 @@ import com.google.common.collect.Lists;
 import io.grpc.ServerInterceptor;
 import lombok.Getter;
 
-@Getter
 public class GlobalServerInterceptorRegistry implements ApplicationContextAware {
 
+    @Getter
     private final List<ServerInterceptor> serverInterceptors = Lists.newArrayList();
     private ApplicationContext applicationContext;
 
     @PostConstruct
     public void init() {
-        Map<String, GlobalServerInterceptorConfigurerAdapter> map = applicationContext.getBeansOfType(GlobalServerInterceptorConfigurerAdapter.class);
-        for (GlobalServerInterceptorConfigurerAdapter globalServerInterceptorConfigurerAdapter : map.values()) {
+        Map<String, GlobalServerInterceptorConfigurer> map = applicationContext.getBeansOfType(GlobalServerInterceptorConfigurer.class);
+        for (GlobalServerInterceptorConfigurer globalServerInterceptorConfigurerAdapter : map.values()) {
             globalServerInterceptorConfigurerAdapter.addServerInterceptors(this);
         }
     }
@@ -33,7 +33,8 @@ public class GlobalServerInterceptorRegistry implements ApplicationContextAware 
     }
 
     @Override
-    public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
+    public void setApplicationContext(ApplicationContext applicationContext) {
         this.applicationContext = applicationContext;
     }
+
 }

--- a/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/springboot/autoconfigure/grpc/server/GlobalServerInterceptorRegistry.java
+++ b/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/springboot/autoconfigure/grpc/server/GlobalServerInterceptorRegistry.java
@@ -13,28 +13,37 @@ import com.google.common.collect.Lists;
 import io.grpc.ServerInterceptor;
 import lombok.Getter;
 
+/**
+ * The global server interceptor registry keeps references to all {@link ServerInterceptor}s that
+ * should be registered globally. The interceptors will be applied in the same order they are added
+ * to this registry.
+ *
+ * @author Michael (yidongnan@gmail.com)
+ * @since 5/17/16
+ */
 public class GlobalServerInterceptorRegistry implements ApplicationContextAware {
 
     @Getter
     private final List<ServerInterceptor> serverInterceptors = Lists.newArrayList();
     private ApplicationContext applicationContext;
 
+    @Override
+    public void setApplicationContext(final ApplicationContext applicationContext) {
+        this.applicationContext = applicationContext;
+    }
+
     @PostConstruct
     public void init() {
-        Map<String, GlobalServerInterceptorConfigurer> map = applicationContext.getBeansOfType(GlobalServerInterceptorConfigurer.class);
-        for (GlobalServerInterceptorConfigurer globalServerInterceptorConfigurerAdapter : map.values()) {
+        final Map<String, GlobalServerInterceptorConfigurer> map =
+                this.applicationContext.getBeansOfType(GlobalServerInterceptorConfigurer.class);
+        for (final GlobalServerInterceptorConfigurer globalServerInterceptorConfigurerAdapter : map.values()) {
             globalServerInterceptorConfigurerAdapter.addServerInterceptors(this);
         }
     }
 
-    public GlobalServerInterceptorRegistry addServerInterceptors(ServerInterceptor interceptor) {
-        serverInterceptors.add(interceptor);
+    public GlobalServerInterceptorRegistry addServerInterceptors(final ServerInterceptor interceptor) {
+        this.serverInterceptors.add(interceptor);
         return this;
-    }
-
-    @Override
-    public void setApplicationContext(ApplicationContext applicationContext) {
-        this.applicationContext = applicationContext;
     }
 
 }

--- a/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/springboot/autoconfigure/grpc/server/GrpcGlobalServerInterceptor.java
+++ b/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/springboot/autoconfigure/grpc/server/GrpcGlobalServerInterceptor.java
@@ -1,0 +1,23 @@
+package net.devh.springboot.autoconfigure.grpc.server;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.springframework.stereotype.Component;
+
+import io.grpc.ServerInterceptor;
+
+/**
+ * Annotation for gRPC {@link ServerInterceptor}s to apply them globally.
+ *
+ * @author Daniel Theuke (daniel.theuke@heuboe.de)
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Component
+public @interface GrpcGlobalServerInterceptor {
+}

--- a/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/springboot/autoconfigure/grpc/server/GrpcServerAutoConfiguration.java
+++ b/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/springboot/autoconfigure/grpc/server/GrpcServerAutoConfiguration.java
@@ -17,9 +17,10 @@ import io.netty.channel.Channel;
 import net.devh.springboot.autoconfigure.grpc.server.codec.GrpcCodecDefinition;
 
 /**
- * User: Michael
- * Email: yidongnan@gmail.com
- * Date: 5/17/16
+ * The auto configuration used by Spring-Boot that contains all beans to run a grpc server/service.
+ *
+ * @author Michael (yidongnan@gmail.com)
+ * @since 5/17/16
  */
 @Configuration
 @EnableConfigurationProperties
@@ -37,7 +38,12 @@ public class GrpcServerAutoConfiguration {
         return new GlobalServerInterceptorRegistry();
     }
 
-    @ConditionalOnMissingBean
+    @Bean
+    public AnnotationGlobalServerInterceptorConfigurer annotationGlobalServerInterceptorConfigurer() {
+        return new AnnotationGlobalServerInterceptorConfigurer();
+    }
+
+    @ConditionalOnMissingBean(GrpcServiceDiscoverer.class)
     @Bean
     public AnnotationGrpcServiceDiscoverer defaultGrpcServiceFinder() {
         return new AnnotationGrpcServiceDiscoverer();
@@ -83,14 +89,11 @@ public class GrpcServerAutoConfiguration {
         }
 
         @Bean
-        public GlobalServerInterceptorConfigurerAdapter globalTraceServerInterceptorConfigurerAdapter(final GrpcTracing grpcTracing) {
-            return new GlobalServerInterceptorConfigurerAdapter() {
-                @Override
-                public void addServerInterceptors(GlobalServerInterceptorRegistry registry) {
-                    registry.addServerInterceptors(grpcTracing.newServerInterceptor());
-                }
-            };
+        public GlobalServerInterceptorConfigurer globalTraceServerInterceptorConfigurerAdapter(
+                final GrpcTracing grpcTracing) {
+            return registry -> registry.addServerInterceptors(grpcTracing.newServerInterceptor());
         }
 
     }
+
 }


### PR DESCRIPTION
* Add support for global ClientInterceptor annotation
* Add support for global ServerInterceptor annotation

With this changes it is possible to declare client and server interceptors with just an annotation. The annotations are meta-annotated with `@Component`, so they will automatically be created if their are on the classpath scanning and can be sorted by `@Order`.

Feel free to request changes or discuss changes. I already detected that my formatter is slightly different from yours. Is there a formatter template or something that I can use?