### PR TITLE
More secure client auth + share the authorization header constants

### DIFF
--- a/examples/security-grpc-client/src/main/java/net/devh/boot/grpc/examples/security/client/SecurityConfiguration.java
+++ b/examples/security-grpc-client/src/main/java/net/devh/boot/grpc/examples/security/client/SecurityConfiguration.java
@@ -17,6 +17,9 @@
 
 package net.devh.boot.grpc.examples.security.client;
 
+import static net.devh.boot.grpc.client.security.AuthenticatingClientInterceptors.basicAuthCallCredentials;
+import static net.devh.boot.grpc.client.security.AuthenticatingClientInterceptors.callCredentialsInterceptor;
+
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -24,7 +27,6 @@ import org.springframework.context.annotation.Configuration;
 import io.grpc.ClientInterceptor;
 import net.devh.boot.grpc.client.inject.GrpcClient;
 import net.devh.boot.grpc.client.interceptor.GlobalClientInterceptorConfigurer;
-import net.devh.boot.grpc.client.security.AuthenticatingClientInterceptors;
 
 /**
  * The security configuration for the client. In this case we assume that we use the same passwords for all stubs. If
@@ -41,15 +43,15 @@ public class SecurityConfiguration {
 
     @Bean
     // Create interceptor for username + password auth.
-    ClientInterceptor basicAuthInterceptor() {
-        return AuthenticatingClientInterceptors.basicAuth(this.username, this.username + "Password");
+    ClientInterceptor clientCredentialsInterceptor() {
+        return callCredentialsInterceptor(basicAuthCallCredentials(this.username, this.username + "Password"));
     }
 
     @Bean
     // Register the auth interceptor globally.
     public GlobalClientInterceptorConfigurer securityInterceptorConfigurer(
-            final ClientInterceptor basicAuthInterceptor) {
-        return registry -> registry.addClientInterceptors(basicAuthInterceptor);
+            final ClientInterceptor clientCredentialsInterceptor) {
+        return registry -> registry.addClientInterceptors(clientCredentialsInterceptor);
     }
 
 }

--- a/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/inject/GrpcClient.java
+++ b/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/inject/GrpcClient.java
@@ -28,6 +28,8 @@ import javax.inject.Inject;
 
 import org.springframework.beans.factory.annotation.Autowired;
 
+import io.grpc.CallCredentials;
+import io.grpc.CallOptions;
 import io.grpc.Channel;
 import io.grpc.ClientInterceptor;
 import io.grpc.stub.AbstractStub;
@@ -41,6 +43,13 @@ import net.devh.boot.grpc.client.config.GrpcChannelProperties.Security;
  * <p>
  * <b>Note:</b> Fields that are annotated with this annotation should NOT be annotated with {@link Autowired} or
  * {@link Inject} (conflict).
+ * </p>
+ *
+ * <p>
+ * <b>Note:</b> If you annotate an AbstractStub with this annotation the bean processing will also apply the
+ * {@link StubTransformer}s in the application context. These can be used, for example, to configure {@link CallOptions}
+ * such as {@link CallCredentials}. Please note that these transformations aren't applied if you inject a
+ * {@link Channel} only.
  * </p>
  *
  * @author Michael (yidongnan@gmail.com)

--- a/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/inject/StubTransformer.java
+++ b/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/inject/StubTransformer.java
@@ -15,33 +15,35 @@
  * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package net.devh.boot.grpc.examples.security.client;
+package net.devh.boot.grpc.client.inject;
 
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
-
-import io.grpc.CallCredentials;
-import net.devh.boot.grpc.client.inject.StubTransformer;
-import net.devh.boot.grpc.client.security.CallCredentialsHelper;
+import io.grpc.Channel;
+import io.grpc.stub.AbstractStub;
+import net.devh.boot.grpc.client.channelfactory.GrpcChannelFactory;
 
 /**
- * The security configuration for the client. In this case we assume that we use the same passwords for all stubs. If
- * you need per stub credentials you can delete the grpcCredentials and define a {@link StubTransformer} yourself.
+ * A stub transformer will be used by the {@link GrpcClientBeanPostProcessor} to configure the stubs before they are
+ * assigned to their fields. Implementations should only call the {@code AbstractStub#with...} methods on the given
+ * stubs and return that result. Implementations should not use this transformer to replace the stub with a unrelated
+ * other instance.
+ *
+ * <p>
+ * <b>Note:</b> StubTransformer will only transform {@link AbstractStub}s and NOT {@link Channel}s. To configure
+ * channels use the {@link GrpcChannelFactory}.
+ * </p>
  *
  * @author Daniel Theuke (daniel.theuke@heuboe.de)
- * @see CallCredentialsHelper
  */
