### PR TITLE
Fixes initialization order issues causing NPEs in `@PostConstruct`

### DIFF
--- a/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/inject/GrpcClient.java
+++ b/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/inject/GrpcClient.java
@@ -35,18 +35,19 @@ import net.devh.boot.grpc.client.config.GrpcChannelProperties;
 import net.devh.boot.grpc.client.config.GrpcChannelProperties.Security;
 
 /**
- * An annotation for fields of type {@link Channel} or subclasses of {@link AbstractStub}/gRPC client services.
- * Annotated fields will be automatically populated by Spring.
+ * An annotation for fields of type {@link Channel} or subclasses of {@link AbstractStub}/gRPC client services. Also
+ * works for annotated methods that only take a single parameter of the same types. Annotated fields/methods will be
+ * automatically populated/invoked by Spring.
  *
  * <p>
- * <b>Note:</b> Fields that are annotated with this annotation should NOT be annotated with {@link Autowired} or
+ * <b>Note:</b> Fields/Methods that are annotated with this annotation should NOT be annotated with {@link Autowired} or
  * {@link Inject} (conflict).
  * </p>
  *
  * @author Michael (yidongnan@gmail.com)
  * @since 2016/12/7
  */
-@Target({ElementType.FIELD})
+@Target({ElementType.FIELD, ElementType.METHOD})
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
 @Inherited

--- a/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/inject/GrpcClientBeanPostProcessor.java
+++ b/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/inject/GrpcClientBeanPostProcessor.java
@@ -22,38 +22,37 @@ import static java.util.Objects.requireNonNull;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Member;
+import java.lang.reflect.Method;
 import java.util.List;
 
-import org.springframework.aop.framework.Advised;
-import org.springframework.aop.support.AopUtils;
 import org.springframework.beans.BeanInstantiationException;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.InvalidPropertyException;
 import org.springframework.beans.factory.BeanCreationException;
+import org.springframework.beans.factory.BeanDefinitionStoreException;
 import org.springframework.beans.factory.config.BeanPostProcessor;
 import org.springframework.context.ApplicationContext;
 import org.springframework.core.annotation.AnnotationUtils;
 import org.springframework.util.ReflectionUtils;
 
-import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Lists;
-import com.google.common.collect.Multimap;
 
 import io.grpc.Channel;
 import io.grpc.ClientInterceptor;
 import io.grpc.stub.AbstractStub;
-import lombok.SneakyThrows;
 import net.devh.boot.grpc.client.channelfactory.GrpcChannelFactory;
 
 /**
- * This {@link BeanPostProcessor} searches for fields in beans that are annotated with {@link GrpcClient} and sets them.
+ * This {@link BeanPostProcessor} searches for fields and methods in beans that are annotated with {@link GrpcClient}
+ * and sets them.
  *
  * @author Michael (yidongnan@gmail.com)
+ * @author Daniel Theuke (daniel.theuke@heuboe.de)
  * @since 5/17/16
  */
