### PR TITLE
Make sleuth an optional dependency

### DIFF
--- a/grpc-client-spring-boot-autoconfigure/pom.xml
+++ b/grpc-client-spring-boot-autoconfigure/pom.xml
@@ -35,6 +35,7 @@
       <groupId>org.springframework.cloud</groupId>
       <artifactId>spring-cloud-starter-sleuth</artifactId>
       <version>${spring-cloud.sleuth.version}</version>
+	  <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>io.zipkin.brave</groupId>

--- a/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/springboot/autoconfigure/grpc/client/GrpcClientAutoConfiguration.java
+++ b/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/springboot/autoconfigure/grpc/client/GrpcClientAutoConfiguration.java
@@ -71,11 +71,11 @@ public class GrpcClientAutoConfiguration {
     @Configuration
     @ConditionalOnProperty(value = "spring.sleuth.scheduled.enabled", matchIfMissing = true)
     @AutoConfigureAfter({TraceAutoConfiguration.class})
-    @ConditionalOnClass(value = {Tracing.class, GrpcTracing.class})
+    @ConditionalOnClass(value = {Tracing.class, GrpcTracing.class, TraceAutoConfiguration.class})
     protected static class TraceClientAutoConfiguration {
 
         @Bean
-        public GrpcTracing grpcTracing(Tracing tracing) {
+        public GrpcTracing grpcTracing(final Tracing tracing) {
             return GrpcTracing.create(tracing);
         }
 

--- a/grpc-server-spring-boot-autoconfigure/pom.xml
+++ b/grpc-server-spring-boot-autoconfigure/pom.xml
@@ -41,6 +41,7 @@
       <groupId>org.springframework.cloud</groupId>
       <artifactId>spring-cloud-starter-sleuth</artifactId>
       <version>${spring-cloud.sleuth.version}</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>io.zipkin.brave</groupId>

--- a/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/springboot/autoconfigure/grpc/server/GrpcServerAutoConfiguration.java
+++ b/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/springboot/autoconfigure/grpc/server/GrpcServerAutoConfiguration.java
@@ -73,12 +73,12 @@ public class GrpcServerAutoConfiguration {
 
     @Configuration
     @ConditionalOnProperty(value = "spring.sleuth.scheduled.enabled", matchIfMissing = true)
-    @AutoConfigureAfter({ TraceAutoConfiguration.class })
-    @ConditionalOnClass(value = {Tracing.class, GrpcTracing.class})
+    @AutoConfigureAfter({TraceAutoConfiguration.class})
+    @ConditionalOnClass(value = {Tracing.class, GrpcTracing.class, TraceAutoConfiguration.class})
     protected static class TraceServerAutoConfiguration {
 
         @Bean
-        public GrpcTracing grpcTracing(Tracing tracing) {
+        public GrpcTracing grpcTracing(final Tracing tracing) {
             return GrpcTracing.create(tracing);
         }
 


### PR DESCRIPTION
I'm not 100% sure about this change, but at least for dependent maven projects sleuth was a required dependency. This PR changes this to make sleuth an optional dependency.

Feel free to request changes or discuss changes.