### PR TITLE
Configure eclipse's generated source folders with gradle

### DIFF
--- a/examples/grpc-lib/build.gradle
+++ b/examples/grpc-lib/build.gradle
@@ -26,6 +26,19 @@ protobuf {
     }
 }
 
+eclipse {
+    classpath {
+        file.beforeMerged { cp ->
+            def generatedGrpcFolder = new org.gradle.plugins.ide.eclipse.model.SourceFolder('src/generated/main/grpc', null);
+            generatedGrpcFolder.entryAttributes['ignore_optional_problems'] = 'true';
+            cp.entries.add( generatedGrpcFolder );
+            def generatedJavaFolder = new org.gradle.plugins.ide.eclipse.model.SourceFolder('src/generated/main/java', null);
+            generatedJavaFolder.entryAttributes['ignore_optional_problems'] = 'true';
+            cp.entries.add( generatedJavaFolder );
+        }
+    }
+}
+
 idea {
     module {
         sourceDirs += file("src/generated/main/java")

--- a/tests/build.gradle
+++ b/tests/build.gradle
@@ -8,6 +8,16 @@ eclipse {
     project {
         name = 'grpc-spring-boot-tests'
     }
+    classpath {
+        file.beforeMerged { cp ->
+            def generatedGrpcFolder = new org.gradle.plugins.ide.eclipse.model.SourceFolder('src/generated/test/grpc', null);
+            generatedGrpcFolder.entryAttributes['ignore_optional_problems'] = 'true';
+            cp.entries.add( generatedGrpcFolder );
+            def generatedJavaFolder = new org.gradle.plugins.ide.eclipse.model.SourceFolder('src/generated/test/java', null);
+            generatedJavaFolder.entryAttributes['ignore_optional_problems'] = 'true';
+            cp.entries.add( generatedJavaFolder );
+        }
+    }
 }
 
 compileTestJava.dependsOn(processTestResources)


### PR DESCRIPTION
Currently everytime I use eclipse and do a refresh project call to update the dependencies the generated source folders are removed from the build path.

This PR configures gradle to properly set up these paths.