### PR TITLE
Fixed multithreading issue in security layer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ bin/
 .project
 .settings/
 .factorypath
+.checkstyle

--- a/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/springboot/autoconfigure/grpc/server/security/interceptors/AuthenticatingServerInterceptor.java
+++ b/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/springboot/autoconfigure/grpc/server/security/interceptors/AuthenticatingServerInterceptor.java
@@ -20,7 +20,9 @@ package net.devh.springboot.autoconfigure.grpc.server.security.interceptors;
 import static java.util.Objects.requireNonNull;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 
@@ -60,14 +62,23 @@ public class AuthenticatingServerInterceptor implements ServerInterceptor {
         Authentication authentication = this.grpcAuthenticationReader.readAuthentication(call, headers);
         if (authentication == null) {
             log.debug("No credentials found: Continuing unauthenticated");
-            return next.startCall(call, headers);
+            try {
+                return next.startCall(call, headers);
+            } catch (AccessDeniedException e) {
+                throw new BadCredentialsException("No credentials found in the request", e);
+            }
         }
         log.debug("Credentials found: Authenticating...");
         authentication = this.authenticationManager.authenticate(authentication);
         SecurityContextHolder.getContext().setAuthentication(authentication);
         log.debug("Authentication successful: Continuing as {} ({})", authentication.getName(),
                 authentication.getAuthorities());
-        return new AuthenticatingServerCallListener<>(next.startCall(call, headers));
+        try {
+            return new AuthenticatingServerCallListener<>(next.startCall(call, headers), authentication);
+        } finally {
+            log.debug("startCall - Authentication cleared");
+            SecurityContextHolder.clearContext();
+        }
     }
 
     /**
@@ -77,16 +88,69 @@ public class AuthenticatingServerInterceptor implements ServerInterceptor {
      */
     private class AuthenticatingServerCallListener<ReqT> extends SimpleForwardingServerCallListener<ReqT> {
 
-        public AuthenticatingServerCallListener(final Listener<ReqT> delegate) {
+        private final Authentication authentication;
+
+        public AuthenticatingServerCallListener(final Listener<ReqT> delegate, Authentication authentication) {
             super(delegate);
+            this.authentication = authentication;
+        }
+
+        @Override
+        public void onMessage(ReqT message) {
+            try {
+                log.debug("onMessage - Authentication set");
+                SecurityContextHolder.getContext().setAuthentication(this.authentication);
+                super.onMessage(message);
+            } finally {
+                log.debug("onMessage - Authentication cleared");
+                SecurityContextHolder.clearContext();
+            }
         }
 
         @Override
         public void onHalfClose() {
             try {
+                log.debug("onHalfClose - Authentication set");
+                SecurityContextHolder.getContext().setAuthentication(this.authentication);
                 super.onHalfClose();
             } finally {
-                log.debug("Authentication cleared");
+                log.debug("onHalfClose - Authentication cleared");
+                SecurityContextHolder.clearContext();
+            }
+        }
+
+        @Override
+        public void onCancel() {
+            try {
+                log.debug("onCancel - Authentication set");
+                SecurityContextHolder.getContext().setAuthentication(this.authentication);
+                super.onCancel();
+            } finally {
+                log.debug("onCancel - Authentication cleared");
+                SecurityContextHolder.clearContext();
+            }
+        }
+
+        @Override
+        public void onComplete() {
+            try {
+                log.debug("onComplete - Authentication set");
+                SecurityContextHolder.getContext().setAuthentication(this.authentication);
+                super.onComplete();
+            } finally {
+                log.debug("onComplete - Authentication cleared");
+                SecurityContextHolder.clearContext();
+            }
+        }
+
+        @Override
+        public void onReady() {
+            try {
+                log.debug("onReady - Authentication set");
+                SecurityContextHolder.getContext().setAuthentication(this.authentication);
+                super.onReady();
+            } finally {
+                log.debug("onReady - Authentication cleared");
                 SecurityContextHolder.clearContext();
             }
         }

--- a/tests/build.gradle
+++ b/tests/build.gradle
@@ -64,6 +64,8 @@ dependencies {
 test {
     useJUnitPlatform()
     testLogging {
+        // failFast = true
+        // showStandardStreams = true
         exceptionFormat = 'full'
     }
 }

--- a/tests/src/test/java/net/devh/test/grpc/AbstractBrokenServerClientTest.java
+++ b/tests/src/test/java/net/devh/test/grpc/AbstractBrokenServerClientTest.java
@@ -21,6 +21,8 @@ import static io.grpc.Status.Code.UNAVAILABLE;
 import static net.devh.test.grpc.util.GrpcAssertions.assertFutureThrowsStatus;
 import static net.devh.test.grpc.util.GrpcAssertions.assertThrowsStatus;
 
+import java.util.concurrent.TimeUnit;
+
 import org.junit.jupiter.api.Test;
 import org.springframework.test.annotation.DirtiesContext;
 
@@ -61,9 +63,10 @@ public abstract class AbstractBrokenServerClientTest {
 
         final StreamRecorder<SomeType> streamRecorder = StreamRecorder.create();
         this.testServiceStub.normal(Empty.getDefaultInstance(), streamRecorder);
-        assertFutureThrowsStatus(UNAVAILABLE, streamRecorder.firstValue());
+        assertFutureThrowsStatus(UNAVAILABLE, streamRecorder.firstValue(), 5, TimeUnit.SECONDS);
         assertThrowsStatus(UNAVAILABLE, () -> this.testServiceBlockingStub.normal(Empty.getDefaultInstance()));
-        assertFutureThrowsStatus(UNAVAILABLE, this.testServiceFutureStub.normal(Empty.getDefaultInstance()));
+        assertFutureThrowsStatus(UNAVAILABLE, this.testServiceFutureStub.normal(Empty.getDefaultInstance()),
+                5, TimeUnit.SECONDS);
         log.info("--- Test completed ---");
     }
 
@@ -79,9 +82,10 @@ public abstract class AbstractBrokenServerClientTest {
 
         final StreamRecorder<SomeType> streamRecorder = StreamRecorder.create();
         this.testServiceStub.unimplemented(Empty.getDefaultInstance(), streamRecorder);
-        assertFutureThrowsStatus(UNAVAILABLE, streamRecorder.firstValue());
+        assertFutureThrowsStatus(UNAVAILABLE, streamRecorder.firstValue(), 5, TimeUnit.SECONDS);
         assertThrowsStatus(UNAVAILABLE, () -> this.testServiceBlockingStub.unimplemented(Empty.getDefaultInstance()));
-        assertFutureThrowsStatus(UNAVAILABLE, this.testServiceFutureStub.unimplemented(Empty.getDefaultInstance()));
+        assertFutureThrowsStatus(UNAVAILABLE, this.testServiceFutureStub.unimplemented(Empty.getDefaultInstance()),
+                5, TimeUnit.SECONDS);
         log.info("--- Test completed ---");
     }
 

--- a/tests/src/test/java/net/devh/test/grpc/AbstractSimpleServerClientTest.java
+++ b/tests/src/test/java/net/devh/test/grpc/AbstractSimpleServerClientTest.java
@@ -23,6 +23,7 @@ import static net.devh.test.grpc.util.GrpcAssertions.assertThrowsStatus;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.test.annotation.DirtiesContext;
@@ -89,9 +90,10 @@ public abstract class AbstractSimpleServerClientTest {
 
         final StreamRecorder<SomeType> streamRecorder = StreamRecorder.create();
         this.testServiceStub.unimplemented(Empty.getDefaultInstance(), streamRecorder);
-        assertFutureThrowsStatus(UNIMPLEMENTED, streamRecorder.firstValue());
+        assertFutureThrowsStatus(UNIMPLEMENTED, streamRecorder.firstValue(), 5, TimeUnit.SECONDS);
         assertThrowsStatus(UNIMPLEMENTED, () -> this.testServiceBlockingStub.unimplemented(Empty.getDefaultInstance()));
-        assertFutureThrowsStatus(UNIMPLEMENTED, this.testServiceFutureStub.unimplemented(Empty.getDefaultInstance()));
+        assertFutureThrowsStatus(UNIMPLEMENTED, this.testServiceFutureStub.unimplemented(Empty.getDefaultInstance()),
+                5, TimeUnit.SECONDS);
         log.info("--- Test completed ---");
     }
 

--- a/tests/src/test/java/net/devh/test/grpc/security/AbstractSecurityTest.java
+++ b/tests/src/test/java/net/devh/test/grpc/security/AbstractSecurityTest.java
@@ -23,6 +23,7 @@ import static net.devh.test.grpc.util.GrpcAssertions.assertThrowsStatus;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.test.annotation.DirtiesContext;
@@ -124,11 +125,11 @@ public abstract class AbstractSecurityTest {
 
             final StreamRecorder<SomeType> streamRecorder = StreamRecorder.create();
             this.brokenTestServiceStub.secure(Empty.getDefaultInstance(), streamRecorder);
-            assertFutureThrowsStatus(PERMISSION_DENIED, streamRecorder.firstValue());
+            assertFutureThrowsStatus(PERMISSION_DENIED, streamRecorder.firstValue(), 5, TimeUnit.SECONDS);
             assertThrowsStatus(PERMISSION_DENIED,
                     () -> this.brokenTestServiceBlockingStub.secure(Empty.getDefaultInstance()));
             assertFutureThrowsStatus(PERMISSION_DENIED,
-                    this.brokenTestServiceFutureStub.secure(Empty.getDefaultInstance()));
+                    this.brokenTestServiceFutureStub.secure(Empty.getDefaultInstance()), 5, TimeUnit.SECONDS);
         }
         log.info("--- Test completed ---");
     }

--- a/tests/src/test/java/net/devh/test/grpc/security/ConcurrentSecurityTest.java
+++ b/tests/src/test/java/net/devh/test/grpc/security/ConcurrentSecurityTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2016-2018 Michael Zhang <yidongnan@gmail.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package net.devh.test.grpc.security;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+import com.google.protobuf.Empty;
+
+import io.grpc.Status.Code;
+import io.grpc.internal.testing.StreamRecorder;
+import lombok.extern.slf4j.Slf4j;
+import net.devh.springboot.autoconfigure.grpc.client.GrpcClient;
+import net.devh.test.grpc.config.ManualSecurityConfiguration;
+import net.devh.test.grpc.config.ServiceConfiguration;
+import net.devh.test.grpc.config.WithBasicAuthSecurityConfiguration;
+import net.devh.test.grpc.proto.SomeType;
+import net.devh.test.grpc.proto.TestServiceGrpc.TestServiceStub;
+import net.devh.test.grpc.util.GrpcAssertions;
+
+@Slf4j
+@SpringBootTest(properties = {
+        "grpc.client.test.negotiationType=PLAINTEXT",
+        "grpc.client.broken.negotiationType=PLAINTEXT"})
+@SpringJUnitConfig(classes = {ServiceConfiguration.class, ManualSecurityConfiguration.class,
+        WithBasicAuthSecurityConfiguration.class})
+@DirtiesContext
+public class ConcurrentSecurityTest {
+
+    @GrpcClient("test")
+    protected TestServiceStub testServiceStub;
+
+    @GrpcClient("broken")
+    protected TestServiceStub brokenTestServiceStub;
+
+    /**
+     * Test secured call.
+     *
+     * @throws Throwable
+     */
+    @Test
+    @DirtiesContext
+    public void testSecuredCall() throws Throwable {
+        final int parallelCount = 50; // Limited for automated tests, increase for in depth tests
+        log.info("--- Starting tests with secured call ---");
+        List<Executable> runnables = new ArrayList<>();
+        for (int i = 0; i < parallelCount; i++) {
+            final StreamRecorder<SomeType> streamRecorder = StreamRecorder.create();
+            this.testServiceStub.secure(Empty.getDefaultInstance(), streamRecorder);
+            runnables.add(() -> assertEquals("1.2.3", streamRecorder.firstValue().get().getVersion()));
+        }
+        for (int i = 0; i < parallelCount; i++) {
+            final StreamRecorder<SomeType> streamRecorder = StreamRecorder.create();
+            this.brokenTestServiceStub.secure(Empty.getDefaultInstance(), streamRecorder);
+            runnables.add(() -> GrpcAssertions.assertFutureThrowsStatus(Code.PERMISSION_DENIED,
+                    streamRecorder.firstValue(), 15, TimeUnit.SECONDS));
+        }
+        Collections.shuffle(runnables);
+        for (Executable executable : runnables) {
+            executable.execute();
+        }
+        log.info("--- Test completed ---");
+    }
+
+}

--- a/tests/src/test/java/net/devh/test/grpc/server/TestServiceImpl.java
+++ b/tests/src/test/java/net/devh/test/grpc/server/TestServiceImpl.java
@@ -50,7 +50,7 @@ public class TestServiceImpl extends TestServiceImplBase {
     @Override
     @Secured("ROLE_CLIENT1")
     public void secure(final Empty request, final StreamObserver<SomeType> responseObserver) {
-        log.debug("secure: {}", SecurityContextHolder.getContext().getAuthentication().getName());
+        log.debug("secure: {}", SecurityContextHolder.getContext().getAuthentication());
         final SomeType version = SomeType.newBuilder().setVersion("1.2.3").build();
         responseObserver.onNext(version);
         responseObserver.onCompleted();

--- a/tests/src/test/java/net/devh/test/grpc/util/FutureAssertions.java
+++ b/tests/src/test/java/net/devh/test/grpc/util/FutureAssertions.java
@@ -29,9 +29,9 @@ public final class FutureAssertions {
 
     @SuppressWarnings("unchecked")
     public static <T extends Exception> T assertFutureThrows(final Class<T> expectedType,
-            final ListenableFuture<?> future) {
+            final ListenableFuture<?> future, int timeout, TimeUnit timeoutUnit) {
         final Throwable cause =
-                assertThrows(ExecutionException.class, () -> future.get(5, TimeUnit.SECONDS)).getCause();
+                assertThrows(ExecutionException.class, () -> future.get(timeout, timeoutUnit)).getCause();
         final Class<? extends Throwable> causeClass = cause.getClass();
         assertTrue(expectedType.isAssignableFrom(causeClass), "The cause was of type: " + causeClass.getName()
                 + ", but it was expected to be a subclass of " + expectedType.getName());

--- a/tests/src/test/java/net/devh/test/grpc/util/GrpcAssertions.java
+++ b/tests/src/test/java/net/devh/test/grpc/util/GrpcAssertions.java
@@ -21,6 +21,8 @@ import static net.devh.test.grpc.util.FutureAssertions.assertFutureThrows;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import java.util.concurrent.TimeUnit;
+
 import org.junit.jupiter.api.function.Executable;
 
 import com.google.common.util.concurrent.ListenableFuture;
@@ -35,8 +37,10 @@ public final class GrpcAssertions {
         return assertStatus(code, exception);
     }
 
-    public static Status assertFutureThrowsStatus(final Status.Code code, final ListenableFuture<?> future) {
-        final StatusRuntimeException exception = assertFutureThrows(StatusRuntimeException.class, future);
+    public static Status assertFutureThrowsStatus(final Status.Code code, final ListenableFuture<?> future, int timeout,
+            TimeUnit timeoutUnit) {
+        final StatusRuntimeException exception =
+                assertFutureThrows(StatusRuntimeException.class, future, timeout, timeoutUnit);
         return assertStatus(code, exception);
     }
 


### PR DESCRIPTION
Improves #122 

In gRPC each callback can be called from a different thread, thus the current setup (which assumes that after the `startCall` method everything is called by the same thread) is wrong.

This PR changes the authenticating interceptor to work similar to grpc's Contexts which also use `ThreadLocal`s.

See also:
* [this question on SO](https://stackoverflow.com/questions/34905499/grpc-java-pass-data-from-server-interceptor-to-rpc-service-call)
* [grpc-Contexts](https://github.com/grpc/grpc-java/blob/master/core/src/main/java/io/grpc/Contexts.java#L44)