### PR TITLE
Fix discovery client refresh. Fixes #171

### DIFF
--- a/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/autoconfigure/GrpcDiscoveryClientAutoConfiguration.java
+++ b/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/autoconfigure/GrpcDiscoveryClientAutoConfiguration.java
@@ -26,6 +26,7 @@ import org.springframework.cloud.client.discovery.DiscoveryClient;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Lazy;
+import org.springframework.context.annotation.Primary;
 
 import com.google.common.collect.ImmutableList;
 
@@ -44,15 +45,23 @@ public class GrpcDiscoveryClientAutoConfiguration {
     @ConditionalOnMissingBean
     @Lazy // Not needed for InProcessChannelFactories
     @Bean
+    @Primary
     NameResolver.Factory grpcNameResolverProviderWithDiscovery(final GrpcChannelsProperties channelProperties,
-            final DiscoveryClient client) {
+            final DiscoveryClientResolverFactory discoveryClientResolverFactory) {
         final List<NameResolver.Factory> factories = ImmutableList.<NameResolver.Factory>builder()
-                .add(new DiscoveryClientResolverFactory(client))
+                .add(discoveryClientResolverFactory)
                 .add(NameResolverProvider.asFactory())
                 .build();
         return new ConfigMappedNameResolverFactory(channelProperties,
                 new CompositeNameResolverFactory(DiscoveryClientResolverFactory.DISCOVERY_SCHEME, factories),
                 DiscoveryClientResolverFactory.DISCOVERY_DEFAULT_URI_MAPPER);
+    }
+
+    @ConditionalOnMissingBean
+    @Lazy // Not needed for InProcessChannelFactories
+    @Bean
+    DiscoveryClientResolverFactory grpcDiscoveryClientResolverFactory(final DiscoveryClient client) {
+        return new DiscoveryClientResolverFactory(client);
     }
 
 }

--- a/testExamples.sh
+++ b/testExamples.sh
@@ -81,6 +81,25 @@ cloudTest() {
 	echo "$EXPECTED"
 	sleep 2s
 
+	# Crash server
+	kill -s TERM $CLOUD_SERVER
+	echo "The server crashed (expected)"
+	sleep 10s
+
+	# and restart server
+	./gradlew :example:cloud-grpc-server:bootRun -x jar -x classes &
+	CLOUD_SERVER=$!
+	sleep 60s
+	
+	# Test again
+	RESPONSE2=$(curl -s localhost:8080/)
+	echo "Response:"
+	echo "$RESPONSE"
+	EXPECTED=$(echo -e "Hello ==> Michael")
+	echo "Expected:"
+	echo "$EXPECTED"
+	sleep 2s
+
 	# Shutdown
 	echo "Triggering shutdown"
 	kill -s TERM $EUREKA
@@ -89,15 +108,27 @@ cloudTest() {
 	kill -s TERM $CLOUD_CLIENT
 	sleep 5s
 
-	# Verify
+	# Verify part 1
 	if [ "$RESPONSE" = "$EXPECTED" ]; then
-		echo "#----------------------#"
-		echo "| Cloud example works! |"
-		echo "#----------------------#"
+		echo "#-----------------------------#"
+		echo "| Cloud example part 1 works! |"
+		echo "#-----------------------------#"
 	else
-		echo "#-----------------------#"
-		echo "| Cloud example failed! |"
-		echo "#-----------------------#"
+		echo "#------------------------------#"
+		echo "| Cloud example part 1 failed! |"
+		echo "#------------------------------#"
+		exit 1
+	fi
+
+	# Verify part 2
+	if [ "$RESPONSE2" = "$EXPECTED" ]; then
+		echo "#-----------------------------#"
+		echo "| Cloud example part 2 works! |"
+		echo "#-----------------------------#"
+	else
+		echo "#------------------------------#"
+		echo "| Cloud example part 2 failed! |"
+		echo "#------------------------------#"
 		exit 1
 	fi
 }


### PR DESCRIPTION
If we use the constructor directly spring won't run the lifecycle
methods and the event listeners, so we have to use a bean reference for
that.

Fixes #171 (Thanks to @andcuevas for reporting this issue)