### PR TITLE
Add missing javadoc

### DIFF
--- a/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/springboot/autoconfigure/grpc/client/AbstractChannelFactory.java
+++ b/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/springboot/autoconfigure/grpc/client/AbstractChannelFactory.java
@@ -68,6 +68,14 @@ public abstract class AbstractChannelFactory implements GrpcChannelFactory {
     private final Map<String, ManagedChannel> channels = new ConcurrentHashMap<>();
     private boolean shutdown = false;
 
+    /**
+     * Creates a new AbstractChannelFactory with eager initialized references.
+     *
+     * @param properties The properties for the channels to create.
+     * @param loadBalancerFactory The load balancer factory to use.
+     * @param nameResolverFactory The name resolver factory to use.
+     * @param globalClientInterceptorRegistry The interceptor registry to use.
+     */
     public AbstractChannelFactory(final GrpcChannelsProperties properties,
             final LoadBalancer.Factory loadBalancerFactory,
             final NameResolver.Factory nameResolverFactory,
@@ -78,6 +86,15 @@ public abstract class AbstractChannelFactory implements GrpcChannelFactory {
         this.globalClientInterceptorRegistry = globalClientInterceptorRegistry;
     }
 
+    /**
+     * Creates a new AbstractChannelFactory with partially lazy initialized references.
+     *
+     * @param <T> The type of the actual factory class or one of its super classes.
+     * @param properties The properties for the channels to create.
+     * @param loadBalancerFactory The load balancer factory to use.
+     * @param nameResolverFactoryCreator The function that creates the name resolver factory.
+     * @param globalClientInterceptorRegistry The interceptor registry to use.
+     */
     @SuppressWarnings("unchecked")
     public <T extends AbstractChannelFactory> AbstractChannelFactory(final GrpcChannelsProperties properties,
             final LoadBalancer.Factory loadBalancerFactory,

--- a/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/springboot/autoconfigure/grpc/client/AddressChannelFactory.java
+++ b/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/springboot/autoconfigure/grpc/client/AddressChannelFactory.java
@@ -29,6 +29,14 @@ import io.grpc.LoadBalancer;
  */
 public class AddressChannelFactory extends AbstractChannelFactory {
 
+    /**
+     * Creates a new AddressChannelFactory that will use the client name and the properties to resolve the grpc server
+     * address.
+     *
+     * @param properties The properties to use.
+     * @param loadBalancerFactory The load balancer factory to use.
+     * @param globalClientInterceptorRegistry The interceptor registry to use.
+     */
     public AddressChannelFactory(final GrpcChannelsProperties properties,
             final LoadBalancer.Factory loadBalancerFactory,
             final GlobalClientInterceptorRegistry globalClientInterceptorRegistry) {

--- a/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/springboot/autoconfigure/grpc/client/AddressChannelNameResolver.java
+++ b/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/springboot/autoconfigure/grpc/client/AddressChannelNameResolver.java
@@ -27,6 +27,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 
 import io.grpc.Attributes;
+import io.grpc.Channel;
 import io.grpc.EquivalentAddressGroup;
 import io.grpc.NameResolver;
 import io.grpc.Status;
@@ -34,6 +35,9 @@ import io.grpc.internal.SharedResourceHolder;
 import lombok.extern.slf4j.Slf4j;
 
 /**
+ * The AddressChannelNameResolver configures the hosts and the associated ports for {@link Channel}s to use based on
+ * {@link GrpcChannelProperties}.
+ *
  * @author Michael (yidongnan@gmail.com)
  * @since 5/17/16
  */
@@ -148,4 +152,5 @@ public class AddressChannelNameResolver extends NameResolver {
             executor = SharedResourceHolder.release(executorResource, executor);
         }
     }
+
 }

--- a/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/springboot/autoconfigure/grpc/client/AddressChannelResolverFactory.java
+++ b/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/springboot/autoconfigure/grpc/client/AddressChannelResolverFactory.java
@@ -27,6 +27,8 @@ import io.grpc.NameResolverProvider;
 import io.grpc.internal.GrpcUtil;
 
 /**
+ * A name resolver factory that will create an {@link AddressChannelNameResolver} based on the target uri.
+ * 
  * @author Michael (yidongnan@gmail.com)
  * @since 5/17/16
  */
@@ -59,4 +61,5 @@ public class AddressChannelResolverFactory extends NameResolverProvider {
     protected int priority() {
         return 5;
     }
+
 }

--- a/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/springboot/autoconfigure/grpc/client/DiscoveryClientNameResolver.java
+++ b/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/springboot/autoconfigure/grpc/client/DiscoveryClientNameResolver.java
@@ -34,6 +34,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 
 import io.grpc.Attributes;
+import io.grpc.Channel;
 import io.grpc.EquivalentAddressGroup;
 import io.grpc.NameResolver;
 import io.grpc.Status;
@@ -41,6 +42,9 @@ import io.grpc.internal.SharedResourceHolder;
 import lombok.extern.slf4j.Slf4j;
 
 /**
+ * The DiscoveryClientNameResolver configures the hosts and the associated ports for {@link Channel}s to use based on a
+ * {@link DiscoveryClient}.
+ *
  * @author Michael (yidongnan@gmail.com)
  * @since 5/17/16
  */
@@ -203,4 +207,5 @@ public class DiscoveryClientNameResolver extends NameResolver {
             executor = SharedResourceHolder.release(executorResource, executor);
         }
     }
+
 }

--- a/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/springboot/autoconfigure/grpc/client/DiscoveryClientResolverFactory.java
+++ b/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/springboot/autoconfigure/grpc/client/DiscoveryClientResolverFactory.java
@@ -29,10 +29,13 @@ import io.grpc.NameResolverProvider;
 import io.grpc.internal.GrpcUtil;
 
 /**
+ * A name resolver factory that will create an {@link DiscoveryClientNameResolver} based on the target uri.
+ * 
  * @author Michael (yidongnan@gmail.com)
  * @since 5/17/16
  */
 public class DiscoveryClientResolverFactory extends NameResolverProvider {
+
     private final DiscoveryClient client;
     private DiscoveryClientChannelFactory discoveryClientChannelFactory;
 
@@ -65,4 +68,5 @@ public class DiscoveryClientResolverFactory extends NameResolverProvider {
     protected int priority() {
         return 5;
     }
+
 }

--- a/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/springboot/autoconfigure/grpc/client/GlobalClientInterceptorRegistry.java
+++ b/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/springboot/autoconfigure/grpc/client/GlobalClientInterceptorRegistry.java
@@ -62,6 +62,12 @@ public class GlobalClientInterceptorRegistry implements ApplicationContextAware 
         }
     }
 