-@Configuration
-public class SecurityConfiguration {
+@FunctionalInterface
+public interface StubTransformer {
 
-    @Value("${auth.username}")
-    private String username;
-
-    @Bean
-    // Create credentials for username + password.
-    CallCredentials grpcCredentials() {
-        return CallCredentialsHelper.basicAuth(this.username, this.username + "Password");
-    }
+    /**
+     * Transform the given stub using {@code AbstractStub#with...} methods.
+     *
+     * @param name The name that was used to create the stub.
+     * @param stub The stub that should be transformed.
+     * @return The transformed stub.
+     */
+    AbstractStub<?> transform(String name, AbstractStub<?> stub);
 
 }

--- a/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/security/AuthenticatingClientInterceptors.java
+++ b/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/security/AuthenticatingClientInterceptors.java
@@ -17,42 +17,69 @@
 
 package net.devh.boot.grpc.client.security;
 
+import static com.google.common.base.Preconditions.checkNotNull;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Objects.requireNonNull;
+import static net.devh.boot.grpc.common.security.SecurityConstants.AUTHORIZATION_HEADER;
+import static net.devh.boot.grpc.common.security.SecurityConstants.BASIC_AUTH_PREFIX;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
+import java.util.concurrent.Executor;
 
+import io.grpc.CallCredentials;
+import io.grpc.CallCredentials2;
+import io.grpc.CallOptions;
+import io.grpc.Channel;
+import io.grpc.ClientCall;
 import io.grpc.ClientInterceptor;
 import io.grpc.Metadata;
-import io.grpc.Metadata.Key;
+import io.grpc.MethodDescriptor;
+import io.grpc.SecurityLevel;
+import io.grpc.Status;
+import io.grpc.stub.AbstractStub;
 import io.grpc.stub.MetadataUtils;
 import net.devh.boot.grpc.client.inject.GrpcClient;
 
 /**
- * Helper class that can be used to create authenticating {@link ClientInterceptor}.
+ * Helper class that can be used to create {@link CallCredentials} and the necessary {@link ClientInterceptor}s.
  *
  * <p>
- * These interceptors can be used like this:
+ * This class can be used like this:
  * </p>
  *
  * <pre>
- * <code>
- * &#64;Bean
- * ClientInterceptor basicAuthInterceptor() {
- *     return basicAuth("foo", "bar");
+ * <code>&#64;Bean
+ * CallCredentials grpcCallCredentials() {
+ *     // Note: This method uses experimental grpc-java-API features.
+ *     return AuthenticatingClientInterceptors.basicAuthCallCredentials("foo", "bar");
+ *     // return AuthenticatingClientInterceptors.requirePrivacy(...); // Always a good idea
  * }
- * </code>
+ *
+ * &#64;Bean
+ * ClientInterceptor grpcCallCredentialsInterceptor() {
+ *     return AuthenticatingClientInterceptors.callCredentialsInterceptor(grpcCallCredentials());
+ * }</code>
  * </pre>
  *
+ * <p>
+ * Currently supported credentials:
+ * </p>
+ * <ul>
+ * <li>{@link #basicAuthCallCredentials(String, String) Basic-Auth}</li>
+ * </ul>
+ *
+ * <p>
+ * <b>Note:</b> You don't need extra call credentials if you authenticate yourself via certificates.
+ * </p>
  *
  * <ul>
- * <li>If you only need a single authenticating client interceptor for all clients, then you can register it globally.
+ * <li>If you only need a single CallCredentials for all clients, then you can register it globally.
  *
  * <pre>
  * <code>&#64;Bean
  * public GlobalClientInterceptorConfigurer basicAuthInterceptorConfigurer() {
- *     return registry -&gt; registry.addClientInterceptors(basicAuthInterceptor());
+ *     return registry -&gt; registry.addClientInterceptors(grpcCallCredentialsInterceptor());
  * }</code>
  * </pre>
  *
@@ -62,7 +89,7 @@ import net.devh.boot.grpc.client.inject.GrpcClient;
  * {@link GrpcClient#interceptorNames()} field to add a bean by name.
  *
  * <pre>
- * <code>&#64;GrpcClient(value = "testChannel", interceptorNames = "basicAuthInterceptor")
+ * <code>&#64;GrpcClient(value = "testChannel", interceptorNames = "grpcCallCredentialsInterceptorForTest")
  * private Channel testChannel;</code>
  * </pre>
  *
@@ -71,12 +98,9 @@ import net.devh.boot.grpc.client.inject.GrpcClient;
  *
  * @author Daniel Theuke (daniel.theuke@heuboe.de)
  */
+// @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1914")
+// @ExperimentalApi("https://github.com/grpc/grpc-java/issues/4901")
 public final class AuthenticatingClientInterceptors {
-
-    /**
-     * A convenience constant that contains the key for the HTTP Authorization Header.
-     */
-    public static final Key<String> AUTHORIZATION_HEADER = Key.of("Authorization", Metadata.ASCII_STRING_MARSHALLER);
 
     /**
      * Creates a new {@link ClientInterceptor} that adds the given username and passwords as basic auth to all requests.
@@ -86,11 +110,59 @@ public final class AuthenticatingClientInterceptors {
      * @param password The password to use.
      * @return The newly created basic auth interceptor.
      * @see #encodeBasicAuth(String, String)
+     * @deprecated Use the (potentially) more secure {@link CallCredentials}.
      */
-    public static ClientInterceptor basicAuth(final String username, final String password) {
+    @Deprecated
+    public static ClientInterceptor basicAuthInterceptor(final String username, final String password) {
         final Metadata extraHeaders = new Metadata();
         extraHeaders.put(AUTHORIZATION_HEADER, encodeBasicAuth(username, password));
         return MetadataUtils.newAttachHeadersInterceptor(extraHeaders);
+    }
+
+    /**
+     * Creates a new {@link ClientInterceptor} that will attach the given call credentials to the given call. This is an
+     * alternative to manually configuring the stubs using {@link AbstractStub#withCallCredentials(CallCredentials)}.
+     *
+     * @param callCredentials The call credentials to attach.
+     * @return The newly created client credentials interceptor.
+     * @see #basicAuthCallCredentials(String, String) Basic-Auth
+     */
+    // TODO: Check alternatives such as using a StubTransformer for the GrpcClientBeanPostProcessor
+    public static ClientInterceptor callCredentialsInterceptor(final CallCredentials callCredentials) {
+        return new CallCredentialsAttachingClientInterceptor(callCredentials);
+    }
+
+    private static final class CallCredentialsAttachingClientInterceptor implements ClientInterceptor {
+
+        private final CallCredentials credentials;
+
+        CallCredentialsAttachingClientInterceptor(final CallCredentials credentials) {
+            this.credentials = checkNotNull(credentials, "credentials");
+        }
+
+        @Override
+        public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(final MethodDescriptor<ReqT, RespT> method,
+                final CallOptions callOptions, final Channel next) {
+            return next.newCall(method, callOptions.withCallCredentials(this.credentials));
+        }
+
+    }
+
+    /**
+     * Creates a new call credential with the given username and password for basic auth.
+     *
+     * <p>
+     * <b>Note:</b> This method uses experimental grpc-java-API features.
+     * </p>
+     *
+     * @param username The username to use.
+     * @param password The password to use.
+     * @return The newly created basic auth credentials.
+     */
+    public static CallCredentials2 basicAuthCallCredentials(final String username, final String password) {
+        final Metadata extraHeaders = new Metadata();
+        extraHeaders.put(AUTHORIZATION_HEADER, encodeBasicAuth(username, password));
+        return new StaticSecurityHeaderCallCredentials(extraHeaders);
     }
 
     /**
@@ -111,7 +183,121 @@ public final class AuthenticatingClientInterceptors {
         } catch (final IllegalArgumentException e) {
             throw new IllegalArgumentException("Failed to encode basic authentication token", e);
         }
-        return "Basic " + new String(encoded, UTF_8);
+        return BASIC_AUTH_PREFIX + new String(encoded, UTF_8);
+    }
+
+    private static final class StaticSecurityHeaderCallCredentials extends CallCredentials2 {
+
+        private final Metadata extraHeaders;
+
+        StaticSecurityHeaderCallCredentials(final Metadata extraHeaders) {
+            this.extraHeaders = requireNonNull(extraHeaders, "extraHeaders");
+        }
+
+        @SuppressWarnings("deprecation") // API evolution in progress
+        @Override
+        public void applyRequestMetadata(final RequestInfo requestInfo, final Executor appExecutor,
+                final MetadataApplier applier) {
+            applier.apply(this.extraHeaders);
+        }
+
+        @Override
+        public void thisUsesUnstableApi() {} // API evolution in progress
+
+    }
+
+    /**
+     * Checks whether the given security level provides privacy for all data being send on the connection.
+     *
+     * <p>
+     * <b>Note:</b> This method uses experimental grpc-java-API features.
+     * </p>
+     *
+     * @param securityLevel The security level to check.
+     * @return True, if and only if the given security level ensures privacy. False otherwise.
+     */
+    public static boolean isPrivacyGuaranteed(final SecurityLevel securityLevel) {
+        return SecurityLevel.PRIVACY_AND_INTEGRITY == securityLevel;
+    }
+
+    /**
+     * Wraps the given call credentials in a new layer, which ensures that the credentials are only send, if the
+     * connection guarantees privacy. If the connection doesn't do that, the call will be aborted before sending any
+     * data.
+     *
+     * <p>
+     * <b>Note:</b> This method uses experimental grpc-java-API features.
+     * </p>
+     *
+     * @param callCredentials The call credentials to wrap.
+     * @return The newly created call credentials.
+     */
+    public static CallCredentials requirePrivacy(final CallCredentials2 callCredentials) {
+        return new RequirePrivacyCallCredentials(callCredentials);
+    }
+
+    private static final class RequirePrivacyCallCredentials extends CallCredentials2 {
+
+        private static final Status STATUS_LACKING_PRIVACY = Status.UNAUTHENTICATED
+                .withDescription("Connection security level does not ensure credential privacy");
+
+        private final CallCredentials2 callCredentials;
+
+        RequirePrivacyCallCredentials(final CallCredentials2 callCredentials) {
+            this.callCredentials = callCredentials;
+        }
+
+        @SuppressWarnings("deprecation") // API evolution in progress
+        @Override
+        public void applyRequestMetadata(final RequestInfo requestInfo, final Executor appExecutor,
+                final MetadataApplier applier) {
+            if (isPrivacyGuaranteed(requestInfo.getSecurityLevel())) {
+                this.callCredentials.applyRequestMetadata(requestInfo, appExecutor, applier);
+            } else {
+                applier.fail(STATUS_LACKING_PRIVACY);
+            }
+        }
+
+        @Override
+        public void thisUsesUnstableApi() {} // API evolution in progress
+
+    }
+
+
+    /**
+     * Wraps the given call credentials in a new layer, that will only include the credentials if the connection
+     * guarantees privacy. If the connection doesn't do that, the call will continue without the credentials.
+     *
+     * <p>
+     * <b>Note:</b> This method uses experimental grpc-java-API features.
+     * </p>
+     *
+     * @param callCredentials The call credentials to wrap.
+     * @return The newly created call credentials.
+     */
+    public static CallCredentials includeWhenPrivate(final CallCredentials2 callCredentials) {
+        return new IncludeWhenPrivateCallCredentials(callCredentials);
+    }
+
+    private static final class IncludeWhenPrivateCallCredentials extends CallCredentials2 {
+
+        private final CallCredentials2 callCredentials;
+
+        IncludeWhenPrivateCallCredentials(final CallCredentials2 callCredentials) {
+            this.callCredentials = callCredentials;
+        }
+
+        @Override
+        public void applyRequestMetadata(final RequestInfo requestInfo, final Executor appExecutor,
+                final MetadataApplier applier) {
+            if (isPrivacyGuaranteed(requestInfo.getSecurityLevel())) {
+                this.callCredentials.applyRequestMetadata(requestInfo, appExecutor, applier);
+            }
+        }
+
+        @Override
+        public void thisUsesUnstableApi() {} // API evolution in progress
+
     }
 
     private AuthenticatingClientInterceptors() {}

--- a/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/security/AuthenticatingClientInterceptors.java
+++ b/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/security/AuthenticatingClientInterceptors.java
@@ -17,29 +17,22 @@
 
 package net.devh.boot.grpc.client.security;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Objects.requireNonNull;
 import static net.devh.boot.grpc.common.security.SecurityConstants.AUTHORIZATION_HEADER;
-import static net.devh.boot.grpc.common.security.SecurityConstants.BASIC_AUTH_PREFIX;
 
 import java.nio.charset.StandardCharsets;
-import java.util.Base64;
-import java.util.concurrent.Executor;
 
 import io.grpc.CallCredentials;
-import io.grpc.CallCredentials2;
 import io.grpc.CallOptions;
 import io.grpc.Channel;
 import io.grpc.ClientCall;
 import io.grpc.ClientInterceptor;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
-import io.grpc.SecurityLevel;
-import io.grpc.Status;
 import io.grpc.stub.AbstractStub;
 import io.grpc.stub.MetadataUtils;
 import net.devh.boot.grpc.client.inject.GrpcClient;
+import net.devh.boot.grpc.client.inject.StubTransformer;
 
 /**
  * Helper class that can be used to create {@link CallCredentials} and the necessary {@link ClientInterceptor}s.
@@ -52,8 +45,8 @@ import net.devh.boot.grpc.client.inject.GrpcClient;
  * <code>&#64;Bean
  * CallCredentials grpcCallCredentials() {
  *     // Note: This method uses experimental grpc-java-API features.
- *     return AuthenticatingClientInterceptors.basicAuthCallCredentials("foo", "bar");
- *     // return AuthenticatingClientInterceptors.requirePrivacy(...); // Always a good idea
+ *     return CallCredentialsHelper.basicAuthCallCredentials("foo", "bar");
+ *     // return CallCredentialsHelper.requirePrivacy(...); // Always a good idea
  * }
  *
  * &#64;Bean
@@ -61,13 +54,6 @@ import net.devh.boot.grpc.client.inject.GrpcClient;
  *     return AuthenticatingClientInterceptors.callCredentialsInterceptor(grpcCallCredentials());
  * }</code>
  * </pre>
- *
- * <p>
- * Currently supported credentials:
- * </p>
- * <ul>
- * <li>{@link #basicAuthCallCredentials(String, String) Basic-Auth}</li>
- * </ul>
  *
  * <p>
  * <b>Note:</b> You don't need extra call credentials if you authenticate yourself via certificates.
@@ -97,9 +83,10 @@ import net.devh.boot.grpc.client.inject.GrpcClient;
  * </ul>
  *
  * @author Daniel Theuke (daniel.theuke@heuboe.de)
+ * @deprecated Use the {@link CallCredentialsHelper} or create the {@link CallCredentials} and {@link StubTransformer}s
+ *             yourself.
  */
-// @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1914")
-// @ExperimentalApi("https://github.com/grpc/grpc-java/issues/4901")
+@Deprecated
 public final class AuthenticatingClientInterceptors {
 
     /**
@@ -109,13 +96,13 @@ public final class AuthenticatingClientInterceptors {
      * @param username The username to use.
      * @param password The password to use.
      * @return The newly created basic auth interceptor.
-     * @see #encodeBasicAuth(String, String)
+     * @see CallCredentialsHelper#encodeBasicAuth(String, String)
      * @deprecated Use the (potentially) more secure {@link CallCredentials}.
      */
     @Deprecated
     public static ClientInterceptor basicAuthInterceptor(final String username, final String password) {
         final Metadata extraHeaders = new Metadata();
-        extraHeaders.put(AUTHORIZATION_HEADER, encodeBasicAuth(username, password));
+        extraHeaders.put(AUTHORIZATION_HEADER, CallCredentialsHelper.encodeBasicAuth(username, password));
         return MetadataUtils.newAttachHeadersInterceptor(extraHeaders);
     }
 
@@ -125,9 +112,10 @@ public final class AuthenticatingClientInterceptors {
      *
      * @param callCredentials The call credentials to attach.
      * @return The newly created client credentials interceptor.
-     * @see #basicAuthCallCredentials(String, String) Basic-Auth
+     * @see CallCredentialsHelper#basicAuth(String, String) Basic-Auth
+     * @deprecated Use {@link StubTransformer}s to set the credentials directly on {@link AbstractStub}s.
      */
-    // TODO: Check alternatives such as using a StubTransformer for the GrpcClientBeanPostProcessor
+    @Deprecated
     public static ClientInterceptor callCredentialsInterceptor(final CallCredentials callCredentials) {
         return new CallCredentialsAttachingClientInterceptor(callCredentials);
     }
@@ -137,7 +125,7 @@ public final class AuthenticatingClientInterceptors {
         private final CallCredentials credentials;
 
         CallCredentialsAttachingClientInterceptor(final CallCredentials credentials) {
-            this.credentials = checkNotNull(credentials, "credentials");
+            this.credentials = requireNonNull(credentials, "credentials");
         }
 
         @Override
@@ -145,158 +133,6 @@ public final class AuthenticatingClientInterceptors {
                 final CallOptions callOptions, final Channel next) {
             return next.newCall(method, callOptions.withCallCredentials(this.credentials));
         }
-
-    }
-
-    /**
-     * Creates a new call credential with the given username and password for basic auth.
-     *
-     * <p>
-     * <b>Note:</b> This method uses experimental grpc-java-API features.
-     * </p>
-     *
-     * @param username The username to use.
-     * @param password The password to use.
-     * @return The newly created basic auth credentials.
-     */
-    public static CallCredentials2 basicAuthCallCredentials(final String username, final String password) {
-        final Metadata extraHeaders = new Metadata();
-        extraHeaders.put(AUTHORIZATION_HEADER, encodeBasicAuth(username, password));
-        return new StaticSecurityHeaderCallCredentials(extraHeaders);
-    }
-
-    /**
-     * Encodes the given username and password as basic auth. The header value will be encoded with
-     * {@link StandardCharsets#UTF_8 UTF_8}.
-     *
-     * @param username The username to use.
-     * @param password The password to use.
-     * @return The encoded basic auth header value.
-     */
-    public static String encodeBasicAuth(final String username, final String password) {
-        requireNonNull(username, "username");
-        requireNonNull(password, "password");
-        final String auth = username + ':' + password;
-        byte[] encoded;
-        try {
-            encoded = Base64.getEncoder().encode(auth.getBytes(UTF_8));
-        } catch (final IllegalArgumentException e) {
-            throw new IllegalArgumentException("Failed to encode basic authentication token", e);
-        }
-        return BASIC_AUTH_PREFIX + new String(encoded, UTF_8);
-    }
-
-    private static final class StaticSecurityHeaderCallCredentials extends CallCredentials2 {
-
-        private final Metadata extraHeaders;
-
-        StaticSecurityHeaderCallCredentials(final Metadata extraHeaders) {
-            this.extraHeaders = requireNonNull(extraHeaders, "extraHeaders");
-        }
-
-        @SuppressWarnings("deprecation") // API evolution in progress
-        @Override
-        public void applyRequestMetadata(final RequestInfo requestInfo, final Executor appExecutor,
-                final MetadataApplier applier) {
-            applier.apply(this.extraHeaders);
-        }
-
-        @Override
-        public void thisUsesUnstableApi() {} // API evolution in progress
-
-    }
-
-    /**
-     * Checks whether the given security level provides privacy for all data being send on the connection.
-     *
-     * <p>
-     * <b>Note:</b> This method uses experimental grpc-java-API features.
-     * </p>
-     *
-     * @param securityLevel The security level to check.
-     * @return True, if and only if the given security level ensures privacy. False otherwise.
-     */
-    public static boolean isPrivacyGuaranteed(final SecurityLevel securityLevel) {
-        return SecurityLevel.PRIVACY_AND_INTEGRITY == securityLevel;
-    }
-
-    /**
-     * Wraps the given call credentials in a new layer, which ensures that the credentials are only send, if the
-     * connection guarantees privacy. If the connection doesn't do that, the call will be aborted before sending any
-     * data.
-     *
-     * <p>
-     * <b>Note:</b> This method uses experimental grpc-java-API features.
-     * </p>
-     *
-     * @param callCredentials The call credentials to wrap.
-     * @return The newly created call credentials.
-     */
-    public static CallCredentials requirePrivacy(final CallCredentials2 callCredentials) {
-        return new RequirePrivacyCallCredentials(callCredentials);
-    }
-
-    private static final class RequirePrivacyCallCredentials extends CallCredentials2 {
-
-        private static final Status STATUS_LACKING_PRIVACY = Status.UNAUTHENTICATED
-                .withDescription("Connection security level does not ensure credential privacy");
-
-        private final CallCredentials2 callCredentials;
-
-        RequirePrivacyCallCredentials(final CallCredentials2 callCredentials) {
-            this.callCredentials = callCredentials;
-        }
-
-        @SuppressWarnings("deprecation") // API evolution in progress
-        @Override
-        public void applyRequestMetadata(final RequestInfo requestInfo, final Executor appExecutor,
-                final MetadataApplier applier) {
-            if (isPrivacyGuaranteed(requestInfo.getSecurityLevel())) {
-                this.callCredentials.applyRequestMetadata(requestInfo, appExecutor, applier);
-            } else {
-                applier.fail(STATUS_LACKING_PRIVACY);
-            }
-        }
-
-        @Override
-        public void thisUsesUnstableApi() {} // API evolution in progress
-
-    }
-
-
-    /**
-     * Wraps the given call credentials in a new layer, that will only include the credentials if the connection
-     * guarantees privacy. If the connection doesn't do that, the call will continue without the credentials.
-     *
-     * <p>
-     * <b>Note:</b> This method uses experimental grpc-java-API features.
-     * </p>
-     *
-     * @param callCredentials The call credentials to wrap.
-     * @return The newly created call credentials.
-     */
-    public static CallCredentials includeWhenPrivate(final CallCredentials2 callCredentials) {
-        return new IncludeWhenPrivateCallCredentials(callCredentials);
-    }
-
-    private static final class IncludeWhenPrivateCallCredentials extends CallCredentials2 {
-
-        private final CallCredentials2 callCredentials;
-
-        IncludeWhenPrivateCallCredentials(final CallCredentials2 callCredentials) {
-            this.callCredentials = callCredentials;
-        }
-
-        @Override
-        public void applyRequestMetadata(final RequestInfo requestInfo, final Executor appExecutor,
-                final MetadataApplier applier) {
-            if (isPrivacyGuaranteed(requestInfo.getSecurityLevel())) {
-                this.callCredentials.applyRequestMetadata(requestInfo, appExecutor, applier);
-            }
-        }
-
-        @Override
-        public void thisUsesUnstableApi() {} // API evolution in progress
 
     }
 

--- a/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/security/CallCredentialsHelper.java
+++ b/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/security/CallCredentialsHelper.java
@@ -1,0 +1,314 @@
+/*
+ * Copyright (c) 2016-2018 Michael Zhang <yidongnan@gmail.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package net.devh.boot.grpc.client.security;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Objects.requireNonNull;
+import static net.devh.boot.grpc.common.security.SecurityConstants.AUTHORIZATION_HEADER;
+import static net.devh.boot.grpc.common.security.SecurityConstants.BASIC_AUTH_PREFIX;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.Map;
+import java.util.concurrent.Executor;
+
+import javax.annotation.Nullable;
+
+import io.grpc.CallCredentials;
+import io.grpc.CallCredentials2;
+import io.grpc.Channel;
+import io.grpc.Metadata;
+import io.grpc.SecurityLevel;
+import io.grpc.Status;
+import io.grpc.stub.AbstractStub;
+import net.devh.boot.grpc.client.autoconfigure.GrpcClientSecurityAutoConfiguration;
+import net.devh.boot.grpc.client.inject.GrpcClient;
+import net.devh.boot.grpc.client.inject.StubTransformer;
+
+/**
+ * Helper class with useful methods to create and configure some commonly used authentication schemes such as
+ * {@code Basic-Auth}.
+ *
+ * <p>
+ * <b>Note:</b> If you have exactly one {@link CallCredentials} bean in your application context then it will be used
+ * for all {@link AbstractStub} that are annotation with {@link GrpcClient}. If you have none or multiple
+ * {@link CallCredentials} in the application context or use {@link Channel}s, then you have to configure the
+ * credentials yourself (See {@link GrpcClientSecurityAutoConfiguration}).
+ * </p>
+ *
+ * <p>
+ * Currently the following {@link CallCredentials} are supported by this class:
+ * </p>
+ * <ul>
+ * <li>{@link #basicAuth(String, String) Basic-Auth}</li>
+ * <li>{@link #requirePrivacy(CallCredentials2) Require privacy for the connection} (Wrapper)</li>
+ * <li>{@link #includeWhenPrivate(CallCredentials2) Include credentials only if connection is private} (Wrapper)</li>
+ * </ul>
+ *
+ * <p>
+ * <b>Usage:</b>
+ * </p>
+ *
+ * <ul>
+ * <li>If you need only a single CallCredentials for all services, then it suffices to declare it as bean in your
+ * application context/configuration.
+ *
+ * <pre>
+ * <code>@Bean
+ * CallCredentials myCallCredentials() {
+ *     return CallCredentialsHelper#basicAuth("user", "password")}
+ * }</code>
+ * </pre>
+ *
+ * </li>
+ * <li>If you need multiple/different CallCredentials for the services or only need them for a subset, then you should
+ * either add none of them or all of them (two ore more) to your application context to prevent the automatic credential
+ * selection. You can use a {@link StubTransformer} to select a CallCredential based on the client name instead.
+ *
+ * <pre>
+ * <code>@Bean
+ * StubTransformer myCallCredentialsTransformer() {
+ *     return CallCredentialsHelper#mappedCredentialsStubTransformer(Map.of(
+ *         "myService1", basicAuth("user1", "password1"),
+ *         "theService2", basicAuth("foo", "bar"),
+ *         "publicApi", null // No credentials needed
+ *     ));
+ * }</code>
+ * </pre>
+ *
+ * </li>
+ * <li>If you need different CallCredentials for each call, then you have to define it in the method yourself.
+ *
+ * <pre>
+ * <code>stub.withCallCredentials(CallCredentialsHelper#basicAuth("user", "password")).doStuff(request);</code>
+ * </pre>
+ *
+ * </li>
+ * </ul>
+ *
+ * @author Daniel Theuke (daniel.theuke@heuboe.de)
+ */
+// @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1914")
+// @ExperimentalApi("https://github.com/grpc/grpc-java/issues/4901")
+public class CallCredentialsHelper {
+
+    /**
+     * Creates a new {@link StubTransformer} that will assign the given credentials to the given {@link AbstractStub}.
+     *
+     * @param credentials The call credentials to assign.
+     * @return The transformed stub.
+     * @see AbstractStub#withCallCredentials(CallCredentials)
+     */
+    public static StubTransformer fixedCredentialsStubTransformer(final CallCredentials credentials) {
+        requireNonNull(credentials, "credentials");
+        return (name, stub) -> stub.withCallCredentials(credentials);
+    }
+
+    /**
+     * Creates a new {@link StubTransformer} that will assign credentials to the given {@link AbstractStub} based on the
+     * name. If the given map does not contain a value for the given name, then the call credentials will be omitted.
+     *
+     * @param credentialsByName The map that contains the call credentials.
+     * @return The transformed stub.
+     * @see #mappedCredentialsStubTransformer(Map, CallCredentials)
+     * @see AbstractStub#withCallCredentials(CallCredentials)
+     */
+    public static StubTransformer mappedCredentialsStubTransformer(
+            final Map<String, CallCredentials> credentialsByName) {
+        return mappedCredentialsStubTransformer(credentialsByName, null);
+    }
+
+    /**
+     * Creates a new {@link StubTransformer} that will assign credentials to the given {@link AbstractStub} based on the
+     * name. If the given map does not contain a value for the given name, then the optional fallback will be used
+     * otherwise the call credentials will be omitted.
+     *
+     * @param credentialsByName The map that contains the call credentials.
+     * @param fallback The optional fallback to use.
+     * @return The transformed stub.
+     * @see AbstractStub#withCallCredentials(CallCredentials)
+     */
+    public static StubTransformer mappedCredentialsStubTransformer(
+            final Map<String, CallCredentials> credentialsByName,
+            @Nullable final CallCredentials fallback) {
+        requireNonNull(credentialsByName, "credentials");
+        return (name, stub) -> {
+            final CallCredentials credentials = credentialsByName.getOrDefault(name, fallback);
+            if (credentials == null) {
+                return stub;
+            } else {
+                return stub.withCallCredentials(credentials);
+            }
+        };
+    }
+
+    /**
+     * Creates a new call credential with the given username and password for basic auth.
+     *
+     * <p>
+     * <b>Note:</b> This method uses experimental grpc-java-API features.
+     * </p>
+     *
+     * @param username The username to use.
+     * @param password The password to use.
+     * @return The newly created basic auth credentials.
+     */
+    public static CallCredentials2 basicAuth(final String username, final String password) {
+        final Metadata extraHeaders = new Metadata();
+        extraHeaders.put(AUTHORIZATION_HEADER, encodeBasicAuth(username, password));
+        return new StaticSecurityHeaderCallCredentials(extraHeaders);
+    }
+
+    /**
+     * Encodes the given username and password as basic auth. The header value will be encoded with
+     * {@link StandardCharsets#UTF_8 UTF_8}.
+     *
+     * @param username The username to use.
+     * @param password The password to use.
+     * @return The encoded basic auth header value.
+     */
+    public static String encodeBasicAuth(final String username, final String password) {
+        requireNonNull(username, "username");
+        requireNonNull(password, "password");
+        final String auth = username + ':' + password;
+        byte[] encoded;
+        try {
+            encoded = Base64.getEncoder().encode(auth.getBytes(UTF_8));
+        } catch (final IllegalArgumentException e) {
+            throw new IllegalArgumentException("Failed to encode basic authentication token", e);
+        }
+        return BASIC_AUTH_PREFIX + new String(encoded, UTF_8);
+    }
+
+    private static final class StaticSecurityHeaderCallCredentials extends CallCredentials2 {
+
+        private final Metadata extraHeaders;
+
+        StaticSecurityHeaderCallCredentials(final Metadata extraHeaders) {
+            this.extraHeaders = requireNonNull(extraHeaders, "extraHeaders");
+        }
+
+        @SuppressWarnings("deprecation") // API evolution in progress
+        @Override
+        public void applyRequestMetadata(final RequestInfo requestInfo, final Executor appExecutor,
+                final MetadataApplier applier) {
+            applier.apply(this.extraHeaders);
+        }
+
+        @Override
+        public void thisUsesUnstableApi() {} // API evolution in progress
+
+    }
+
+    /**
+     * Checks whether the given security level provides privacy for all data being send on the connection.
+     *
+     * <p>
+     * <b>Note:</b> This method uses experimental grpc-java-API features.
+     * </p>
+     *
+     * @param securityLevel The security level to check.
+     * @return True, if and only if the given security level ensures privacy. False otherwise.
+     */
+    public static boolean isPrivacyGuaranteed(final SecurityLevel securityLevel) {
+        return SecurityLevel.PRIVACY_AND_INTEGRITY == securityLevel;
+    }
+
+    /**
+     * Wraps the given call credentials in a new layer, which ensures that the credentials are only send, if the
+     * connection guarantees privacy. If the connection doesn't do that, the call will be aborted before sending any
+     * data.
+     *
+     * <p>
+     * <b>Note:</b> This method uses experimental grpc-java-API features.
+     * </p>
+     *
+     * @param callCredentials The call credentials to wrap.
+     * @return The newly created call credentials.
+     */
+    public static CallCredentials requirePrivacy(final CallCredentials2 callCredentials) {
+        return new RequirePrivacyCallCredentials(callCredentials);
+    }
+
+    private static final class RequirePrivacyCallCredentials extends CallCredentials2 {
+
+        private static final Status STATUS_LACKING_PRIVACY = Status.UNAUTHENTICATED
+                .withDescription("Connection security level does not ensure credential privacy");
+
+        private final CallCredentials2 callCredentials;
+
+        RequirePrivacyCallCredentials(final CallCredentials2 callCredentials) {
+            this.callCredentials = callCredentials;
+        }
+
+        @SuppressWarnings("deprecation") // API evolution in progress
+        @Override
+        public void applyRequestMetadata(final RequestInfo requestInfo, final Executor appExecutor,
+                final MetadataApplier applier) {
+            if (isPrivacyGuaranteed(requestInfo.getSecurityLevel())) {
+                this.callCredentials.applyRequestMetadata(requestInfo, appExecutor, applier);
+            } else {
+                applier.fail(STATUS_LACKING_PRIVACY);
+            }
+        }
+
+        @Override
+        public void thisUsesUnstableApi() {} // API evolution in progress
+
+    }
+
+
+    /**
+     * Wraps the given call credentials in a new layer, that will only include the credentials if the connection
+     * guarantees privacy. If the connection doesn't do that, the call will continue without the credentials.
+     *
+     * <p>
+     * <b>Note:</b> This method uses experimental grpc-java-API features.
+     * </p>
+     *
+     * @param callCredentials The call credentials to wrap.
+     * @return The newly created call credentials.
+     */
+    public static CallCredentials includeWhenPrivate(final CallCredentials2 callCredentials) {
+        return new IncludeWhenPrivateCallCredentials(callCredentials);
+    }
+
+    private static final class IncludeWhenPrivateCallCredentials extends CallCredentials2 {
+
+        private final CallCredentials2 callCredentials;
+
+        IncludeWhenPrivateCallCredentials(final CallCredentials2 callCredentials) {
+            this.callCredentials = callCredentials;
+        }
+
+        @Override
+        public void applyRequestMetadata(final RequestInfo requestInfo, final Executor appExecutor,
+                final MetadataApplier applier) {
+            if (isPrivacyGuaranteed(requestInfo.getSecurityLevel())) {
+                this.callCredentials.applyRequestMetadata(requestInfo, appExecutor, applier);
+            }
+        }
+
+        @Override
+        public void thisUsesUnstableApi() {} // API evolution in progress
+
+    }
+
+    private CallCredentialsHelper() {}
+
+}

--- a/grpc-client-spring-boot-autoconfigure/src/main/resources/META-INF/spring.factories
+++ b/grpc-client-spring-boot-autoconfigure/src/main/resources/META-INF/spring.factories
@@ -1,4 +1,5 @@
 # AutoConfiguration
 org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
 net.devh.boot.grpc.client.autoconfigure.GrpcClientAutoConfiguration,\
-net.devh.boot.grpc.client.autoconfigure.GrpcClientMetricAutoConfiguration
+net.devh.boot.grpc.client.autoconfigure.GrpcClientMetricAutoConfiguration,\
+net.devh.boot.grpc.client.autoconfigure.GrpcClientSecurityAutoConfiguration

--- a/grpc-common-spring-boot/src/main/java/net/devh/boot/grpc/common/security/SecurityConstants.java
+++ b/grpc-common-spring-boot/src/main/java/net/devh/boot/grpc/common/security/SecurityConstants.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2016-2018 Michael Zhang <yidongnan@gmail.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package net.devh.boot.grpc.common.security;
+
+import java.nio.charset.StandardCharsets;
+
+import io.grpc.Metadata;
+import io.grpc.Metadata.Key;
+
+/**
+ * A helper class with constants related to grpc security.
+ *
+ * @author Daniel Theuke (daniel.theuke@heuboe.de)
+ */
+public final class SecurityConstants {
+
+    /**
+     * A convenience constant that contains the key for the HTTP Authorization Header.
+     */
+    public static final Key<String> AUTHORIZATION_HEADER = Key.of("Authorization", Metadata.ASCII_STRING_MARSHALLER);
+
+    /**
+     * The prefix for basic auth as used in the {@link #AUTHORIZATION_HEADER}. This library assumes that the both the
+     * username and password are {@link StandardCharsets#UTF_8 UTF_8} encoded before being turned into a base64 string.
+     */
+    public static final String BASIC_AUTH_PREFIX = "Basic ";
+
+    private SecurityConstants() {}
+
+}

--- a/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/security/authentication/BasicGrpcAuthenticationReader.java
+++ b/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/security/authentication/BasicGrpcAuthenticationReader.java
@@ -18,6 +18,8 @@
 package net.devh.boot.grpc.server.security.authentication;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static net.devh.boot.grpc.common.security.SecurityConstants.AUTHORIZATION_HEADER;
+import static net.devh.boot.grpc.common.security.SecurityConstants.BASIC_AUTH_PREFIX;
 
 import java.util.Base64;
 
@@ -38,7 +40,7 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class BasicGrpcAuthenticationReader implements GrpcAuthenticationReader {
 
-    private static final String PREFIX = "basic ";
+    private static final String PREFIX = BASIC_AUTH_PREFIX.toLowerCase();
     private static final int PREFIX_LENGTH = PREFIX.length();
 
     @Override

--- a/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/security/authentication/GrpcAuthenticationReader.java
+++ b/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/security/authentication/GrpcAuthenticationReader.java
@@ -25,7 +25,6 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
 
 import io.grpc.Metadata;
-import io.grpc.Metadata.Key;
 import io.grpc.ServerCall;
 
 /**
@@ -41,11 +40,6 @@ import io.grpc.ServerCall;
  */
 @FunctionalInterface
 public interface GrpcAuthenticationReader {
-
-    /**
-     * A convenience constant that contains the key for the HTTP Authorization Header.
-     */
-    Key<String> AUTHORIZATION_HEADER = Key.of("Authorization", Metadata.ASCII_STRING_MARSHALLER);
 
     /**
      * Tries to read the {@link Authentication} information from the given call and metadata.

--- a/tests/src/test/java/net/devh/boot/grpc/test/config/WithBasicAuthSecurityConfiguration.java
+++ b/tests/src/test/java/net/devh/boot/grpc/test/config/WithBasicAuthSecurityConfiguration.java
@@ -17,6 +17,9 @@
 
 package net.devh.boot.grpc.test.config;
 
+import static net.devh.boot.grpc.client.security.AuthenticatingClientInterceptors.basicAuthCallCredentials;
+import static net.devh.boot.grpc.client.security.AuthenticatingClientInterceptors.callCredentialsInterceptor;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -42,7 +45,6 @@ import net.devh.boot.grpc.client.channelfactory.GrpcChannelFactory;
 import net.devh.boot.grpc.client.channelfactory.InProcessChannelFactory;
 import net.devh.boot.grpc.client.config.GrpcChannelsProperties;
 import net.devh.boot.grpc.client.interceptor.GlobalClientInterceptorRegistry;
-import net.devh.boot.grpc.client.security.AuthenticatingClientInterceptors;
 import net.devh.boot.grpc.server.config.GrpcServerProperties;
 import net.devh.boot.grpc.server.security.authentication.BasicGrpcAuthenticationReader;
 import net.devh.boot.grpc.server.security.authentication.CompositeGrpcAuthenticationReader;
@@ -121,7 +123,8 @@ public class WithBasicAuthSecurityConfiguration {
 
     @Bean
     ClientInterceptor basicAuthInterceptor() {
-        return AuthenticatingClientInterceptors.basicAuth("client1", "client1");
+        // return AuthenticatingClientInterceptors.basicAuthInterceptor("client1", "client1");
+        return callCredentialsInterceptor(basicAuthCallCredentials("client1", "client1"));
     }
 
     @Bean // For testing only
@@ -150,7 +153,7 @@ public class WithBasicAuthSecurityConfiguration {
                 } else {
                     throw new IllegalArgumentException("Unknown username: " + name);
                 }
-                interceptors.add(AuthenticatingClientInterceptors.basicAuth(username, username));
+                interceptors.add(callCredentialsInterceptor(basicAuthCallCredentials(username, username)));
                 return super.createChannel("test", interceptors);
             }
 

--- a/tests/src/test/java/net/devh/boot/grpc/test/config/WithBasicAuthSecurityConfiguration.java
+++ b/tests/src/test/java/net/devh/boot/grpc/test/config/WithBasicAuthSecurityConfiguration.java
@@ -17,8 +17,8 @@
 
 package net.devh.boot.grpc.test.config;
 
-import static net.devh.boot.grpc.client.security.AuthenticatingClientInterceptors.basicAuthCallCredentials;
 import static net.devh.boot.grpc.client.security.AuthenticatingClientInterceptors.callCredentialsInterceptor;
+import static net.devh.boot.grpc.client.security.CallCredentialsHelper.basicAuth;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -122,12 +122,14 @@ public class WithBasicAuthSecurityConfiguration {
     // Client-Side
 
     @Bean
+    @SuppressWarnings("deprecation") // Used to fake authentication based on the client's name (including Channels)
     ClientInterceptor basicAuthInterceptor() {
         // return AuthenticatingClientInterceptors.basicAuthInterceptor("client1", "client1");
-        return callCredentialsInterceptor(basicAuthCallCredentials("client1", "client1"));
+        return callCredentialsInterceptor(basicAuth("client1", "client1"));
     }
 
     @Bean // For testing only
+    @SuppressWarnings("deprecation") // Used to fake authentication based on the client's name (including Channels)
     GrpcChannelFactory testChannelFactory(final GrpcChannelsProperties properties,
             final GlobalClientInterceptorRegistry globalClientInterceptorRegistry,
             final List<GrpcChannelConfigurer> channelConfigurers) {
@@ -153,7 +155,7 @@ public class WithBasicAuthSecurityConfiguration {
                 } else {
                     throw new IllegalArgumentException("Unknown username: " + name);
                 }
-                interceptors.add(callCredentialsInterceptor(basicAuthCallCredentials(username, username)));
+                interceptors.add(callCredentialsInterceptor(basicAuth(username, username)));
                 return super.createChannel("test", interceptors);
             }
 


### PR DESCRIPTION
~~This PR **shouldn't be merged** yet to avoid unnecessary breaking changes. 
[Grpc 1.17](https://github.com/grpc/grpc-java/milestone/30) (which will be released in December) changes the call credentials behavior and thus breaks this code. (`CallCredentials2` will be renamed to/merged with `CallCredentials`)~~
Grpc 1.17 didn't bring the breaking changes and it is uncertain when the break will be. Also It won't be a hard break, since there will be a migration time in the other direction as well. So I guess we can merge this in for now.

### Added features
* Easier to add non-basic-auth features
* Easier to prevent passwords/tokens from being stolen
* Use grpc library feature (`CallCredentials`)

I created the PR this early to allow other developers to comment on this and propose changes. 

### Alternatives considered

* I'm not that happy with the names, so if you have a better suggestion go ahead.
* Instead of the `CallCredentialsAttachingClientInterceptor` it would also be possible to use something like a `StubTransformer` that configures the annotated stubs with the CallCredentials instead of adding it somewhere in the interceptor chain.

### See also

* https://github.com/grpc/grpc-java/issues/1914
* https://github.com/grpc/grpc-java/issues/4901