### PR TITLE
Automatically create actuator InfoContributor

### DIFF
--- a/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/autoconfigure/package-info.java
+++ b/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/autoconfigure/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * The Spring-Boot auto configuration classes that setup the gRPC client environment.
+ */
+
+package net.devh.boot.grpc.client.autoconfigure;

--- a/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/metric/package-info.java
+++ b/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/metric/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * A package containing the client side classes for grpc metric collection.
+ */
+
+package net.devh.boot.grpc.client.metric;

--- a/grpc-common-spring-boot/src/main/java/net/devh/boot/grpc/common/autoconfigure/package-info.java
+++ b/grpc-common-spring-boot/src/main/java/net/devh/boot/grpc/common/autoconfigure/package-info.java
@@ -1,0 +1,6 @@
+/**
+ * The Spring-Boot auto configuration classes that setup the gRPC environment with features that can be used by both the
+ * client and the server.
+ */
+
+package net.devh.boot.grpc.common.autoconfigure;

--- a/grpc-common-spring-boot/src/main/java/net/devh/boot/grpc/common/metric/MetricUtils.java
+++ b/grpc-common-spring-boot/src/main/java/net/devh/boot/grpc/common/metric/MetricUtils.java
@@ -19,6 +19,8 @@ package net.devh.boot.grpc.common.metric;
 
 import static net.devh.boot.grpc.common.metric.MetricConstants.TAG_METHOD_NAME;
 import static net.devh.boot.grpc.common.metric.MetricConstants.TAG_SERVICE_NAME;
+import static net.devh.boot.grpc.common.util.GrpcUtils.extractMethodName;
+import static net.devh.boot.grpc.common.util.GrpcUtils.extractServiceName;
 
 import io.grpc.MethodDescriptor;
 import io.micrometer.core.instrument.Counter;
@@ -63,35 +65,6 @@ public final class MetricUtils {
                 .description(description)
                 .tag(TAG_SERVICE_NAME, extractServiceName(method))
                 .tag(TAG_METHOD_NAME, extractMethodName(method));
-    }
-
-    /**
-     * Extracts the service name from the given method.
-     *
-     * @param method The method to get the service name from.
-     * @return The extracted service name.
-     * @see MethodDescriptor#extractFullServiceName(String)
-     * @see #extractMethodName(MethodDescriptor)
-     */
-    public static String extractServiceName(final MethodDescriptor<?, ?> method) {
-        return MethodDescriptor.extractFullServiceName(method.getFullMethodName());
-    }
-
-    /**
-     * Extracts the method name from the given method.
-     *
-     * @param method The method to get the method name from.
-     * @return The extracted method name.
-     * @see #extractServiceName(MethodDescriptor)
-     */
-    public static String extractMethodName(final MethodDescriptor<?, ?> method) {
-        // This method is the equivalent of MethodDescriptor.extractFullServiceName
-        final String fullMethodName = method.getFullMethodName();
-        final int index = fullMethodName.lastIndexOf('/');
-        if (index == -1) {
-            return fullMethodName;
-        }
-        return fullMethodName.substring(index + 1);
     }
 
     private MetricUtils() {}

--- a/grpc-common-spring-boot/src/main/java/net/devh/boot/grpc/common/metric/package-info.java
+++ b/grpc-common-spring-boot/src/main/java/net/devh/boot/grpc/common/metric/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Shared code for grpc metric collection related classes.
+ */
+
+package net.devh.boot.grpc.common.metric;

--- a/grpc-common-spring-boot/src/main/java/net/devh/boot/grpc/common/util/GrpcUtils.java
+++ b/grpc-common-spring-boot/src/main/java/net/devh/boot/grpc/common/util/GrpcUtils.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2016-2018 Michael Zhang <yidongnan@gmail.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package net.devh.boot.grpc.common.util;
+
+import io.grpc.MethodDescriptor;
+
+/**
+ * Utility class that contains methods to extract some information from grpc classes.
+ *
+ * @author Daniel Theuke (daniel.theuke@heuboe.de)
+ */
+public final class GrpcUtils {
+
+    /**
+     * Extracts the service name from the given method.
+     *
+     * @param method The method to get the service name from.
+     * @return The extracted service name.
+     * @see MethodDescriptor#extractFullServiceName(String)
+     * @see #extractMethodName(MethodDescriptor)
+     */
+    public static String extractServiceName(final MethodDescriptor<?, ?> method) {
+        return MethodDescriptor.extractFullServiceName(method.getFullMethodName());
+    }
+
+    /**
+     * Extracts the method name from the given method.
+     *
+     * @param method The method to get the method name from.
+     * @return The extracted method name.
+     * @see #extractServiceName(MethodDescriptor)
+     */
+    public static String extractMethodName(final MethodDescriptor<?, ?> method) {
+        // This method is the equivalent of MethodDescriptor.extractFullServiceName
+        final String fullMethodName = method.getFullMethodName();
+        final int index = fullMethodName.lastIndexOf('/');
+        if (index == -1) {
+            return fullMethodName;
+        }
+        return fullMethodName.substring(index + 1);
+    }
+
+    private GrpcUtils() {}
+
+}

--- a/grpc-common-spring-boot/src/main/java/net/devh/boot/grpc/common/util/package-info.java
+++ b/grpc-common-spring-boot/src/main/java/net/devh/boot/grpc/common/util/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Utilities for both the server and the client.
+ */
+
+package net.devh.boot.grpc.common.util;

--- a/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/autoconfigure/package-info.java
+++ b/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/autoconfigure/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * The Spring-Boot auto configuration classes that setup the gRPC server environment.
+ */
+
+package net.devh.boot.grpc.server.autoconfigure;

--- a/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/metric/package-info.java
+++ b/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/metric/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * A package containing the server side classes for grpc metric collection.
+ */
+
+package net.devh.boot.grpc.server.metric;


### PR DESCRIPTION
Automatically create and actuator InfoContributor, that exposes the grpc server port and the running services.

![actuator-info-example](https://user-images.githubusercontent.com/1579362/49071175-af1a8100-f22d-11e8-8aa0-2b1f2e35db66.png)

## Features

* Exposes the grpc server port
* Exposes a sorted map of services with their sorted methods

## TBD

* Should we add a separate property to enable the InfoContributor?
* Should we add a separate property to toggle the service listing?
* What do you thing about adding package-info.java files? (Related #144)
  * I will add the other missing files in a different PR.

![package-info-example](https://user-images.githubusercontent.com/1579362/49071949-6663c780-f22f-11e8-8d12-8f073c41ab6b.png)


