### PR TITLE
Use new DataSize feature to simplify size limit setup

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -34,9 +34,11 @@ Java技术交流群：294712648 <a target="_blank" href="http://shang.qq.com/wpa
 
 ## 版本
 
-2.x.x.RELEASE 支持 Spring Boot 2 & Spring Cloud Finchley, Greenwich。
+2.x.x.RELEASE 支持 Spring Boot 2.1+ & Spring Cloud Greenwich。
 
 最新的版本：``2.4.0.RELEASE``
+
+(使用 `2.4.0.RELEASE` 版本可以支持 Spring Boot 2.0.X & Spring Cloud Finchley).
 
 1.x.x.RELEASE 支持 Spring Boot 1 & Spring Cloud Edgware 、Dalston、Camden。
 

--- a/README.md
+++ b/README.md
@@ -31,9 +31,11 @@ application
 
 ## Versions
 
-2.x.x.RELEASE support Spring Boot 2 & Spring Cloud Finchley, Greenwich.
+2.x.x.RELEASE supports Spring Boot 2.1+ & Spring Cloud Greenwich.
 
 The latest version: ``2.4.0.RELEASE``
+
+(Use `2.4.0.RELEASE` for Spring Boot 2.0.X & Spring Cloud Finchley).
 
 1.x.x.RELEASE support Spring Boot 1 & Spring Cloud Edgware, Dalston, Camden.
 

--- a/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/autoconfigure/GrpcDiscoveryClientAutoConfiguration.java
+++ b/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/autoconfigure/GrpcDiscoveryClientAutoConfiguration.java
@@ -33,7 +33,6 @@ import com.google.common.collect.ImmutableList;
 import io.grpc.NameResolver;
 import io.grpc.NameResolverProvider;
 import net.devh.boot.grpc.client.config.GrpcChannelsProperties;
-import net.devh.boot.grpc.client.nameresolver.CompositeNameResolverFactory;
 import net.devh.boot.grpc.client.nameresolver.ConfigMappedNameResolverFactory;
 import net.devh.boot.grpc.client.nameresolver.DiscoveryClientResolverFactory;
 
@@ -55,7 +54,8 @@ public class GrpcDiscoveryClientAutoConfiguration {
                 .add(NameResolverProvider.asFactory())
                 .build();
         return new ConfigMappedNameResolverFactory(channelProperties,
-                new CompositeNameResolverFactory(DiscoveryClientResolverFactory.DISCOVERY_SCHEME, factories),
+                new net.devh.boot.grpc.client.nameresolver.CompositeNameResolverFactory(
+                        DiscoveryClientResolverFactory.DISCOVERY_SCHEME, factories),
                 DiscoveryClientResolverFactory.DISCOVERY_DEFAULT_URI_MAPPER);
     }
 

--- a/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/channelfactory/AbstractChannelFactory.java
+++ b/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/channelfactory/AbstractChannelFactory.java
@@ -29,6 +29,8 @@ import java.util.concurrent.TimeUnit;
 import javax.annotation.PreDestroy;
 import javax.annotation.concurrent.GuardedBy;
 
+import org.springframework.util.unit.DataSize;
+
 import com.google.common.collect.Lists;
 
 import io.grpc.Channel;
@@ -228,9 +230,9 @@ public abstract class AbstractChannelFactory<T extends ManagedChannelBuilder<T>>
      */
     protected void configureLimits(final T builder, final String name) {
         final GrpcChannelProperties properties = getPropertiesFor(name);
-        final Integer maxInboundMessageSize = properties.getMaxInboundMessageSize();
+        final DataSize maxInboundMessageSize = properties.getMaxInboundMessageSize();
         if (maxInboundMessageSize != null) {
-            builder.maxInboundMessageSize(maxInboundMessageSize);
+            builder.maxInboundMessageSize((int) maxInboundMessageSize.toBytes());
         }
     }
 

--- a/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/config/GrpcChannelProperties.java
+++ b/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/config/GrpcChannelProperties.java
@@ -25,7 +25,10 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
+import org.springframework.boot.convert.DataSizeUnit;
 import org.springframework.boot.convert.DurationUnit;
+import org.springframework.util.unit.DataSize;
+import org.springframework.util.unit.DataUnit;
 
 import io.grpc.LoadBalancerRegistry;
 import io.grpc.ManagedChannelBuilder;