+    /**
+     * Adds the given {@link ClientInterceptor} to the list of globally registered interceptors.
+     *
+     * @param interceptor The interceptor to add.
+     * @return This instance for chaining.
+     */
     public GlobalClientInterceptorRegistry addClientInterceptors(final ClientInterceptor interceptor) {
         this.clientInterceptors.add(interceptor);
         return this;

--- a/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/springboot/autoconfigure/grpc/client/GrpcChannelsProperties.java
+++ b/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/springboot/autoconfigure/grpc/client/GrpcChannelsProperties.java
@@ -27,6 +27,8 @@ import com.google.common.collect.Maps;
 import lombok.Data;
 
 /**
+ * The container for named channel properties.
+ *
  * @author Michael (yidongnan@gmail.com)
  * @since 5/17/16
  */
@@ -37,8 +39,8 @@ public class GrpcChannelsProperties {
     @NestedConfigurationProperty
     private Map<String, GrpcChannelProperties> client = Maps.newHashMap();
 
-    public GrpcChannelProperties getChannel(String name) {
-        return client.getOrDefault(name, GrpcChannelProperties.DEFAULT);
+    public GrpcChannelProperties getChannel(final String name) {
+        return this.client.getOrDefault(name, GrpcChannelProperties.DEFAULT);
     }
 
 }

--- a/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/springboot/autoconfigure/grpc/server/AnnotationGrpcServiceDiscoverer.java
+++ b/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/springboot/autoconfigure/grpc/server/AnnotationGrpcServiceDiscoverer.java
@@ -37,6 +37,9 @@ import net.devh.springboot.autoconfigure.grpc.server.codec.GrpcCodec;
 import net.devh.springboot.autoconfigure.grpc.server.codec.GrpcCodecDefinition;
 
 /**
+ * A {@link GrpcServiceDiscoverer} that searches for beans with the {@link GrpcService} and {@link GrpcCodec}
+ * annotations.
+ *
  * @author Michael (yidongnan@gmail.com)
  * @since 5/17/16
  */
@@ -46,7 +49,7 @@ public class AnnotationGrpcServiceDiscoverer implements ApplicationContextAware,
     private ApplicationContext applicationContext;
 
     @Override
-    public void setApplicationContext(ApplicationContext applicationContext) {
+    public void setApplicationContext(final ApplicationContext applicationContext) {
         this.applicationContext = applicationContext;
     }
 
@@ -104,4 +107,5 @@ public class AnnotationGrpcServiceDiscoverer implements ApplicationContextAware,
         }
         return ServerInterceptors.intercept(serviceDefinition, Lists.newArrayList(interceptors));
     }
+
 }

