### PR TITLE
Update dependencies and plugins

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,22 +12,24 @@ buildscript {
     ext {
         projectVersion = '2.1.1.SNAPSHOT'
 
-        grpcVersion = '1.14.0'
-        protobufVersion = '3.5.1'
-        protobufGradlePluginVersion = '0.8.4'
+        grpcVersion = '1.16.1'
+        protobufVersion = '3.6.1'
+        protobufGradlePluginVersion = '0.8.7'
+        nettyTCNativeVersion = '2.0.17.Final'
 
-        springBootVersion = '2.0.4.RELEASE'
-        springSecurityVersion = '5.0.5.RELEASE'
-        springSleuthVersion = '2.0.1.RELEASE'
-        springCloudVersion = 'Finchley.SR1'
+        springBootVersion = '2.0.6.RELEASE'
+        springSecurityVersion = '5.0.9.RELEASE'
+        springCloudVersion = 'Finchley.SR2'
+        springCloudSleuthVersion = '2.0.2.RELEASE'
         springCloudConsulVersion = '2.0.1.RELEASE'
-        springCloudEurekaVersion = '2.0.1.RELEASE'
-        braveInstrumentationGrpc = '5.1.2'
+        springCloudEurekaVersion = '2.0.2.RELEASE'
+        braveInstrumentationGrpc = '5.5.0'
+        jUnitVersion = '5.3.1'
     }
     dependencies {
-        classpath "io.spring.gradle:dependency-management-plugin:0.6.1.RELEASE"
+        classpath "io.spring.gradle:dependency-management-plugin:1.0.6.RELEASE"
         classpath "org.springframework.boot:spring-boot-gradle-plugin:${springBootVersion}"
-        classpath "com.diffplug.spotless:spotless-plugin-gradle:3.15.0"
+        classpath "com.diffplug.spotless:spotless-plugin-gradle:3.16.0"
     }
 }
 
@@ -124,9 +126,9 @@ allprojects {
         maven { url 'https://repo.spring.io/libs-milestone' }
     }
     dependencies {
-        compileOnly('org.projectlombok:lombok:1.18.0')
-        testCompile('org.projectlombok:lombok:1.18.0')
-        annotationProcessor('org.projectlombok:lombok:1.18.0')
+        compileOnly('org.projectlombok:lombok:1.18.4')
+        testCompile('org.projectlombok:lombok:1.18.4')
+        annotationProcessor('org.projectlombok:lombok:1.18.4')
     }
     buildscript {
         repositories {

--- a/grpc-client-spring-boot-autoconfigure/build.gradle
+++ b/grpc-client-spring-boot-autoconfigure/build.gradle
@@ -8,7 +8,7 @@ compileJava.dependsOn(processResources)
 dependencies {
     compileOnly("org.springframework.boot:spring-boot-configuration-processor:${springBootVersion}")
     compile("org.springframework.boot:spring-boot-starter:${springBootVersion}")
-    compileOnly("org.springframework.cloud:spring-cloud-starter-sleuth:${springSleuthVersion}")
+    compileOnly("org.springframework.cloud:spring-cloud-starter-sleuth:${springCloudSleuthVersion}")
     compileOnly("org.springframework.cloud:spring-cloud-starter-consul-discovery:${springCloudConsulVersion}")
     compileOnly("org.springframework.cloud:spring-cloud-starter-netflix-eureka-client:${springCloudEurekaVersion}")
     compileOnly("io.zipkin.brave:brave-instrumentation-grpc:${braveInstrumentationGrpc}")

--- a/grpc-server-spring-boot-autoconfigure/build.gradle
+++ b/grpc-server-spring-boot-autoconfigure/build.gradle
@@ -9,7 +9,7 @@ dependencies {
     compileOnly("org.springframework.boot:spring-boot-configuration-processor:${springBootVersion}")
     compile("org.springframework.boot:spring-boot-starter:${springBootVersion}")
     compileOnly("org.springframework.security:spring-security-core:${springSecurityVersion}")
-    compileOnly("org.springframework.cloud:spring-cloud-starter-sleuth:${springSleuthVersion}")
+    compileOnly("org.springframework.cloud:spring-cloud-starter-sleuth:${springCloudSleuthVersion}")
     compileOnly("org.springframework.cloud:spring-cloud-starter-consul-discovery:${springCloudConsulVersion}")
     compileOnly("org.springframework.cloud:spring-cloud-starter-netflix-eureka-client:${springCloudEurekaVersion}")
     compileOnly("io.zipkin.brave:brave-instrumentation-grpc:${braveInstrumentationGrpc}")

--- a/tests/build.gradle
+++ b/tests/build.gradle
@@ -3,6 +3,13 @@ version = "${projectVersion}"
 
 apply plugin: 'com.google.protobuf'
 
+apply plugin: 'eclipse'
+eclipse {
+    project {
+        name = 'grpc-spring-boot-tests'
+    }
+}
+
 compileTestJava.dependsOn(processTestResources)
 
 dependencies {
@@ -53,11 +60,11 @@ dependencies {
         "io.grpc:grpc-testing:${grpcVersion}",
         "org.springframework.boot:spring-boot-starter-test:${springBootVersion}",
         "org.springframework.security:spring-security-config:${springSecurityVersion}",
-        "io.netty:netty-tcnative-boringssl-static:2.0.12.Final",
-        "org.junit.jupiter:junit-jupiter-api:5.3.1"
+        "io.netty:netty-tcnative-boringssl-static:${nettyTCNativeVersion}",
+        "org.junit.jupiter:junit-jupiter-api:${jUnitVersion}"
     )
     testRuntimeOnly(
-        "org.junit.jupiter:junit-jupiter-engine:5.3.1"
+        "org.junit.jupiter:junit-jupiter-engine:${jUnitVersion}"
     )
 }
 


### PR DESCRIPTION
Updates grpc to 1.16.1 (for new ClientCredentials features)
Updates protobuf to 3.6.1
Update Spring Boot to 2.0.6.RELEASE
Update Spring Security to 5.0.9.RELEASE
Update Lombok to 1.18.4 (For Java 11 support)

----------------

I also tested this library with Spring-Boot 2.1 (which officially adds Java 11 support) and it seems to work fine. However, Spring Cloud Finchley Release is not explicitly compatible with Spring Boot 2.1.0, only the next release will be. Java 8 will be EOL in two months, that's why we should update the libraries soon. It is not necessary to change the compilation level, so we can stay compatible with older releases.

> Greenwich.RELEASE
> Due by December 20, 2018 (This is a tentative date.)
> Compatible with Spring Boot 2.1.0, Framework 5.1 and Java 11.

The tests and everything still work even with mixed versions. We should keep an eye on the `Greenwich` release and update to Spring-Boot 2.1 after that release.


