### PR TITLE
Update to grpc 1.17.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ buildscript {
     ext {
         projectVersion = '2.1.1.SNAPSHOT'
 
-        grpcVersion = '1.16.1'
+        grpcVersion = '1.17.1'
         protobufVersion = '3.6.1'
         protobufGradlePluginVersion = '0.8.7'
         nettyTCNativeVersion = '2.0.17.Final'

--- a/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/autoconfigure/GrpcClientAutoConfiguration.java
+++ b/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/autoconfigure/GrpcClientAutoConfiguration.java
@@ -37,7 +37,6 @@ import io.grpc.CompressorRegistry;
 import io.grpc.DecompressorRegistry;
 import io.grpc.LoadBalancer;
 import io.grpc.NameResolver;
-import io.grpc.util.RoundRobinLoadBalancerFactory;
 import net.devh.boot.grpc.client.channelfactory.GrpcChannelConfigurer;
 import net.devh.boot.grpc.client.channelfactory.GrpcChannelFactory;
 import net.devh.boot.grpc.client.channelfactory.InProcessChannelFactory;
@@ -88,8 +87,10 @@ public class GrpcClientAutoConfiguration {
     @ConditionalOnMissingBean
     @Lazy // Not needed for InProcessChannelFactories
     @Bean
+    @SuppressWarnings("deprecation") // Required to stay compatible with pre 1.17.0 versions
     public LoadBalancer.Factory grpcLoadBalancerFactory() {
-        return RoundRobinLoadBalancerFactory.getInstance();
+        return io.grpc.util.RoundRobinLoadBalancerFactory.getInstance();
+        // return LoadBalancerRegistry.getDefaultRegistry().getProvider("round_robin");
     }
 
     @ConditionalOnMissingBean

--- a/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/nameresolver/AddressChannelNameResolver.java
+++ b/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/nameresolver/AddressChannelNameResolver.java
@@ -19,7 +19,7 @@ package net.devh.boot.grpc.client.nameresolver;
 
 import java.net.InetSocketAddress;
 import java.util.List;
-import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executor;
 
 import javax.annotation.concurrent.GuardedBy;
 
@@ -48,18 +48,18 @@ public class AddressChannelNameResolver extends NameResolver {
     private final String name;
     private final GrpcChannelProperties properties;
 
-    private final SharedResourceHolder.Resource<ExecutorService> executorResource;
+    private final SharedResourceHolder.Resource<Executor> executorResource;
     @GuardedBy("this")
     private boolean shutdown;
     @GuardedBy("this")
-    private ExecutorService executor;
+    private Executor executor;
     @GuardedBy("this")
     private boolean resolving;
     @GuardedBy("this")
     private Listener listener;
 
-    public AddressChannelNameResolver(String name, GrpcChannelProperties properties,
-            SharedResourceHolder.Resource<ExecutorService> executorResource) {
+    public AddressChannelNameResolver(final String name, final GrpcChannelProperties properties,
+            final SharedResourceHolder.Resource<Executor> executorResource) {
         this.name = name;
         this.properties = properties;
         this.executorResource = executorResource;

--- a/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/nameresolver/DiscoveryClientNameResolver.java
+++ b/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/nameresolver/DiscoveryClientNameResolver.java
@@ -20,7 +20,7 @@ package net.devh.boot.grpc.client.nameresolver;
 import java.net.InetSocketAddress;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 
@@ -54,13 +54,13 @@ public class DiscoveryClientNameResolver extends NameResolver {
     private final String name;
     private final DiscoveryClient client;
     private final SharedResourceHolder.Resource<ScheduledExecutorService> timerServiceResource;
-    private final SharedResourceHolder.Resource<ExecutorService> executorResource;
+    private final SharedResourceHolder.Resource<Executor> executorResource;
     @GuardedBy("this")
     private boolean shutdown;
     @GuardedBy("this")
     private ScheduledExecutorService timerService;
     @GuardedBy("this")
-    private ExecutorService executor;
+    private Executor executor;
     @GuardedBy("this")
     private ScheduledFuture<?> resolutionTask;
     @GuardedBy("this")
@@ -70,9 +70,9 @@ public class DiscoveryClientNameResolver extends NameResolver {
     @GuardedBy("this")
     private List<ServiceInstance> serviceInstanceList;
 
-    public DiscoveryClientNameResolver(String name, DiscoveryClient client,
-            SharedResourceHolder.Resource<ScheduledExecutorService> timerServiceResource,
-            SharedResourceHolder.Resource<ExecutorService> executorResource) {
+    public DiscoveryClientNameResolver(final String name, final DiscoveryClient client,
+            final SharedResourceHolder.Resource<ScheduledExecutorService> timerServiceResource,
+            final SharedResourceHolder.Resource<Executor> executorResource) {
         this.name = name;
         this.client = client;
         this.timerServiceResource = timerServiceResource;


### PR DESCRIPTION
Updates grpc to 1.17.1.

Requires further testing to verify that it does not break compatibility with pre 1.17.1 versions.

grpc 1.17.1 is compatible with grpc-spring-boot-starter pre 1.17.1.
grpc-spring-boot-starter with 1.17.1 is very likely to be compatible with grpc pre 1.17.1.