--- a/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/springboot/autoconfigure/grpc/server/ConsulGrpcRegistrationCustomizer.java
+++ b/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/springboot/autoconfigure/grpc/server/ConsulGrpcRegistrationCustomizer.java
@@ -23,26 +23,34 @@ import java.util.List;
 import org.springframework.cloud.consul.serviceregistry.ConsulRegistration;
 import org.springframework.cloud.consul.serviceregistry.ConsulRegistrationCustomizer;
 
-
 /**
+ * Adds the grpc server port to the consul registration.
+ *
  * @author Michael (yidongnan@gmail.com)
  * @since 7/21/2018
  */
 public class ConsulGrpcRegistrationCustomizer implements ConsulRegistrationCustomizer {
 
-    private GrpcServerProperties grpcServerProperties;
+    private final GrpcServerProperties grpcServerProperties;
 
-    public ConsulGrpcRegistrationCustomizer(GrpcServerProperties grpcServerProperties) {
+    /**
+     * Creates a new ConsulGrpcRegistrationCustomizer which will read the grpc server port from the given
+     * {@link GrpcServerProperties}.
+     *
+     * @param grpcServerProperties The properties to get the server port from.
+     */
+    public ConsulGrpcRegistrationCustomizer(final GrpcServerProperties grpcServerProperties) {
         this.grpcServerProperties = grpcServerProperties;
     }
 
     @Override
-    public void customize(ConsulRegistration registration) {
+    public void customize(final ConsulRegistration registration) {
         List<String> tags = registration.getService().getTags();
         if (tags == null) {
             tags = new ArrayList<>();
         }
-        tags.add("gRPC.port=" + grpcServerProperties.getPort());
+        tags.add("gRPC.port=" + this.grpcServerProperties.getPort());
         registration.getService().setTags(tags);
     }
+
 }

--- a/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/springboot/autoconfigure/grpc/server/GlobalServerInterceptorRegistry.java
+++ b/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/springboot/autoconfigure/grpc/server/GlobalServerInterceptorRegistry.java
@@ -57,6 +57,12 @@ public class GlobalServerInterceptorRegistry implements ApplicationContextAware 
         }
     }
 
