### PR TITLE
Added tests for streaming calls

### DIFF
--- a/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/security/authentication/AnonymousAuthenticationReader.java
+++ b/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/security/authentication/AnonymousAuthenticationReader.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2016-2018 Michael Zhang <yidongnan@gmail.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package net.devh.boot.grpc.server.security.authentication;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.Collection;
+
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.AuthorityUtils;
+
+import io.grpc.Metadata;
+import io.grpc.ServerCall;
+import lombok.extern.slf4j.Slf4j;
+import net.devh.boot.grpc.server.security.check.AccessPredicate;
+import net.devh.boot.grpc.server.security.check.ManualGrpcSecurityMetadataSource;
+
+/**
+ * The AnonymousAuthenticationReader allows users without credentials to get an anonymous identity.
+ *
+ * <p>
+ * <b>Note:</b> Anonymous authentication is currently required when using the {@link ManualGrpcSecurityMetadataSource
+ * manually configured security} with {@link AccessPredicate#permitAll() permitAll}.
+ * </p>
+ *
+ * @author Daniel Theuke (daniel.theuke@heuboe.de)
+ */
+@Slf4j
+public class AnonymousAuthenticationReader implements GrpcAuthenticationReader {
+
+    private final String key;
+    private final Object principal;
+    private final Collection<? extends GrantedAuthority> authorities;
+
+    /**
+     * Creates a new AnonymousAuthenticationReader with the given key and {@code "anonymousUser"} as principal with the
+     * {@code ROLE_ANONYMOUS}.
+     *
+     * @param key The key to used to identify tokens that were created by this instance.
+     */
+    public AnonymousAuthenticationReader(final String key) {
+        this(key, "anonymousUser", AuthorityUtils.createAuthorityList("ROLE_ANONYMOUS"));
+    }
+
+    /**
+     * Creates a new AnonymousAuthenticationReader with the given key,principal and authorities.
+     *
+     * @param key The key to used to identify tokens that were created by this instance.
+     * @param principal The principal which will be used to represent anonymous users.
+     * @param authorities The authority list for anonymous users.
+     */
+    public AnonymousAuthenticationReader(final String key, final Object principal,
+            final Collection<? extends GrantedAuthority> authorities) {
+        this.key = requireNonNull(key, "key");
+        this.principal = requireNonNull(principal, "principal");;
+        this.authorities = requireNonNull(authorities, "authorities");;
+    }
+
+    @Override
+    public Authentication readAuthentication(final ServerCall<?, ?> call, final Metadata headers) {
+        log.debug("Continue with anonymous auth");
+        return new AnonymousAuthenticationToken(this.key, this.principal, this.authorities);
+    }
+
+}

--- a/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/security/authentication/AnonymousAuthenticationReader.java
+++ b/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/security/authentication/AnonymousAuthenticationReader.java
@@ -29,16 +29,9 @@ import org.springframework.security.core.authority.AuthorityUtils;
 import io.grpc.Metadata;
 import io.grpc.ServerCall;
 import lombok.extern.slf4j.Slf4j;
-import net.devh.boot.grpc.server.security.check.AccessPredicate;
-import net.devh.boot.grpc.server.security.check.ManualGrpcSecurityMetadataSource;
 
 /**
  * The AnonymousAuthenticationReader allows users without credentials to get an anonymous identity.
- *
- * <p>
- * <b>Note:</b> Anonymous authentication is currently required when using the {@link ManualGrpcSecurityMetadataSource
- * manually configured security} with {@link AccessPredicate#permitAll() permitAll}.
- * </p>
  *
  * @author Daniel Theuke (daniel.theuke@heuboe.de)
  */

--- a/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/security/check/AccessPredicate.java
+++ b/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/security/check/AccessPredicate.java
@@ -34,10 +34,6 @@ import com.google.common.collect.ImmutableSet;
  * Predicate that can be used to check whether the given {@link Authentication} has access to the protected
  * service/method. This interface assumes, that the user is authenticated before the method is called.
  *
