### PR TITLE
Use delombok to generate javadocs for the config files

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -143,6 +143,13 @@ allprojects {
 
 Project commonProject = project(':grpc-common-spring-boot');
 
+String javaAPIdoc;
+if (JavaVersion.current().isJava9Compatible()) {
+    javaAPIdoc = 'https://docs.oracle.com/en/java/javase/11/docs/api';
+} else {
+    javaAPIdoc = 'https://docs.oracle.com/javase/8/docs/api/';
+}
+
 allprojects { project ->
     if (project.parent?.name != "examples") {
 
@@ -182,7 +189,7 @@ allprojects { project ->
                 options.linksOffline('https://static.javadoc.io/net.devh/grpc-common-spring-boot/' + projectVersion, commonProject.buildDir.getPath() + '/docs/javadoc')
             }
             options.links = [
-                    'https://docs.oracle.com/javase/8/docs/api/',
+                    javaAPIdoc,
                     'https://grpc.io/grpc-java/javadoc/',
                     'https://static.javadoc.io/io.micrometer/micrometer-core/' + micrometerVersion + '/',
                     'https://docs.spring.io/spring-framework/docs/' + springFrameworkVersion + '/javadoc-api/',

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,6 @@
 import java.time.OffsetDateTime
 import java.time.format.DateTimeFormatter
+import io.franzbecker.gradle.lombok.task.DelombokTask
 
 buildscript {
     repositories {
@@ -35,6 +36,7 @@ buildscript {
 
 plugins {
     id "net.nemerosa.versioning" version "2.8.2"
+    id "io.franzbecker.gradle-lombok" version "2.0" apply false
 }
 
 wrapper {
@@ -53,8 +55,9 @@ allprojects {
     apply plugin: 'java'
     apply plugin: 'idea'
     apply plugin: 'eclipse'
-    apply plugin: "io.spring.dependency-management"
+    apply plugin: 'io.spring.dependency-management'
     apply plugin: 'com.diffplug.gradle.spotless'
+    apply plugin: 'io.franzbecker.gradle-lombok'
 
     compileJava {
         sourceCompatibility = JavaVersion.VERSION_1_8
@@ -127,13 +130,6 @@ allprojects {
         maven { url 'https://repo.spring.io/libs-milestone' }
     }
 
-    dependencies {
-        compileOnly("org.projectlombok:lombok:${lombokVersion}")
-        testCompileOnly("org.projectlombok:lombok:${lombokVersion}")
-        annotationProcessor("org.projectlombok:lombok:${lombokVersion}")
-        testAnnotationProcessor("org.projectlombok:lombok:${lombokVersion}")
-    }
-
     buildscript {
         repositories {
             mavenLocal()
@@ -145,8 +141,11 @@ allprojects {
     }
 }
 
+Project commonProject = project(':grpc-common-spring-boot');
+
 allprojects { project ->
-    if (!project.parent || project.parent.name != "examples") {
+    if (project.parent?.name != "examples") {
+
         buildscript {
             dependencyManagement {
                 imports {
@@ -155,19 +154,40 @@ allprojects { project ->
             }
 
             ext {
+                micrometerVersion = dependencyManagement.importedProperties['micrometer.version']
                 springFrameworkVersion = dependencyManagement.importedProperties['spring.version']
                 springSecurityVersion = dependencyManagement.importedProperties['spring-security.version']
             }
         }
+    }
+    if (project.name == 'grpc-common-spring-boot' || project.name == 'grpc-client-spring-boot-autoconfigure' || project.name == 'grpc-server-spring-boot-autoconfigure') {
+        // Properly generate javadocs for the important projects
 
-        tasks.withType(Javadoc) {
-            def links = [
+        task delombok(type: DelombokTask, dependsOn: compileJava) {
+            ext.outputDir = file("$buildDir/delombok")
+            outputs.dir(outputDir)
+            sourceSets.main.java.srcDirs.each {
+                inputs.dir(it)
+                args(it, "-d", outputDir)
+            }
+        }
+
+        // Javadoc Task
+        javadoc {
+            dependsOn delombok
+            source = delombok.outputDir
+            failOnError = false
+            options.jFlags('-Dhttp.agent=gradle-javadoc') // Required for javadoc.io
+            if (project.name != 'grpc-common-spring-boot') {
+                options.linksOffline('https://static.javadoc.io/net.devh/grpc-common-spring-boot/' + projectVersion, commonProject.buildDir.getPath() + '/docs/javadoc')
+            }
+            options.links = [
                     'https://docs.oracle.com/javase/8/docs/api/',
                     'https://grpc.io/grpc-java/javadoc/',
+                    'https://static.javadoc.io/io.micrometer/micrometer-core/' + micrometerVersion + '/',
                     'https://docs.spring.io/spring-framework/docs/' + springFrameworkVersion + '/javadoc-api/',
                     'https://docs.spring.io/spring-security/site/docs/' + springSecurityVersion + '/api/'
             ]
-            options.setLinks(links)
         }
     }
 }

--- a/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/config/GrpcChannelProperties.java
+++ b/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/config/GrpcChannelProperties.java
@@ -17,6 +17,7 @@
 
 package net.devh.boot.grpc.client.config;
 
+import java.io.File;
 import java.net.URI;
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
@@ -26,16 +27,19 @@ import java.util.concurrent.TimeUnit;
 import org.springframework.boot.convert.DurationUnit;
 
 import io.grpc.internal.GrpcUtil;
-import io.grpc.netty.NettyChannelBuilder;
+import io.grpc.netty.shaded.io.grpc.netty.NettyChannelBuilder;
+import io.grpc.netty.shaded.io.grpc.netty.NettyServerBuilder;
+import io.grpc.netty.shaded.io.netty.handler.ssl.SslContextBuilder;
 import lombok.Data;
 
 /**
- * The channel properties for a single named grpc channel or service reference.
+ * The channel properties for a single named gRPC channel or service reference.
  *
  * @author Michael (yidongnan@gmail.com)
  * @since 5/17/16
  */
 @Data
+@SuppressWarnings("javadoc")
 public class GrpcChannelProperties {
 
     public static final GrpcChannelProperties DEFAULT = new GrpcChannelProperties();
@@ -62,11 +66,34 @@ public class GrpcChannelProperties {
      * <li>{@code discovery:/foo-service}</li>
      * <li>{@code discovery:///foo-service}</li>
      * </ul>
+     *
+     * @param address The address to connect to.
+     * @return The address to connect to.
      */
     private URI address = null;
 
     /**
-     * Sets the target address uri.
+     * Sets the target address uri. The target uri must be in the format: {@code schema:[//[authority]][/path]}. If
+     * nothing is configured then the {@link io.grpc.NameResolver.Factory} will decide on the default.
+     *
+     * <p>
+     * <b>Examples</b>
+     * </p>
+     *
+     * <ul>
+     * <li>{@code static://localhost:9090} (refers to exactly one IPv4 or IPv6 address, dependent on the jre
+     * configuration, it does not check whether there is actually someone listening on that network interface)</li>
+     * <li>{@code static://10.0.0.10}</li>
+     * <li>{@code static://10.0.0.10,10.11.12.11}</li>
+     * <li>{@code static://10.0.0.10:9090,10.0.0.11:80,10.0.0.12:1234,[::1]:8080}</li>
+     * <li>{@code dns:/localhost (might refer to the IPv4 or the IPv6 address or both, dependent on the system
+     * configuration, it does not check whether there is actually someone listening on that network interface)}</li>
+     * <li>{@code dns:/example.com}</li>
+     * <li>{@code dns:/example.com:9090}</li>
+     * <li>{@code dns:///example.com:9090}</li>
+     * <li>{@code discovery:/foo-service}</li>
+     * <li>{@code discovery:///foo-service}</li>
+     * </ul>
      *
      * @param uri The string representation of an uri to use as target address.
      */
@@ -74,24 +101,48 @@ public class GrpcChannelProperties {
         this.address = URI.create(uri);
     }
 
+    /**
+     * Removed property.
+     *
+     * @param host Removed.
+     * @deprecated Use {@link #setAddress(String)} instead.
+     */
     @Deprecated
     public void setHost(final String host) {
         throw new UnsupportedOperationException(
                 "Use the 'address' attribute with 'static://host1:port1,...,hostn:portn' instead");
     }
 
+    /**
+     * Removed property.
+     *
+     * @param hosts Removed.
+     * @deprecated Use {@link #setAddress(String)} instead.
+     */
     @Deprecated
     public void setHost(final List<String> hosts) {
         throw new UnsupportedOperationException(
                 "Use the 'address' attribute with 'static://host1:port1,...,hostn:portn' instead");
     }
 
+    /**
+     * Removed property.
+     *
+     * @param port Removed.
+     * @deprecated Use {@link #setAddress(String)} instead.
+     */
     @Deprecated
     public void setPort(final String port) {
         throw new UnsupportedOperationException(
                 "Use the 'address' attribute with 'static://host1:port1,...,hostn:portn' instead");
     }
 
+    /**
+     * Removed property.
+     *
+     * @param ports Removed.
+     * @deprecated Use {@link #setAddress(String)} instead.
+     */
     @Deprecated
     public void setPort(final List<String> ports) {
         throw new UnsupportedOperationException(
@@ -100,25 +151,34 @@ public class GrpcChannelProperties {
 
     /**
      * Setting to enable keepAlive. Default to {@code false}.
+     *
+     * @param enableKeepAlive Whether keep alive should be enabled.
+     * @return True, if keep alive should be enabled. False otherwise.
      */
     private boolean enableKeepAlive = false;
 
     /**
-     * The default delay before we send a keepAlive. Very large values such as 1000 days might disable keepAlives.
-     * Defaults to {@code 60s}. Default unit {@link ChronoUnit#SECONDS SECONDS}.
+     * The default delay before we send a keepAlives. Defaults to {@code 60s}. Default unit {@link ChronoUnit#SECONDS
+     * SECONDS}.
      *
-     * @see #enableKeepAlive
-     * @see NettyChannelBuilder#keepAliveTime(long, TimeUnit)
+     * @see #setEnableKeepAlive(boolean)
+     * @see NettyServerBuilder#keepAliveTime(long, TimeUnit)
+     *
+     * @param keepAliveTime The new default delay before sending keepAlives.
+     * @return The default delay before sending keepAlives.
      */
     @DurationUnit(ChronoUnit.SECONDS)
     private Duration keepAliveTime = Duration.of(60, ChronoUnit.SECONDS);
 
     /**
-     * The default timeout for a keepAlive ping request. Defaults to {@code 20s}. Default unit {@link ChronoUnit#SECONDS
-     * SECONDS}.
+     * The default timeout for a keepAlives ping request. Defaults to {@code 20s}. Default unit
+     * {@link ChronoUnit#SECONDS SECONDS}.
      *
-     * @see #enableKeepAlive
-     * @see NettyChannelBuilder#keepAliveTimeout(long, TimeUnit)
+     * @see #setEnableKeepAlive(boolean)
+     * @see NettyServerBuilder#keepAliveTimeout(long, TimeUnit)
+     *
+     * @param keepAliveTimeout Sets the default timeout for a keepAlives ping request.
+     * @return The default timeout for a keepAlives ping request.
      */
     @DurationUnit(ChronoUnit.SECONDS)
     private Duration keepAliveTimeout = Duration.of(20, ChronoUnit.SECONDS);
@@ -127,15 +187,22 @@ public class GrpcChannelProperties {
      * Sets whether keepAlive will be performed when there are no outstanding RPC on a connection. Defaults to
      * {@code false}.
      *
-     * @see #enableKeepAlive
+     * @see #setEnableKeepAlive(boolean)
      * @see NettyChannelBuilder#keepAliveWithoutCalls(boolean)
+     *
+     * @param keepAliveWithoutCalls whether keepAlive will be performed when there are no outstanding RPC on a
+     *        connection.
+     * @return True, if keepAlives should be performed even when there are no RPCs. False otherwise.
      */
     private boolean keepAliveWithoutCalls = false;
 
     /**
      * The maximum message size in bytes allowed to be received by the channel. If not set ({@code null}) then it will
-     * default to {@link GrpcUtil#DEFAULT_MAX_MESSAGE_SIZE DEFAULT_MAX_MESSAGE_SIZE}. If set to {@code -1} then it will
-     * use {@link Integer#MAX_VALUE} as limit.
+     * default to {@link GrpcUtil#DEFAULT_MAX_MESSAGE_SIZE gRPC's default}. If set to {@code -1} then it will use the
+     * highest possible limit (not recommended).
+     *
+     * @param maxInboundMessageSize The maximum message size.
+     * @return The maximum message size allowed.
      */
     private Integer maxInboundMessageSize = null;
 
@@ -145,11 +212,16 @@ public class GrpcChannelProperties {
      * The negotiation type to use on the connection. Either of {@link NegotiationType#TLS TLS} (recommended),
      * {@link NegotiationType#PLAINTEXT_UPGRADE PLAINTEXT_UPGRADE} or {@link NegotiationType#PLAINTEXT PLAINTEXT}.
      * Defaults to TLS.
+     *
+     * @param negotiationType The negotiation type to use.
+     * @return The negotiation type that the channel will use.
      */
     private NegotiationType negotiationType = NegotiationType.TLS;
 
     /**
      * Security options for transport security.
+     *
+     * @return The security options for transport security.
      */
     private final Security security = new Security();
 
@@ -158,28 +230,49 @@ public class GrpcChannelProperties {
 
         /**
          * Flag that controls whether client can authenticate using certificates. Defaults to {@code false}.
+         *
+         * @param clientAuthEnabled Whether the client can authenticate itself using certificates.
+         * @return True, if the client can authenticate itself using certificates.
          */
         private boolean clientAuthEnabled = false;
 
         /**
-         * Path to SSL certificate chain. Required if {@link #clientAuthEnabled} is true.
+         * Path to SSL certificate chain. Required if {@link #isClientAuthEnabled()} is true.
+         *
+         * @see SslContextBuilder#keyManager(File, File)
+         *
+         * @param certificateChainPath The path to the certificate chain.
+         * @return The path to the certificate chain or null, if security is not enabled.
          */
         private String certificateChainPath = null;
 
         /**
-         * Path to private key. Required if {@link #clientAuthEnabled} is true.
+         * Path to private key. Required if {@link #isClientAuthEnabled} is true.
+         *
+         * @see SslContextBuilder#keyManager(File, File)
+         *
+         * @param privateKeyPath The path to the private key.
+         * @return The path to the private key or null, if security is not enabled.
          */
         private String privateKeyPath = null;
 
         /**
          * Path to the trusted certificate collection. If {@code null} or empty it will use the system's default
-         * collection (Default).
+         * collection (Default). This collection will be used to verify client certificates.
+         *
+         * @see SslContextBuilder#trustManager(File)
+         *
+         * @param trustCertCollectionPath The path to the trusted certificate collection.
+         * @return The path to the trusted certificate collection or null.
          */
         private String trustCertCollectionPath = null;
 
         /**
          * The authority to check for during certificate checks. By default the clients will use the name of the client
          * to check the server certificate's common + alternative names.
+         *
+         * @param authorityOverride The authority to check for in the certificate.
+         * @return The override for the authority to check for or null, there is no override configured.
          */
         private String authorityOverride = null;
 
@@ -188,9 +281,9 @@ public class GrpcChannelProperties {
     /**
      * Gets the maximum message size in bytes allowed to be received by the channel. If not set ({@code null}) then it
      * will default to {@link GrpcUtil#DEFAULT_MAX_MESSAGE_SIZE DEFAULT_MAX_MESSAGE_SIZE}. If set to {@code -1} then it
-     * will use {@link Integer#MAX_VALUE} as limit.
+     * will use the highest possible limit (not recommended).
      *
-     * @return The maximum message size in bytes allowed or null if the default should be used.
+     * @return The maximum message size allowed or null if the default should be used.
      */
     public Integer getMaxInboundMessageSize() {
         if (this.maxInboundMessageSize != null && this.maxInboundMessageSize == -1) {

--- a/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/config/GrpcChannelsProperties.java
+++ b/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/config/GrpcChannelsProperties.java
@@ -34,11 +34,25 @@ import lombok.Data;
  */
 @Data
 @ConfigurationProperties("grpc")
+@SuppressWarnings("javadoc")
 public class GrpcChannelsProperties {
 
+    /**
+     * The configuration mapping for each client.
+     *
+     * @param client The client mappings to use.
+     * @return The client mappings to use.
+     */
     @NestedConfigurationProperty
-    private Map<String, GrpcChannelProperties> client = Maps.newHashMap();
+    private final Map<String, GrpcChannelProperties> client = Maps.newHashMap();
 
+    /**
+     * Gets the properties for the given channel. This will return an instance with default values, if the channel does
+     * not have any configuration.
+     *
+     * @param name The name of the channel to get the properties for.
+     * @return The properties for the given channel name or an instance with default value, if it does not exist.
+     */
     public GrpcChannelProperties getChannel(final String name) {
         return this.client.getOrDefault(name, GrpcChannelProperties.DEFAULT);
     }

--- a/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/autoconfigure/GrpcMetadataConsulConfiguration.java
+++ b/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/autoconfigure/GrpcMetadataConsulConfiguration.java
@@ -31,7 +31,7 @@ import net.devh.boot.grpc.server.cloud.ConsulGrpcRegistrationCustomizer;
 import net.devh.boot.grpc.server.config.GrpcServerProperties;
 
 /**
- * Configuration class that configures the required beans for grpc discovery via Consul.
+ * Configuration class that configures the required beans for gRPC discovery via Consul.
  *
  * @author Michael (yidongnan@gmail.com)
  * @since 5/17/16
@@ -41,6 +41,12 @@ import net.devh.boot.grpc.server.config.GrpcServerProperties;
 @ConditionalOnClass({ConsulDiscoveryProperties.class, ConsulClient.class, GrpcServerProperties.class})
 public class GrpcMetadataConsulConfiguration {
 
+    /**
+     * Creates a bean that registers the gRPC endpoint via consul.
+     *
+     * @param grpcServerProperties The server properties used to fill in the blanks.
+     * @return The newly created consulGrpcRegistrationCustomizer bean.
+     */
     @ConditionalOnMissingBean
     @Bean
     public ConsulRegistrationCustomizer consulGrpcRegistrationCustomizer(


### PR DESCRIPTION
Currently the javadocs for the configuration look very empty:

![before](https://user-images.githubusercontent.com/1579362/52705478-4c5e9900-2f83-11e9-8331-c3027a86c4a2.png)

After delombok:

![after](https://user-images.githubusercontent.com/1579362/52705889-4ae1a080-2f84-11e9-9e43-dab0d993c217.png)