@@ -270,17 +273,19 @@ public class GrpcChannelProperties {
     // Message Transfer
     // --------------------------------------------------
 
-    private Integer maxInboundMessageSize = null;
+    @DataSizeUnit(DataUnit.BYTES)
+    private DataSize maxInboundMessageSize = null;
 
     /**
-     * Gets the maximum message size in bytes allowed to be received by the channel. If not set ({@code null}) then it
-     * {@link GrpcUtil#DEFAULT_MAX_MESSAGE_SIZE gRPC's default} should be used.
+     * Gets the maximum message size allowed to be received by the channel. If not set ({@code null}) then
+     * {@link GrpcUtil#DEFAULT_MAX_MESSAGE_SIZE gRPC's default} should be used. If set to {@code -1} then it will use
+     * the highest possible limit (not recommended).
      *
      * @return The maximum message size allowed or null if the default should be used.
-     *
-     * @see #setMaxInboundMessageSize(Integer)
+     * 
+     * @see #setMaxInboundMessageSize(DataSize)
      */
-    public Integer getMaxInboundMessageSize() {
+    public DataSize getMaxInboundMessageSize() {
         return this.maxInboundMessageSize;
     }
 
@@ -294,11 +299,11 @@ public class GrpcChannelProperties {
      *
      * @see ManagedChannelBuilder#maxInboundMessageSize(int)
      */
-    public void setMaxInboundMessageSize(final Integer maxInboundMessageSize) {
-        if (maxInboundMessageSize == null || maxInboundMessageSize >= 0) {
+    public void setMaxInboundMessageSize(final DataSize maxInboundMessageSize) {
+        if (maxInboundMessageSize == null || maxInboundMessageSize.toBytes() >= 0) {
             this.maxInboundMessageSize = maxInboundMessageSize;
-        } else if (maxInboundMessageSize == -1) {
-            this.maxInboundMessageSize = Integer.MAX_VALUE;
+        } else if (maxInboundMessageSize.toBytes() == -1) {
+            this.maxInboundMessageSize = DataSize.ofBytes(Integer.MAX_VALUE);
         } else {
             throw new IllegalArgumentException("Unsupported maxInboundMessageSize: " + maxInboundMessageSize);
         }
@@ -558,7 +563,7 @@ public class GrpcChannelProperties {
          * @return The cipher suite accepted for secure connections or null.
          */
         public List<String> getCiphers() {
-            return ciphers;
+            return this.ciphers;
         }
 
         /**
@@ -576,7 +581,7 @@ public class GrpcChannelProperties {
          * @return The protocols accepted for secure connections or null.
          */
         public String[] getProtocols() {
-            return protocols;
+            return this.protocols;
         }
 
         /**

--- a/grpc-client-spring-boot-autoconfigure/src/test/java/net/devh/boot/grpc/client/config/GrpcChannelPropertiesGivenUnitTest.java
+++ b/grpc-client-spring-boot-autoconfigure/src/test/java/net/devh/boot/grpc/client/config/GrpcChannelPropertiesGivenUnitTest.java
@@ -26,12 +26,16 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.util.unit.DataSize;
 
 /**
  * Tests whether the property resolution using suffixes works.
  */
 @ExtendWith(SpringExtension.class)
-@SpringBootTest(properties = "grpc.client.test.keepAliveTime=42m")
+@SpringBootTest(properties = {
+        "grpc.client.test.keepAliveTime=42m",
+        "grpc.client.test.maxInboundMessageSize=5MB"
+})
 class GrpcChannelPropertiesGivenUnitTest {
 
     @Autowired
@@ -39,7 +43,9 @@ class GrpcChannelPropertiesGivenUnitTest {
 
     @Test
     void test() {
-        assertEquals(Duration.ofMinutes(42), this.grpcChannelsProperties.getChannel("test").getKeepAliveTime());
+        final GrpcChannelProperties properties = this.grpcChannelsProperties.getChannel("test");
+        assertEquals(Duration.ofMinutes(42), properties.getKeepAliveTime());
+        assertEquals(DataSize.ofMegabytes(5), properties.getMaxInboundMessageSize());
     }
 
 }

--- a/grpc-client-spring-boot-autoconfigure/src/test/java/net/devh/boot/grpc/client/config/GrpcChannelPropertiesNoUnitTest.java
+++ b/grpc-client-spring-boot-autoconfigure/src/test/java/net/devh/boot/grpc/client/config/GrpcChannelPropertiesNoUnitTest.java
@@ -26,12 +26,16 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.util.unit.DataSize;
 
 /**
  * Tests whether the property resolution without suffixes works (backwards compatibility).
  */
 @ExtendWith(SpringExtension.class)
-@SpringBootTest(properties = "grpc.client.test.keepAliveTime=42")
+@SpringBootTest(properties = {
+        "grpc.client.test.keepAliveTime=42",
+        "grpc.client.test.maxInboundMessageSize=5242880"
+})
 class GrpcChannelPropertiesNoUnitTest {
 
     @Autowired
@@ -39,7 +43,9 @@ class GrpcChannelPropertiesNoUnitTest {
 
     @Test
     void test() {
-        assertEquals(Duration.ofSeconds(42), this.grpcChannelsProperties.getChannel("test").getKeepAliveTime());
+        final GrpcChannelProperties properties = this.grpcChannelsProperties.getChannel("test");
+        assertEquals(Duration.ofSeconds(42), properties.getKeepAliveTime());
+        assertEquals(DataSize.ofMegabytes(5), properties.getMaxInboundMessageSize());
     }
 
 }

--- a/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/serverfactory/AbstractGrpcServerFactory.java
+++ b/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/serverfactory/AbstractGrpcServerFactory.java
@@ -23,6 +23,7 @@ import java.io.File;
 import java.util.List;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.util.unit.DataSize;
 
 import com.google.common.collect.Lists;
 
@@ -170,9 +171,9 @@ public abstract class AbstractGrpcServerFactory<T extends ServerBuilder<T>> impl
      * @param builder The server builder to configure.
      */
     protected void configureLimits(final T builder) {
-        final Integer maxInboundMessageSize = this.properties.getMaxInboundMessageSize();
+        final DataSize maxInboundMessageSize = this.properties.getMaxInboundMessageSize();
         if (maxInboundMessageSize != null) {
-            builder.maxInboundMessageSize(maxInboundMessageSize);
+            builder.maxInboundMessageSize((int) maxInboundMessageSize.toBytes());
         }
     }
 

--- a/grpc-server-spring-boot-autoconfigure/src/test/java/net/devh/boot/grpc/server/config/GrpcServerPropertiesGivenUnitTest.java
+++ b/grpc-server-spring-boot-autoconfigure/src/test/java/net/devh/boot/grpc/server/config/GrpcServerPropertiesGivenUnitTest.java
@@ -26,12 +26,16 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.util.unit.DataSize;
 
 /**
  * Tests whether the property resolution using suffixes works.
  */
 @ExtendWith(SpringExtension.class)
-@SpringBootTest(properties = "grpc.server.keepAliveTime=42m")
+@SpringBootTest(properties = {
+        "grpc.server.keepAliveTime=42m",
+        "grpc.server.maxInboundMessageSize=5MB"
+})
 class GrpcServerPropertiesGivenUnitTest {
 
     @Autowired
@@ -40,6 +44,7 @@ class GrpcServerPropertiesGivenUnitTest {
     @Test
     void test() {
         assertEquals(Duration.ofMinutes(42), this.grpcServerProperties.getKeepAliveTime());
+        assertEquals(DataSize.ofMegabytes(5), this.grpcServerProperties.getMaxInboundMessageSize());
     }
 
 }

--- a/grpc-server-spring-boot-autoconfigure/src/test/java/net/devh/boot/grpc/server/config/GrpcServerPropertiesNoUnitTest.java
+++ b/grpc-server-spring-boot-autoconfigure/src/test/java/net/devh/boot/grpc/server/config/GrpcServerPropertiesNoUnitTest.java
@@ -26,12 +26,16 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.util.unit.DataSize;
 
 /**
  * Tests whether the property resolution without suffixes works (backwards compatibility).
  */
 @ExtendWith(SpringExtension.class)
-@SpringBootTest(properties = "grpc.server.keepAliveTime=42")
+@SpringBootTest(properties = {
+        "grpc.server.keepAliveTime=42",
+        "grpc.server.maxInboundMessageSize=5242880"
+})
 class GrpcServerPropertiesNoUnitTest {
 
     @Autowired
@@ -40,6 +44,7 @@ class GrpcServerPropertiesNoUnitTest {
     @Test
     void test() {
         assertEquals(Duration.ofSeconds(42), this.grpcServerProperties.getKeepAliveTime());
+        assertEquals(DataSize.ofMegabytes(5), this.grpcServerProperties.getMaxInboundMessageSize());
     }
 
 }


### PR DESCRIPTION
This PR changes the configuration to use Spring-Boot 2.1's `DataSize` feature which simplifies the setup of the size limit by using data size unit suffixes.

## Example

**Current**

````properties
grpc.server.maxInboundMessageSize=5242880
````

**New**

````properties
grpc.server.maxInboundMessageSize=5MB
````

(The same works also for the client)

## Pros

Simplified configuration

## Cons


Spring Boot 2.0 cannot be used anymore, because this change requires features from Spring-Boot 2.1 or later. It might be possible to still use 2.0 by manually copying the two required classes from 2.1 (not tested).

## Tasks

* [x] Use `DataSize` feature
* [x] Add tests to ensure config backwards compatibility
* [x] Discus whether this change is worth its price