- * <p>
- * <b>Note:</b> The {@link ManualGrpcSecurityMetadataSource} uses {@code null} for public access.
- * </p>
- *
  * @author Daniel Theuke (daniel.theuke@heuboe.de)
  */
 public interface AccessPredicate extends Predicate<Authentication> {
@@ -60,7 +56,26 @@ public interface AccessPredicate extends Predicate<Authentication> {
     }
 
     /**
+     * Special constant that symbolizes that everybody (including unauthenticated users) can access the instance (no
+     * protection).
+     *
+     * <p>
+     * <b>Note:</b> This is a special constant, that does not allow execution and mutation. It's sole purpose is to
+     * avoid ambiguity for {@code null} values. It should only be used in {@code ==} comparisons.
+     * </p>
+     *
+     * @return A special constant that symbolizes public access.
+     */
+    static AccessPredicate permitAll() {
+        return AccessPredicates.PERMIT_ALL;
+    }
+
+    /**
      * All authenticated users can access the protected instance including anonymous users.
+     *
+     * <p>
+     * <b>Note:</b> The negation of this call is {@link #denyAll()} and NOT all unauthenticated.
+     * </p>
      *
      * @return A newly created AccessPredicate that always returns true.
      */
@@ -79,6 +94,10 @@ public interface AccessPredicate extends Predicate<Authentication> {
 
     /**
      * Nobody can access the protected instance.
+     *
+     * <p>
+     * <b>Note:</b> The negation of this call is {@link #authenticated()} and NOT {@link #permitAll()}.
+     * </p>
      *
      * @return A newly created AccessPredicate that always returns false.
      */

--- a/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/security/check/AccessPredicate.java
+++ b/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/security/check/AccessPredicate.java
@@ -32,7 +32,11 @@ import com.google.common.collect.ImmutableSet;
 
 /**
  * Predicate that can be used to check whether the given {@link Authentication} has access to the protected
- * service/method.
+ * service/method. This interface assumes, that the user is authenticated before the method is called.
+ *
+ * <p>
+ * <b>Note:</b> The {@link ManualGrpcSecurityMetadataSource} uses {@code null} for public access.
+ * </p>
  *
  * @author Daniel Theuke (daniel.theuke@heuboe.de)
  */
@@ -58,14 +62,19 @@ public interface AccessPredicate extends Predicate<Authentication> {
     /**
      * All authenticated users can access the protected instance including anonymous users.
      *
-     * <p>
-     * <b>Note:</b> If anonymous authentication is not configured then the users still don't have access.
-     * </p>
-     *
      * @return A newly created AccessPredicate that always returns true.
      */
-    static AccessPredicate permitAll() {
+    static AccessPredicate authenticated() {
         return authentication -> true;
+    }
+
+    /**
+     * All authenticated users can access the protected instance excluding anonymous users.
+     *
+     * @return A newly created AccessPredicate that checks whether the user is explicitly authenticated.
+     */
+    static AccessPredicate fullyAuthenticated() {
+        return authentication -> !(authentication instanceof AnonymousAuthenticationToken);
     }
 
     /**
@@ -75,15 +84,6 @@ public interface AccessPredicate extends Predicate<Authentication> {
      */
     static AccessPredicate denyAll() {
         return authentication -> false;
-    }
-
-    /**
-     * All authenticated users can access the protected instance (excluding anonymous users).
-     *
-     * @return A newly created AccessPredicate that checks whether the user is explicitly authenticated.
-     */
-    static AccessPredicate fullyAuthenticated() {
-        return authentication -> !(authentication instanceof AnonymousAuthenticationToken);
     }
 
     /**

--- a/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/security/check/AccessPredicates.java
+++ b/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/security/check/AccessPredicates.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2016-2018 Michael Zhang <yidongnan@gmail.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package net.devh.boot.grpc.server.security.check;
+
+import java.util.function.Predicate;
+
+import org.springframework.security.authentication.InternalAuthenticationServiceException;
+import org.springframework.security.core.Authentication;
+
+/**
+ * Helper class that contains some internal constants for {@link AccessPredicate}s.
+ *
+ * @author Daniel Theuke (daniel.theuke@heuboe.de)
+ */
+final class AccessPredicates {
+
+    /**
+     * A marker constant that indicates that all restrictions should be disabled. This instance should never be
+     * executed, mutated or used in mutation. It should only be used in {@code ==} comparisons.
+     */
+    static final AccessPredicate PERMIT_ALL = new AccessPredicate() {
+
+        @Override
+        @Deprecated // Should never be called
+        public boolean test(final Authentication t) {
+            throw new InternalAuthenticationServiceException(
+                    "Tried to execute the 'permit-all' access predicate. The server's security configuration is broken.");
+        }
+
+        @Override
+        @Deprecated // Should never be called
+        public AccessPredicate and(final Predicate<? super Authentication> other) {
+            throw new UnsupportedOperationException("Not allowed for 'permit-all' access predicate");
+        }
+
+        @Override
+        @Deprecated // Should never be called
+        public AccessPredicate or(final Predicate<? super Authentication> other) {
+            throw new UnsupportedOperationException("Not allowed for 'permit-all' access predicate");
+        }
+
+        @Override
+        @Deprecated // Should never be called
+        public AccessPredicate negate() {
+            throw new UnsupportedOperationException("Not allowed for 'permit-all' access predicate");
+        }
+
+    };
+
+    private AccessPredicates() {}
+}

--- a/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/security/check/ManualGrpcSecurityMetadataSource.java
+++ b/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/security/check/ManualGrpcSecurityMetadataSource.java
@@ -25,15 +25,21 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import javax.annotation.Nullable;
+
 import org.springframework.security.access.AccessDecisionManager;
 import org.springframework.security.access.ConfigAttribute;
 import org.springframework.security.core.Authentication;
 
 import io.grpc.MethodDescriptor;
 import io.grpc.ServiceDescriptor;
+import net.devh.boot.grpc.server.security.authentication.AnonymousAuthenticationReader;
 
 /**
- * A {@link GrpcSecurityMetadataSource} that can be manually configured. This metadata source only works if an
+ * A {@link GrpcSecurityMetadataSource} for manual configuration. For each {@link MethodDescriptor gRPC method} a
+ * {@link AccessPredicate} can be defined, that checks whether the user is authenticated and has access. If you want to
+ * allow public access then use {@code null} as the AccessPredicate parameter or enable
+ * {@link AnonymousAuthenticationReader anonymous authentication}. This metadata source only works if an
  * {@link AccessDecisionManager} is configured with an {@link AccessPredicateVoter}.
  *
  * <p>
@@ -61,44 +67,62 @@ public final class ManualGrpcSecurityMetadataSource extends AbstractGrpcSecurity
      * Set the given access predicate for the all methods of the given service. This will replace previously set
      * predicates.
      *
-     * @param service The service to protect.
-     * @param predicate The predicate used to check the {@link Authentication}. If set to null it will use the default.
+     * @param service The service to protect with a custom check.
+     * @param predicate The predicate used to check the {@link Authentication}. IIf set to null it will use the public
+     *        access.
      * @see #setDefault(AccessPredicate)
      */
-    public void set(final ServiceDescriptor service, final AccessPredicate predicate) {
+    public void set(final ServiceDescriptor service, @Nullable final AccessPredicate predicate) {
         requireNonNull(service, "service");
-        if (predicate == null) {
-            for (final MethodDescriptor<?, ?> method : service.getMethods()) {
-                this.accessMap.remove(method);
-            }
-        } else {
-            final Collection<ConfigAttribute> wrappedPredicate = wrap(predicate);
-            for (final MethodDescriptor<?, ?> method : service.getMethods()) {
-                this.accessMap.put(method, wrappedPredicate);
-            }
+        final Collection<ConfigAttribute> wrappedPredicate = wrap(predicate);
+        for (final MethodDescriptor<?, ?> method : service.getMethods()) {
+            this.accessMap.put(method, wrappedPredicate);
+        }
+    }
+
+    /**
+     * Removes all access predicates for the all methods of the given service. After that, the default will be used for
+     * those methods.
+     *
+     * @param service The service to protect with only the default.
+     * @see #setDefault(AccessPredicate)
+     */
+    public void remove(final ServiceDescriptor service) {
+        requireNonNull(service, "service");
+        for (final MethodDescriptor<?, ?> method : service.getMethods()) {
+            this.accessMap.remove(method);
         }
     }
 
     /**
      * Set the given access predicate for the given method. This will replace previously set predicates.
      *
-     * @param method The method to protect.
-     * @param predicate The predicate used to check the {@link Authentication}. If set to null it will use the default.
+     * @param method The method to protect with a custom check.
+     * @param predicate The predicate used to check the {@link Authentication}. If set to null it will use the public
+     *        access.
      * @see #setDefault(AccessPredicate)
      */
-    public void set(final MethodDescriptor<?, ?> method, final AccessPredicate predicate) {
+    public void set(final MethodDescriptor<?, ?> method, @Nullable final AccessPredicate predicate) {
         requireNonNull(method, "method");
-        if (predicate == null) {
-            this.accessMap.remove(method);
-        } else {
-            this.accessMap.put(method, wrap(predicate));
-        }
+        this.accessMap.put(method, wrap(predicate));
+    }
+
+    /**
+     * Removes the any access predicate for the given method. After that, the default will be used for that method.
+     *
+     * @param method The method to protect with only the default.
+     * @see #setDefault(AccessPredicate)
+     */
+    public void remove(final MethodDescriptor<?, ?> method) {
+        requireNonNull(method, "method");
+        this.accessMap.remove(method);
     }
 
     /**
      * Sets the default that will be used if no specific configuration has been made.
      *
-     * @param predicate The default predicate used to check the {@link Authentication}.
+     * @param predicate The default predicate used to check the {@link Authentication}. If set to null it will use the
+     *        public access.
      */
     public void setDefault(final AccessPredicate predicate) {
         this.defaultAttributes = wrap(predicate);
@@ -111,6 +135,9 @@ public final class ManualGrpcSecurityMetadataSource extends AbstractGrpcSecurity
      * @return The newly created list with the given predicate.
      */
     protected Collection<ConfigAttribute> wrap(final AccessPredicate predicate) {
+        if (predicate == null) {
+            return of(); // Empty collection => public invocation
+        }
         return of(new AccessPredicateConfigAttribute(predicate));
     }
 

--- a/tests/src/test/java/net/devh/boot/grpc/test/config/ManualSecurityConfiguration.java
+++ b/tests/src/test/java/net/devh/boot/grpc/test/config/ManualSecurityConfiguration.java
@@ -46,6 +46,9 @@ public class ManualSecurityConfiguration {
     GrpcSecurityMetadataSource grpcSecurityMetadataSource() {
         final ManualGrpcSecurityMetadataSource source = new ManualGrpcSecurityMetadataSource();
         source.set(TestServiceGrpc.getSecureMethod(), AccessPredicate.hasRole("ROLE_CLIENT1"));
+        source.set(TestServiceGrpc.getSecureDrainMethod(), AccessPredicate.hasRole("ROLE_CLIENT1"));
+        source.set(TestServiceGrpc.getSecureSupplyMethod(), AccessPredicate.hasRole("ROLE_CLIENT1"));
+        source.set(TestServiceGrpc.getSecureBidiMethod(), AccessPredicate.hasRole("ROLE_CLIENT1"));
         source.setDefault(AccessPredicate.permitAll());
         return source;
     }

--- a/tests/src/test/java/net/devh/boot/grpc/test/config/ManualSecurityConfiguration.java
+++ b/tests/src/test/java/net/devh/boot/grpc/test/config/ManualSecurityConfiguration.java
@@ -49,7 +49,7 @@ public class ManualSecurityConfiguration {
         source.set(TestServiceGrpc.getSecureDrainMethod(), AccessPredicate.hasRole("ROLE_CLIENT1"));
         source.set(TestServiceGrpc.getSecureSupplyMethod(), AccessPredicate.hasRole("ROLE_CLIENT1"));
         source.set(TestServiceGrpc.getSecureBidiMethod(), AccessPredicate.hasRole("ROLE_CLIENT1"));
-        source.setDefault(null); // Public
+        source.setDefault(AccessPredicate.permitAll());
         return source;
     }
 

--- a/tests/src/test/java/net/devh/boot/grpc/test/config/ManualSecurityConfiguration.java
+++ b/tests/src/test/java/net/devh/boot/grpc/test/config/ManualSecurityConfiguration.java
@@ -49,7 +49,7 @@ public class ManualSecurityConfiguration {
         source.set(TestServiceGrpc.getSecureDrainMethod(), AccessPredicate.hasRole("ROLE_CLIENT1"));
         source.set(TestServiceGrpc.getSecureSupplyMethod(), AccessPredicate.hasRole("ROLE_CLIENT1"));
         source.set(TestServiceGrpc.getSecureBidiMethod(), AccessPredicate.hasRole("ROLE_CLIENT1"));
-        source.setDefault(AccessPredicate.permitAll());
+        source.setDefault(null); // Public
         return source;
     }
 

--- a/tests/src/test/java/net/devh/boot/grpc/test/config/WithBasicAuthSecurityConfiguration.java
+++ b/tests/src/test/java/net/devh/boot/grpc/test/config/WithBasicAuthSecurityConfiguration.java
@@ -20,11 +20,9 @@ package net.devh.boot.grpc.test.config;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.UUID;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.security.authentication.AnonymousAuthenticationProvider;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.AuthenticationProvider;
 import org.springframework.security.authentication.ProviderManager;
@@ -46,7 +44,6 @@ import net.devh.boot.grpc.client.config.GrpcChannelsProperties;
 import net.devh.boot.grpc.client.interceptor.GlobalClientInterceptorRegistry;
 import net.devh.boot.grpc.client.security.AuthenticatingClientInterceptors;
 import net.devh.boot.grpc.server.config.GrpcServerProperties;
-import net.devh.boot.grpc.server.security.authentication.AnonymousAuthenticationReader;
 import net.devh.boot.grpc.server.security.authentication.BasicGrpcAuthenticationReader;
 import net.devh.boot.grpc.server.security.authentication.CompositeGrpcAuthenticationReader;
 import net.devh.boot.grpc.server.security.authentication.GrpcAuthenticationReader;
@@ -61,7 +58,7 @@ public class WithBasicAuthSecurityConfiguration {
 
     // Server-Side
 
-    private static final String ANONYMOUS_KEY = UUID.randomUUID().toString();
+    // private static final String ANONYMOUS_KEY = UUID.randomUUID().toString();
 
     @Bean
     PasswordEncoder passwordEncoder() {
@@ -89,16 +86,16 @@ public class WithBasicAuthSecurityConfiguration {
         return provider;
     }
 
-    @Bean
-    AnonymousAuthenticationProvider anonymousAuthenticationProvider() {
-        return new AnonymousAuthenticationProvider(ANONYMOUS_KEY);
-    }
+    // @Bean
+    // AnonymousAuthenticationProvider anonymousAuthenticationProvider() {
+    // return new AnonymousAuthenticationProvider(ANONYMOUS_KEY);
+    // }
 
     @Bean
     AuthenticationManager authenticationManager() {
         final List<AuthenticationProvider> providers = new ArrayList<>();
         providers.add(daoAuthenticationProvider());
-        providers.add(anonymousAuthenticationProvider());
+        // providers.add(anonymousAuthenticationProvider());
         return new ProviderManager(providers);
     }
 
@@ -106,14 +103,14 @@ public class WithBasicAuthSecurityConfiguration {
     GrpcAuthenticationReader authenticationReader() {
         final List<GrpcAuthenticationReader> readers = new ArrayList<>();
         readers.add(new BasicGrpcAuthenticationReader());
-        readers.add(new AnonymousAuthenticationReader(ANONYMOUS_KEY));
+        // readers.add(new AnonymousAuthenticationReader(ANONYMOUS_KEY));
         return new CompositeGrpcAuthenticationReader(readers);
     }
 
     @Bean // For testing only
     GrpcServerFactory testServerFactory(final GrpcServerProperties properties,
-            GrpcServiceDiscoverer serviceDiscoverer) {
-        InProcessGrpcServerFactory factory = new InProcessGrpcServerFactory("test", properties);
+            final GrpcServiceDiscoverer serviceDiscoverer) {
+        final InProcessGrpcServerFactory factory = new InProcessGrpcServerFactory("test", properties);
         for (final GrpcServiceDefinition service : serviceDiscoverer.findGrpcServices()) {
             factory.addService(service);
         }

--- a/tests/src/test/java/net/devh/boot/grpc/test/security/AnnotatedSecurityWithCertificateTest.java
+++ b/tests/src/test/java/net/devh/boot/grpc/test/security/AnnotatedSecurityWithCertificateTest.java
@@ -41,11 +41,11 @@ import net.devh.boot.grpc.test.config.WithCertificateSecurityConfiguration;
         "grpc.client.test.security.certificateChainPath=src/test/resources/certificates/client1.crt",
         "grpc.client.test.security.privateKeyPath=src/test/resources/certificates/client1.key",
 
-        "grpc.client.broken.security.authorityOverride=localhost",
-        "grpc.client.broken.security.trustCertCollectionPath=src/test/resources/certificates/trusted-servers-collection",
-        "grpc.client.broken.security.clientAuthEnabled=true",
-        "grpc.client.broken.security.certificateChainPath=src/test/resources/certificates/client2.crt",
-        "grpc.client.broken.security.privateKeyPath=src/test/resources/certificates/client2.key"
+        "grpc.client.noPerm.security.authorityOverride=localhost",
+        "grpc.client.noPerm.security.trustCertCollectionPath=src/test/resources/certificates/trusted-servers-collection",
+        "grpc.client.noPerm.security.clientAuthEnabled=true",
+        "grpc.client.noPerm.security.certificateChainPath=src/test/resources/certificates/client2.crt",
+        "grpc.client.noPerm.security.privateKeyPath=src/test/resources/certificates/client2.key"
 })
 @SpringJUnitConfig(
         classes = {ServiceConfiguration.class, BaseAutoConfiguration.class, AnnotatedSecurityConfiguration.class,

--- a/tests/src/test/java/net/devh/boot/grpc/test/security/ConcurrentSecurityTest.java
+++ b/tests/src/test/java/net/devh/boot/grpc/test/security/ConcurrentSecurityTest.java
@@ -55,7 +55,7 @@ public class ConcurrentSecurityTest {
     @GrpcClient("test")
     protected TestServiceStub testServiceStub;
 
-    @GrpcClient("broken")
+    @GrpcClient("noPerm")
     protected TestServiceStub brokenTestServiceStub;
 
     /**

--- a/tests/src/test/java/net/devh/boot/grpc/test/security/ManualSecurityWithCertificateTest.java
+++ b/tests/src/test/java/net/devh/boot/grpc/test/security/ManualSecurityWithCertificateTest.java
@@ -41,11 +41,11 @@ import net.devh.boot.grpc.test.config.WithCertificateSecurityConfiguration;
         "grpc.client.test.security.certificateChainPath=src/test/resources/certificates/client1.crt",
         "grpc.client.test.security.privateKeyPath=src/test/resources/certificates/client1.key",
 
-        "grpc.client.broken.security.authorityOverride=localhost",
-        "grpc.client.broken.security.trustCertCollectionPath=src/test/resources/certificates/trusted-servers-collection",
-        "grpc.client.broken.security.clientAuthEnabled=true",
-        "grpc.client.broken.security.certificateChainPath=src/test/resources/certificates/client2.crt",
-        "grpc.client.broken.security.privateKeyPath=src/test/resources/certificates/client2.key"
+        "grpc.client.noPerm.security.authorityOverride=localhost",
+        "grpc.client.noPerm.security.trustCertCollectionPath=src/test/resources/certificates/trusted-servers-collection",
+        "grpc.client.noPerm.security.clientAuthEnabled=true",
+        "grpc.client.noPerm.security.certificateChainPath=src/test/resources/certificates/client2.crt",
+        "grpc.client.noPerm.security.privateKeyPath=src/test/resources/certificates/client2.key"
 })
 @SpringJUnitConfig(
         classes = {ServiceConfiguration.class, BaseAutoConfiguration.class, ManualSecurityConfiguration.class,

--- a/tests/src/test/java/net/devh/boot/grpc/test/util/DynamicTestCollection.java
+++ b/tests/src/test/java/net/devh/boot/grpc/test/util/DynamicTestCollection.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2016-2018 Michael Zhang <yidongnan@gmail.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package net.devh.boot.grpc.test.util;
+
+import static org.junit.jupiter.api.DynamicTest.dynamicTest;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.function.Executable;
+
+public class DynamicTestCollection implements Iterable<DynamicTest> {
+
+    private final List<DynamicTest> tests = new ArrayList<>();
+
+    public static DynamicTestCollection create() {
+        return new DynamicTestCollection();
+    }
+
+    private DynamicTestCollection() {}
+
+    @Override
+    public Iterator<DynamicTest> iterator() {
+        return this.tests.iterator();
+    }
+
+    public DynamicTestCollection add(final String name, final Executable executable) {
+        this.tests.add(dynamicTest(name, executable));
+        return this;
+    }
+
+}

--- a/tests/src/test/java/net/devh/boot/grpc/test/util/TriConsumer.java
+++ b/tests/src/test/java/net/devh/boot/grpc/test/util/TriConsumer.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2016-2018 Michael Zhang <yidongnan@gmail.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package net.devh.boot.grpc.test.util;
+
+@FunctionalInterface
+public interface TriConsumer<S, T, U> {
+
+    void accept(S s, T t, U u);
+
+}

--- a/tests/src/test/proto/TestService.proto
+++ b/tests/src/test/proto/TestService.proto
@@ -13,9 +13,18 @@ service TestService {
 
     // Unimplemented method
     rpc unimplemented(google.protobuf.Empty) returns (SomeType) {}
-    
+
     // Secured method
     rpc secure(google.protobuf.Empty) returns (SomeType) {}
+
+    // Secured method with only multiple requests
+    rpc secureDrain(stream SomeType) returns (google.protobuf.Empty) {}
+
+    // Secured method with only multiple answers
+    rpc secureSupply(google.protobuf.Empty) returns (stream SomeType) {}
+
+    // Secured method with both multiple requests and answers
+    rpc secureBidi(stream SomeType) returns (stream SomeType) {}
 
 }
 


### PR DESCRIPTION
## Features

* Added `AnonymousAuthenticationReader` to allow some calls to skip authentication, when using AuthorizationCheckingServerInterceptor.
* Added some convenience methods to `AccessPredicate`
* Added tests for streaming calls
* Fixed missing `AccessDeniedException` -> `AuthenticationException` transformations

## TBD

* I noticed that the `permitAll` access setting does not allow unauthenticated users to access the methods, if anonymous authentication is not enabled. Should I add/change it to an explicit `permitAll`?