+    /**
+     * Adds the given {@link ServerInterceptor} to the list of globally registered interceptors.
+     *
+     * @param interceptor The interceptor to add.
+     * @return This instance for chaining.
+     */
     public GlobalServerInterceptorRegistry addServerInterceptors(final ServerInterceptor interceptor) {
         this.serverInterceptors.add(interceptor);
         return this;

--- a/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/springboot/autoconfigure/grpc/server/GrpcMetedataConsulConfiguration.java
+++ b/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/springboot/autoconfigure/grpc/server/GrpcMetedataConsulConfiguration.java
@@ -28,6 +28,8 @@ import org.springframework.context.annotation.Configuration;
 import com.ecwid.consul.v1.ConsulClient;
 
 /**
+ * Configuration class that configures the required beans for grpc discovery via Consul.
+ *
  * @author Michael (yidongnan@gmail.com)
  * @since 5/17/16
  */
@@ -38,7 +40,9 @@ public class GrpcMetedataConsulConfiguration {
 
     @ConditionalOnMissingBean
     @Bean
-    public ConsulRegistrationCustomizer consulGrpcRegistrationCustomizer(GrpcServerProperties grpcServerProperties) {
+    public ConsulRegistrationCustomizer consulGrpcRegistrationCustomizer(
+            final GrpcServerProperties grpcServerProperties) {
         return new ConsulGrpcRegistrationCustomizer(grpcServerProperties);
     }
+
 }

--- a/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/springboot/autoconfigure/grpc/server/GrpcMetedataEurekaConfiguration.java
+++ b/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/springboot/autoconfigure/grpc/server/GrpcMetedataEurekaConfiguration.java
@@ -29,6 +29,8 @@ import com.netflix.appinfo.EurekaInstanceConfig;
 import com.netflix.discovery.EurekaClient;
 
 /**
+ * Configuration class that configures the required beans for grpc discovery via Eureka.
+ *
  * @author Michael (yidongnan@gmail.com)
  * @since 5/17/16
  */
@@ -48,6 +50,7 @@ public class GrpcMetedataEurekaConfiguration {
         if (this.instance == null) {
             return;
         }
-        this.instance.getMetadataMap().put("gRPC.port", String.valueOf(grpcProperties.getPort()));
+        this.instance.getMetadataMap().put("gRPC.port", String.valueOf(this.grpcProperties.getPort()));
     }
+
 }

--- a/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/springboot/autoconfigure/grpc/server/GrpcService.java
+++ b/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/springboot/autoconfigure/grpc/server/GrpcService.java
@@ -25,11 +25,13 @@ import java.lang.annotation.Target;
 
 import org.springframework.stereotype.Service;
 
+import io.grpc.BindableService;
 import io.grpc.ServerInterceptor;
 
 /**
  * Annotation that marks gRPC services that should be registered with a gRPC server. If spring-boot's auto configuration
- * is used, then the server will be created automatically.
+ * is used, then the server will be created automatically. This annotation should only be added to implementations of
+ * {@link BindableService} (GrpcService-ImplBase).
  *
  * @author Michael (yidongnan@gmail.com)
  * @since 5/17/16

--- a/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/springboot/autoconfigure/grpc/server/GrpcServiceDefinition.java
+++ b/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/springboot/autoconfigure/grpc/server/GrpcServiceDefinition.java
@@ -20,30 +20,57 @@ package net.devh.springboot.autoconfigure.grpc.server;
 import io.grpc.ServerServiceDefinition;
 
 /**
+ * Container class that contains all relevant information about a grpc service.
+ *
  * @author Michael (yidongnan@gmail.com)
  * @since 5/17/16
+ * @see GrpcServiceDiscoverer
  */
 public class GrpcServiceDefinition {
+
     private final String beanName;
     private final Class<?> beanClazz;
     private final ServerServiceDefinition definition;
 
-    public GrpcServiceDefinition(String beanName, Class<?> beanClazz, ServerServiceDefinition definition) {
-        super();
+    /**
+     * Creates a new GrpcServiceDefinition.
+     *
+     * @param beanName The name of the grpc service bean in the spring context.
+     * @param beanClazz The class of the grpc service bean.
+     * @param definition The grpc service definition.
+     */
+    public GrpcServiceDefinition(final String beanName, final Class<?> beanClazz,
+            final ServerServiceDefinition definition) {
         this.beanName = beanName;
         this.beanClazz = beanClazz;
         this.definition = definition;
     }
 
+    /**
+     * Gets the name of the grpc service bean.
+     *
+     * @return The name of the bean.
+     */
     public String getBeanName() {
         return this.beanName;
     }
 
+    /**
+     * Gets the class of the grpc service bean.
+     *
+     * @return The class of the grpc service bean.
+     */
     public Class<?> getBeanClazz() {
         return this.beanClazz;
     }
 
+    /**
+     * Gets the grpc service definition.
+     *
+     * @return The grpc service definition.
+     */
     public ServerServiceDefinition getDefinition() {
         return this.definition;
     }
+
 }

--- a/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/springboot/autoconfigure/grpc/server/GrpcServiceDiscoverer.java
+++ b/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/springboot/autoconfigure/grpc/server/GrpcServiceDiscoverer.java
@@ -22,12 +22,26 @@ import java.util.Collection;
 import net.devh.springboot.autoconfigure.grpc.server.codec.GrpcCodecDefinition;
 
 /**
+ * An interface for a bean that will be used to find grpc services and codecs. These will then be provided to the
+ * {@link GrpcServerFactory} which then uses them to configure the server.
+ *
  * @author Michael (yidongnan@gmail.com)
  * @since 5/17/16
  */
 public interface GrpcServiceDiscoverer {
 
+    /**
+     * Find the grpc services that should provided by the server.
+     *
+     * @return The grpc services that should be provided. Never null.
+     */
     Collection<GrpcServiceDefinition> findGrpcServices();
 
+    /**
+     * Find the grpc codecs that should uses by the server.
+     *
+     * @return The grpc codecs that should be provided. Never null.
+     */
     Collection<GrpcCodecDefinition> findGrpcCodec();
+
 }

--- a/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/springboot/autoconfigure/grpc/server/NettyGrpcServerFactory.java
+++ b/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/springboot/autoconfigure/grpc/server/NettyGrpcServerFactory.java
@@ -17,6 +17,8 @@
 
 package net.devh.springboot.autoconfigure.grpc.server;
 
+import static java.util.Objects.requireNonNull;
+
 import java.io.File;
 import java.net.InetSocketAddress;
 import java.util.List;
@@ -61,8 +63,13 @@ public class NettyGrpcServerFactory implements GrpcServerFactory {
     @Autowired
     private HealthStatusManager healthStatusManager;
 
+    /**
+     * Creates a new netty server factory with the given properties.
+     *
+     * @param properties The properties used to configure the server.
+     */
     public NettyGrpcServerFactory(final GrpcServerProperties properties) {
-        this.properties = properties;
+        this.properties = requireNonNull(properties, "properties");
     }
 
     @Override

--- a/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/springboot/autoconfigure/grpc/server/codec/CodecType.java
+++ b/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/springboot/autoconfigure/grpc/server/codec/CodecType.java
@@ -18,12 +18,26 @@
 package net.devh.springboot.autoconfigure.grpc.server.codec;
 
 /**
+ * The type of the codec.
+ *
  * @author Michael (yidongnan@gmail.com)
  * @since 10/13/18
  */
 public enum CodecType {
 
-    COMPRESS, DECOMPRESS, ALL;
+    /**
+     * The codec should be used for compression only.
+     */
+    COMPRESS,
 
-    CodecType() {}
+    /**
+     * The codec should be used for decompression only.
+     */
+    DECOMPRESS,
+
+    /**
+     * The codec should be used for both compression and decompression.
+     */
+    ALL;
+
 }

--- a/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/springboot/autoconfigure/grpc/server/codec/GrpcCodec.java
+++ b/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/springboot/autoconfigure/grpc/server/codec/GrpcCodec.java
@@ -25,7 +25,12 @@ import java.lang.annotation.Target;
 
 import org.springframework.stereotype.Component;
 
+import io.grpc.Codec;
+
 /**
+ * Annotation that marks gRPC codecs that should be registered with a gRPC server. This annotation should only be added
+ * to beans that implement {@link Codec}.
+ *
  * @author Michael (yidongnan@gmail.com)
  * @since 10/13/18
  */
@@ -35,7 +40,18 @@ import org.springframework.stereotype.Component;
 @Component
 public @interface GrpcCodec {
 
+    /**
+     * Advertised codecs will be listed in the {@code Accept-Encoding} header. Defaults to false.
+     *
+     * @return True, of the codec should be advertised. False otherwise.
+     */
     boolean advertised() default false;
 
+    /**
+     * Gets the type of codec the annotated bean should be used for.
+     *
+     * @return The type of codec.
+     */
     CodecType codecType() default CodecType.ALL;
+
 }

--- a/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/springboot/autoconfigure/grpc/server/codec/GrpcCodecDefinition.java
+++ b/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/springboot/autoconfigure/grpc/server/codec/GrpcCodecDefinition.java
@@ -21,6 +21,10 @@ import io.grpc.Codec;
 import lombok.Getter;
 
 /**
+ * Container class that contains all relevant information about a grpc codec.
+ *
+ * @see GrpcCodec
+ *
  * @author Michael (yidongnan@gmail.com)
  * @since 10/13/18
  */
@@ -28,14 +32,20 @@ import lombok.Getter;
 public class GrpcCodecDefinition {
 
     private final Codec codec;
-
     private final boolean advertised;
-
     private final CodecType codecType;
 
-    public GrpcCodecDefinition(Codec codec, boolean advertised, CodecType codecType) {
+    /**
+     * Creates a new GrpcCodecDefinition.
+     *
+     * @param codec The codec bean.
+     * @param advertised Whether the codec should be advertised in the headers.
+     * @param codecType The type of the codec.
+     */
+    public GrpcCodecDefinition(final Codec codec, final boolean advertised, final CodecType codecType) {
         this.codec = codec;
         this.advertised = advertised;
         this.codecType = codecType;
     }
+
 }


### PR DESCRIPTION
This adds javadocs to the rest of the classes/methods that were omitted in previous runs.
The only exception to that goal is the client lib because I'm not 100% sure how those components work and thus the javadocs would end up too inaccurate.

For the formatting I used the new layout/formatter, but I guess we still have to make a separate format commit after we add the automated tooling for it.