-public class GrpcClientBeanPostProcessor implements BeanPostProcessor, AutoCloseable {
+public class GrpcClientBeanPostProcessor implements BeanPostProcessor {
 
-    private final Multimap<String, Field> beansToProcess = HashMultimap.create();
     private final ApplicationContext applicationContext;
 
     // Lazy initialized when needed to avoid overly eager creation of that factory,
@@ -65,13 +64,27 @@ public class GrpcClientBeanPostProcessor implements BeanPostProcessor, AutoClose
     }
 
     @Override
-    public Object postProcessBeforeInitialization(final Object bean, final String beanName) {
+    public Object postProcessBeforeInitialization(final Object bean, final String beanName) throws BeansException {
         Class<?> clazz = bean.getClass();
         do {
             for (final Field field : clazz.getDeclaredFields()) {
-                if (field.isAnnotationPresent(GrpcClient.class)) {
+                GrpcClient annotation = AnnotationUtils.findAnnotation(field, GrpcClient.class);
+                if (annotation != null) {
                     ReflectionUtils.makeAccessible(field);
-                    this.beansToProcess.put(beanName, field);
+                    ReflectionUtils.setField(field, bean, processInjectionPoint(field, field.getType(), annotation));
+                }
+            }
+            for (final Method method : clazz.getDeclaredMethods()) {
+                GrpcClient annotation = AnnotationUtils.findAnnotation(method, GrpcClient.class);
+                if (annotation != null) {
+                    Class<?>[] paramTypes = method.getParameterTypes();
+                    if (paramTypes.length != 1) {
+                        throw new BeanDefinitionStoreException(
+                                "Method " + method + " doesn't have exactly one parameter.");
+                    }
+                    ReflectionUtils.makeAccessible(method);
+                    ReflectionUtils.invokeMethod(method, bean,
+                            processInjectionPoint(method, paramTypes[0], annotation));
                 }
             }
             clazz = clazz.getSuperclass();
@@ -79,21 +92,27 @@ public class GrpcClientBeanPostProcessor implements BeanPostProcessor, AutoClose
         return bean;
     }
 
-    @Override
-    public Object postProcessAfterInitialization(final Object bean, final String beanName) throws BeansException {
-        if (this.beansToProcess.containsKey(beanName)) {
-            final Object target = getTargetBean(bean);
-            for (final Field field : this.beansToProcess.get(beanName)) {
-                final GrpcClient annotation = AnnotationUtils.getAnnotation(field, GrpcClient.class);
-
-                final List<ClientInterceptor> interceptors = interceptorsFromAnnotation(annotation);
-                final Channel channel = getChannelFactory().createChannel(annotation.value(), interceptors);
-
-                final Object value = valueForField(field, channel);
-                ReflectionUtils.setField(field, target, value);
-            }
+    /**
+     * Processes the given injection point and computes the appropriate value for the injection.
+     *
+     * @param <T> The type of the value to be injected.
+     * @param injectionTarget The target of the injection.
+     * @param injectionType The class that will be used to compute injection.
+     * @param annotation The annotation on the target with the metadata for the injection.
+     * @return The value to be injected for the given injection point.
+     */
+    protected <T> T processInjectionPoint(Member injectionTarget, Class<T> injectionType, GrpcClient annotation) {
+        final List<ClientInterceptor> interceptors = interceptorsFromAnnotation(annotation);
+        final Channel channel = getChannelFactory().createChannel(annotation.value(), interceptors);
+        if (channel == null) {
+            throw new IllegalStateException("Channel factory created a null channel");
         }
-        return bean;
+
+        final T value = valueForMember(injectionTarget, injectionType, channel);
+        if (value == null) {
+            throw new IllegalStateException("Injection value is null unexpectedly");
+        }
+        return value;
     }
 
     /**
@@ -144,44 +163,32 @@ public class GrpcClientBeanPostProcessor implements BeanPostProcessor, AutoClose
     }
 
     /**
-     * Creates the instance for the given field.
+     * Creates the instance to be injected for the given member.
      *
-     * @param field The field to create the instance for.
+     * @param <T> The type of the instance to be injected.
+     * @param injectionTarget The target member for the injection.
+     * @param injectionType The class that should injected.
      * @param channel The channel that should be used to create the instance.
      * @return The value that matches the type of the given field.
      * @throws BeansException If the value of the field could not be created or the type of the field is unsupported.
      */
-    protected Object valueForField(final Field field, final Channel channel) throws BeansException {
-        final Class<?> fieldType = field.getType();
-        if (Channel.class.equals(fieldType)) {
-            return channel;
-        } else if (AbstractStub.class.isAssignableFrom(fieldType)) {
+    protected <T> T valueForMember(Member injectionTarget, Class<T> injectionType, final Channel channel)
+            throws BeansException {
+        if (Channel.class.equals(injectionType)) {
+            return injectionType.cast(channel);
+        } else if (AbstractStub.class.isAssignableFrom(injectionType)) {
             try {
-                final Constructor<?> constructor = ReflectionUtils.accessibleConstructor(fieldType, Channel.class);
+                final Constructor<T> constructor = ReflectionUtils.accessibleConstructor(injectionType, Channel.class);
                 return constructor.newInstance(channel);
             } catch (final NoSuchMethodException | InstantiationException | IllegalAccessException
                     | IllegalArgumentException | InvocationTargetException e) {
-                throw new BeanInstantiationException(fieldType,
-                        "Failed to create gRPC client for field: " + field, e);
+                throw new BeanInstantiationException(injectionType,
+                        "Failed to create gRPC client for : " + injectionTarget, e);
             }
         } else {
-            throw new InvalidPropertyException(field.getDeclaringClass(), field.getName(),
-                    "Unsupported field type " + fieldType.getName());
+            throw new InvalidPropertyException(injectionTarget.getDeclaringClass(), injectionTarget.getName(),
+                    "Unsupported type " + injectionType.getName());
         }
-    }
-
-    @SneakyThrows
-    private Object getTargetBean(final Object bean) {
-        Object target = bean;
-        while (AopUtils.isAopProxy(target)) {
-            target = ((Advised) target).getTargetSource().getTarget();
-        }
-        return target;
-    }
-
-    @Override
-    public void close() {
-        this.beansToProcess.clear();
     }
 
 }

--- a/tests/src/test/java/net/devh/boot/grpc/test/AbstractSimpleServerClientTest.java
+++ b/tests/src/test/java/net/devh/boot/grpc/test/AbstractSimpleServerClientTest.java
@@ -21,9 +21,12 @@ import static io.grpc.Status.Code.UNIMPLEMENTED;
 import static net.devh.boot.grpc.test.util.GrpcAssertions.assertFutureThrowsStatus;
 import static net.devh.boot.grpc.test.util.GrpcAssertions.assertThrowsStatus;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+
+import javax.annotation.PostConstruct;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.test.annotation.DirtiesContext;
@@ -56,6 +59,15 @@ public abstract class AbstractSimpleServerClientTest {
     protected TestServiceBlockingStub testServiceBlockingStub;
     @GrpcClient("test")
     protected TestServiceFutureStub testServiceFutureStub;
+
+    @PostConstruct
+    public void init() {
+        // Test injection
+        assertNotNull(this.channel, "channel");
+        assertNotNull(this.testServiceBlockingStub, "testServiceBlockingStub");
+        assertNotNull(this.testServiceFutureStub, "testServiceFutureStub");
+        assertNotNull(this.testServiceStub, "testServiceStub");
+    }
 
     /**
      * Test successful call.

--- a/tests/src/test/java/net/devh/boot/grpc/test/inject/GrpcClientInjectionTest.java
+++ b/tests/src/test/java/net/devh/boot/grpc/test/inject/GrpcClientInjectionTest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2016-2018 Michael Zhang <yidongnan@gmail.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package net.devh.boot.grpc.test.inject;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import javax.annotation.PostConstruct;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+import io.grpc.Channel;
+import net.devh.boot.grpc.client.inject.GrpcClient;
+import net.devh.boot.grpc.test.config.BaseAutoConfiguration;
+import net.devh.boot.grpc.test.config.InProcessConfiguration;
+import net.devh.boot.grpc.test.config.ServiceConfiguration;
+import net.devh.boot.grpc.test.proto.TestServiceGrpc.TestServiceBlockingStub;
+import net.devh.boot.grpc.test.proto.TestServiceGrpc.TestServiceFutureStub;
+import net.devh.boot.grpc.test.proto.TestServiceGrpc.TestServiceStub;
+
+/**
+ * A test checking that the client injection works.
+ *
+ * @author Daniel Theuke (daniel.theuke@heuboe.de)
+ */
+@SpringBootTest
+@SpringJUnitConfig(classes = {InProcessConfiguration.class, ServiceConfiguration.class, BaseAutoConfiguration.class})
+@DirtiesContext
+public class GrpcClientInjectionTest {
+
+    @GrpcClient("test")
+    protected Channel channel;
+    @GrpcClient("test")
+    protected TestServiceStub stub;
+    @GrpcClient("test")
+    protected TestServiceBlockingStub blockingStub;
+    @GrpcClient("test")
+    protected TestServiceFutureStub futureStub;
+
+    protected Channel channelSetted;
+    protected TestServiceStub stubSetted;
+    protected TestServiceBlockingStub blockingStubSetted;
+    protected TestServiceFutureStub futureStubSetted;
+
+
+    @PostConstruct
+    public void init() {
+        // Test injection
+        assertNotNull(this.channel, "channel");
+        assertNotNull(this.stub, "stub");
+        assertNotNull(this.blockingStub, "blockingStub");
+        assertNotNull(this.futureStub, "futureStub");
+    }
+
+    @GrpcClient("test")
+    public void inject(Channel channel) {
+        assertNotNull(channel, "channel");
+        this.channelSetted = channel;
+    }
+
+    @GrpcClient("test")
+    public void inject(TestServiceStub stub) {
+        assertNotNull(stub, "stub");
+        this.stubSetted = stub;
+    }
+
+    @GrpcClient("test")
+    public void inject(TestServiceBlockingStub stub) {
+        assertNotNull(stub, "stub");
+        this.blockingStubSetted = stub;
+    }
+
+    @GrpcClient("test")
+    public void inject(TestServiceFutureStub stub) {
+        assertNotNull(stub, "stub");
+        this.futureStubSetted = stub;
+    }
+
+    @Test
+    public void testAllSet() {
+        // Field injection
+        assertNotNull(this.channel, "channel");
+        assertNotNull(this.stub, "stub");
+        assertNotNull(this.blockingStub, "blockingStub");
+        assertNotNull(this.futureStub, "futureStub");
+        // Setter injection
+        assertNotNull(this.channelSetted, "channelSetted");
+        assertNotNull(this.stubSetted, "stubSetted");
+        assertNotNull(this.blockingStubSetted, "blockingStubSetted");
+        assertNotNull(this.futureStubSetted, "futureStubSetted");
+    }
+
+}


### PR DESCRIPTION
Fixes #156 

Currently the injection only takes place after the initialization and thus causes NPEs in `@PostConstruct` if the supposedly injected values are used in there.

This PR changes the behavior of the bean post processor to inject the clients before the initialization and thus prevent those conflicts.

I also modified the injection behavior to allow setters to be used as well.