### PR TITLE
Fix most compile time warnings

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -65,10 +65,7 @@ allprojects {
     }
 
     compileJava.options*.compilerArgs = [
-            "-Xlint:serial", "-Xlint:varargs", "-Xlint:classfile", "-Xlint:dep-ann",
-            "-Xlint:divzero", "-Xlint:empty", "-Xlint:finally", "-Xlint:overrides",
-            "-Xlint:path", "-Xlint:static", "-Xlint:try", "-Xlint:fallthrough",
-            "-Xlint:deprecation", "-Xlint:unchecked", "-Xlint:-options"
+            "-Xlint:all", "-Xlint:-cast", "-Xlint:-processing"
     ]
 
     spotless {

--- a/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/channelfactory/GrpcChannelFactory.java
+++ b/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/channelfactory/GrpcChannelFactory.java
@@ -67,4 +67,7 @@ public interface GrpcChannelFactory extends AutoCloseable {
      */
     Channel createChannel(String name, List<ClientInterceptor> interceptors);
 
+    @Override
+    void close();
+
 }

--- a/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/inject/GrpcClientBeanPostProcessor.java
+++ b/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/inject/GrpcClientBeanPostProcessor.java
@@ -149,7 +149,7 @@ public class GrpcClientBeanPostProcessor implements BeanPostProcessor, AutoClose
                 clientInterceptor = this.applicationContext.getBean(interceptorClass);
             } else {
                 try {
-                    clientInterceptor = interceptorClass.newInstance();
+                    clientInterceptor = interceptorClass.getConstructor().newInstance();
                 } catch (final Exception e) {
                     throw new BeanCreationException("Failed to create interceptor instance", e);
                 }

--- a/grpc-server-spring-boot-autoconfigure/build.gradle
+++ b/grpc-server-spring-boot-autoconfigure/build.gradle
@@ -16,6 +16,7 @@ dependencies {
     compileOnly("org.springframework.cloud:spring-cloud-starter-sleuth:${springCloudSleuthVersion}")
     compileOnly("org.springframework.cloud:spring-cloud-starter-consul-discovery:${springCloudConsulVersion}")
     compileOnly("org.springframework.cloud:spring-cloud-starter-netflix-eureka-client:${springCloudEurekaVersion}")
+    compileOnly("com.google.inject:guice:4.2.2") // Only needed to avoid some warnings during compilation (for eureka)
     compileOnly("io.zipkin.brave:brave-instrumentation-grpc:${braveInstrumentationGrpc}")
     compile("io.grpc:grpc-netty:${grpcVersion}")
     compileOnly("io.grpc:grpc-netty-shaded:${grpcVersion}")

--- a/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/config/GrpcServerProperties.java
+++ b/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/config/GrpcServerProperties.java
@@ -99,6 +99,12 @@ public class GrpcServerProperties {
          */
         private String trustCertCollectionPath = null;
 
+        /**
+         * Sets the path to the private key path.
+         *
+         * @param certificatePath The path to the private key.
+         * @deprecated Use the privateKeyPath property instead.
+         */
         @Deprecated
         public void setCertificatePath(final String certificatePath) {
             log.warn("The 'grpc.server.security.certificatePath' property is deprecated. "
@@ -121,6 +127,12 @@ public class GrpcServerProperties {
         return this.port;
     }
 
+    /**
+     * Sets the maximum message size to use.
+     *
+     * @param maxMessageSize The max message size to use.
+     * @deprecated Use the maxInboundMessageSize property instead.
+     */
     @Deprecated
     public void setMaxMessageSize(final int maxMessageSize) {
         log.warn("The 'grpc.server.maxMessageSize' property is deprecated. "

--- a/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/security/authentication/AnonymousAuthenticationReader.java
+++ b/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/security/authentication/AnonymousAuthenticationReader.java
@@ -62,8 +62,8 @@ public class AnonymousAuthenticationReader implements GrpcAuthenticationReader {
     public AnonymousAuthenticationReader(final String key, final Object principal,
             final Collection<? extends GrantedAuthority> authorities) {
         this.key = requireNonNull(key, "key");
-        this.principal = requireNonNull(principal, "principal");;
-        this.authorities = requireNonNull(authorities, "authorities");;
+        this.principal = requireNonNull(principal, "principal");
+        this.authorities = requireNonNull(authorities, "authorities");
     }
 
     @Override

--- a/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/security/check/AccessPredicates.java
+++ b/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/security/check/AccessPredicates.java
@@ -35,6 +35,9 @@ final class AccessPredicates {
      */
     static final AccessPredicate PERMIT_ALL = new AccessPredicate() {
 
+        /**
+         * @deprecated Should never be called
+         */
         @Override
         @Deprecated // Should never be called
         public boolean test(final Authentication t) {
@@ -42,18 +45,27 @@ final class AccessPredicates {
                     "Tried to execute the 'permit-all' access predicate. The server's security configuration is broken.");
         }
 
+        /**
+         * @deprecated Should never be called
+         */
         @Override
         @Deprecated // Should never be called
         public AccessPredicate and(final Predicate<? super Authentication> other) {
             throw new UnsupportedOperationException("Not allowed for 'permit-all' access predicate");
         }
 
+        /**
+         * @deprecated Should never be called
+         */
         @Override
         @Deprecated // Should never be called
         public AccessPredicate or(final Predicate<? super Authentication> other) {
             throw new UnsupportedOperationException("Not allowed for 'permit-all' access predicate");
         }
 
+        /**
+         * @deprecated Should never be called
+         */
         @Override
         @Deprecated // Should never be called
         public AccessPredicate negate() {

--- a/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/serverfactory/GrpcServerLifecycle.java
+++ b/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/serverfactory/GrpcServerLifecycle.java
@@ -65,7 +65,7 @@ public class GrpcServerLifecycle implements SmartLifecycle {
 
     @Override
     public boolean isRunning() {
-        return this.server == null ? false : !this.server.isShutdown();
+        return this.server != null && !this.server.isShutdown();
     }
 
     @Override

--- a/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/service/AnnotationGrpcServiceDiscoverer.java
+++ b/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/service/AnnotationGrpcServiceDiscoverer.java
@@ -80,7 +80,7 @@ public class AnnotationGrpcServiceDiscoverer implements ApplicationContextAware,
                 serverInterceptor = this.applicationContext.getBean(interceptorClass);
             } else {
                 try {
-                    serverInterceptor = interceptorClass.newInstance();
+                    serverInterceptor = interceptorClass.getConstructor().newInstance();
                 } catch (final Exception e) {
                     throw new BeanCreationException("Failed to create interceptor instance", e);
                 }


### PR DESCRIPTION
Fixes most compile time warnings:

* Enable more linters
* Shutdown should not throw InterruptedException #143 
* `Class#newInstance()` is deprecated in Java9+

Currently there are the following warnings left:

* https://github.com/google/protobuf-gradle-plugin/issues/280
* And I'm not sure on how to fix this warning
  ````txt
  eureka-client-1.9.3.jar(com/netflix/appinfo/EurekaInstanceConfig.class): warning: Cannot find annotation method 'value()' in type 'ImplementedBy': class file for com.google.inject.ImplementedBy not found
  eureka-client-1.9.3.jar(com/netflix/discovery/EurekaClient.class): warning: Cannot find annotation method 'value()' in type 'ImplementedBy'
    ````