### PR TITLE
Improve tracing

### DIFF
--- a/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/springboot/autoconfigure/grpc/client/GrpcClientAutoConfiguration.java
+++ b/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/springboot/autoconfigure/grpc/client/GrpcClientAutoConfiguration.java
@@ -100,11 +100,13 @@ public class GrpcClientAutoConfiguration {
 
     @Configuration
     @ConditionalOnProperty(value = "spring.sleuth.scheduled.enabled", matchIfMissing = true)
-    @AutoConfigureAfter({TraceAutoConfiguration.class})
-    @ConditionalOnClass(value = {Tracing.class, GrpcTracing.class, TraceAutoConfiguration.class})
+    @AutoConfigureAfter(TraceAutoConfiguration.class)
+    @ConditionalOnBean(Tracing.class)
+    @ConditionalOnClass(GrpcTracing.class)
     protected static class TraceClientAutoConfiguration {
 
         @Bean
+        @ConditionalOnMissingBean
         public GrpcTracing grpcTracing(final Tracing tracing) {
             return GrpcTracing.create(tracing);
         }

--- a/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/springboot/autoconfigure/grpc/server/GrpcServerAutoConfiguration.java
+++ b/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/springboot/autoconfigure/grpc/server/GrpcServerAutoConfiguration.java
@@ -18,6 +18,7 @@
 package net.devh.springboot.autoconfigure.grpc.server;
 
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -99,11 +100,13 @@ public class GrpcServerAutoConfiguration {
 
     @Configuration
     @ConditionalOnProperty(value = "spring.sleuth.scheduled.enabled", matchIfMissing = true)
-    @AutoConfigureAfter({TraceAutoConfiguration.class})
-    @ConditionalOnClass(value = {Tracing.class, GrpcTracing.class, TraceAutoConfiguration.class})
+    @AutoConfigureAfter(TraceAutoConfiguration.class)
+    @ConditionalOnBean(Tracing.class)
+    @ConditionalOnClass(GrpcTracing.class)
     protected static class TraceServerAutoConfiguration {
 
         @Bean
+        @ConditionalOnMissingBean
         public GrpcTracing grpcTracing(final Tracing tracing) {
             return GrpcTracing.create(tracing);
         }


### PR DESCRIPTION
Remove bean dependency on auto config.
Fix conflict/creating `GrpcTracing` bean twice, if both server and client are in the same application.

I have never used sleuth so, I'm not sure, whether the `spring.sleuth.scheduled.enabled` property check was added intentionally or to avoid conflicts with missing beans. If it is for the later, then maybe we can remove that as well, with the new condition layout?