### PR TITLE
Add call attributes to the authentication if no details are present

### DIFF
--- a/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/security/interceptors/AuthenticatingServerInterceptor.java
+++ b/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/security/interceptors/AuthenticatingServerInterceptor.java
@@ -21,6 +21,7 @@ import static java.util.Objects.requireNonNull;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.authentication.AbstractAuthenticationToken;
 import org.springframework.security.authentication.AnonymousAuthenticationToken;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.BadCredentialsException;
@@ -68,6 +69,12 @@ public class AuthenticatingServerInterceptor implements ServerInterceptor {
             } catch (final AccessDeniedException e) {
                 throw new BadCredentialsException("No credentials found in the request", e);
             }
+        }
+        if (authentication.getDetails() == null && authentication instanceof AbstractAuthenticationToken) {
+            // Append call attributes to the authentication request.
+            // This gives the AuthenticationManager access to information like remote and local address.
+            // It can then decide whether it wants to use its own user details or the attributes.
+            ((AbstractAuthenticationToken) authentication).setDetails(call.getAttributes());
         }
         log.debug("Credentials found: Authenticating...");
         authentication = this.authenticationManager.authenticate(authentication);


### PR DESCRIPTION
This allows the `AuthenticationManager` to decide based on attributes such
as the remote or local address. For example it could decide whether the
client originates from a blacklisted ip-range. Another example could be
using multiple inbound addresses for internal and external use which use
a different set of `AuthenticationProvider`s.

Multiple inbound addresses for netty will be added via https://github.com/grpc/grpc-java/pull/5067 .