### PR TITLE
Better message size config

### DIFF
--- a/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/springboot/autoconfigure/grpc/client/AbstractChannelFactory.java
+++ b/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/springboot/autoconfigure/grpc/client/AbstractChannelFactory.java
@@ -54,7 +54,7 @@ public abstract class AbstractChannelFactory implements GrpcChannelFactory {
         this.nameResolverFactory = nameResolverFactory;
         this.globalClientInterceptorRegistry = globalClientInterceptorRegistry;
     }
-    
+
     @SuppressWarnings("unchecked")
     public <T extends AbstractChannelFactory> AbstractChannelFactory(final GrpcChannelsProperties properties,
             final LoadBalancer.Factory loadBalancerFactory,
@@ -104,11 +104,12 @@ public abstract class AbstractChannelFactory implements GrpcChannelFactory {
                     .keepAliveTime(channelProperties.getKeepAliveTime(), TimeUnit.SECONDS)
                     .keepAliveTimeout(channelProperties.getKeepAliveTimeout(), TimeUnit.SECONDS);
         }
-        if (channelProperties.getMaxInboundMessageSize() >= 0) {
-            builder.maxInboundMessageSize(channelProperties.getMaxInboundMessageSize());
-        } else if (channelProperties.getMaxInboundMessageSize() == -1) {
-            builder.maxInboundMessageSize(Integer.MAX_VALUE);
+
+        final Integer maxInboundMessageSize = channelProperties.getMaxInboundMessageSize();
+        if (maxInboundMessageSize != null) {
+            builder.maxInboundMessageSize(maxInboundMessageSize);
         }
+
         if (channelProperties.isFullStreamDecompression()) {
             builder.enableFullStreamDecompression();
         }

--- a/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/springboot/autoconfigure/grpc/client/GrpcChannelProperties.java
+++ b/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/springboot/autoconfigure/grpc/client/GrpcChannelProperties.java
@@ -58,11 +58,12 @@ public class GrpcChannelProperties {
     private long keepAliveTimeout = 20;
 
     /**
-     * The maximum message size in bytes allowed to be received on the channel. If not set (<tt>-2</tt>)
-     * then it will default to {@link GrpcUtil#DEFAULT_MAX_MESSAGE_SIZE DEFAULT_MAX_MESSAGE_SIZE}. If
-     * set to <tt>-1</tt> then it will use {@link Integer#MAX_VALUE} as limit.
+     * The maximum message size in bytes allowed to be received by the channel. If not set
+     * ({@code null}) then it will default to {@link GrpcUtil#DEFAULT_MAX_MESSAGE_SIZE
+     * DEFAULT_MAX_MESSAGE_SIZE}. If set to {@code -1} then it will use {@link Integer#MAX_VALUE} as
+     * limit.
      */
-    private int maxInboundMessageSize = -2;
+    private Integer maxInboundMessageSize = null;
 
     private boolean fullStreamDecompression = false;
 
@@ -72,5 +73,20 @@ public class GrpcChannelProperties {
      * {@link NegotiationType#PLAINTEXT PLAINTEXT}. Defaults to TLS.
      */
     private NegotiationType negotiationType = NegotiationType.TLS;
+
+    /**
+     * Gets the maximum message size in bytes allowed to be received by the channel. If not set
+     * ({@code null}) then it will default to {@link GrpcUtil#DEFAULT_MAX_MESSAGE_SIZE
+     * DEFAULT_MAX_MESSAGE_SIZE}. If set to {@code -1} then it will use {@link Integer#MAX_VALUE} as
+     * limit.
+     *
+     * @return The maximum message size in bytes allowed or null if the default should be used.
+     */
+    public Integer getMaxInboundMessageSize() {
+        if (this.maxInboundMessageSize != null && this.maxInboundMessageSize == -1) {
+            this.maxInboundMessageSize = Integer.MAX_VALUE;
+        }
+        return this.maxInboundMessageSize;
+    }
 
 }

--- a/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/springboot/autoconfigure/grpc/server/GrpcServerProperties.java
+++ b/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/springboot/autoconfigure/grpc/server/GrpcServerProperties.java
@@ -3,6 +3,7 @@ package net.devh.springboot.autoconfigure.grpc.server;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.util.SocketUtils;
 
+import io.grpc.internal.GrpcUtil;
 import lombok.Data;
 
 /**
@@ -22,14 +23,16 @@ public class GrpcServerProperties {
 
     /**
      * Server port to listen on. Defaults to {@code 9090}. If set to {@code 0} a random available port
-     * will be used.
+     * will be selected and used.
      */
     private int port = 9090;
 
     /**
-     * The maximum message size allowed to be received for the server.
+     * The maximum message size in bytes allowed to be received by the server. If not set ({@code null})
+     * then it will default to {@link GrpcUtil#DEFAULT_MAX_MESSAGE_SIZE DEFAULT_MAX_MESSAGE_SIZE}. If
+     * set to {@code -1} then it will use {@link Integer#MAX_VALUE} as limit.
      */
-    private int maxMessageSize;
+    private Integer maxInboundMessageSize = null;
 
     /**
      * Whether grpc health service is enabled or not. Defaults to {@code true}.
@@ -68,7 +71,7 @@ public class GrpcServerProperties {
 
     /**
      * Gets the port the server should listen on. Defaults to {@code 9090}. If set to {@code 0} a random
-     * available port will be used.
+     * available port will be selected and used.
      *
      * @return The server port to listen to.
      */
@@ -77,6 +80,21 @@ public class GrpcServerProperties {
             this.port = SocketUtils.findAvailableTcpPort();
         }
         return this.port;
+    }
+
+    /**
+     * Gets the maximum message size in bytes allowed to be received by the server. If not set
+     * ({@code null}) then it will default to {@link GrpcUtil#DEFAULT_MAX_MESSAGE_SIZE
+     * DEFAULT_MAX_MESSAGE_SIZE}. If set to {@code -1} then it will use {@link Integer#MAX_VALUE} as
+     * limit.
+     *
+     * @return The maximum message size in bytes allowed or null if the default should be used.
+     */
+    public Integer getMaxInboundMessageSize() {
+        if (this.maxInboundMessageSize != null && this.maxInboundMessageSize == -1) {
+            this.maxInboundMessageSize = Integer.MAX_VALUE;
+        }
+        return this.maxInboundMessageSize;
     }
 
 }

--- a/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/springboot/autoconfigure/grpc/server/NettyGrpcServerFactory.java
+++ b/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/springboot/autoconfigure/grpc/server/NettyGrpcServerFactory.java
@@ -68,9 +68,12 @@ public class NettyGrpcServerFactory implements GrpcServerFactory {
             final File certificate = new File(this.properties.getSecurity().getCertificatePath());
             builder.useTransportSecurity(certificateChain, certificate);
         }
-        if (this.properties.getMaxMessageSize() > 0) {
-            builder.maxInboundMessageSize(this.properties.getMaxMessageSize());
+
+        final Integer maxInboundMessageSize = this.properties.getMaxInboundMessageSize();
+        if (maxInboundMessageSize != null) {
+            builder.maxInboundMessageSize(maxInboundMessageSize);
         }
+
         if (this.codecList.isEmpty()) {
             final CompressorRegistry compressorRegistry = CompressorRegistry.newEmptyInstance();
             final DecompressorRegistry decompressorRegistry = DecompressorRegistry.emptyInstance();


### PR DESCRIPTION
Using to many values for to many different things is too confusing so using null for the default is better suited. Also make the server use the same behavior as the client.