### PR TITLE
Move Trace configuration to its own file

### DIFF
--- a/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/autoconfigure/GrpcClientAutoConfiguration.java
+++ b/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/autoconfigure/GrpcClientAutoConfiguration.java
@@ -24,15 +24,12 @@ import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
-import org.springframework.cloud.sleuth.autoconfig.TraceAutoConfiguration;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Lazy;
 
-import brave.grpc.GrpcTracing;
 import io.grpc.Attributes;
 import io.grpc.CompressorRegistry;
 import io.grpc.DecompressorRegistry;
@@ -47,14 +44,12 @@ import net.devh.boot.grpc.client.channelfactory.ShadedNettyChannelFactory;
 import net.devh.boot.grpc.client.config.GrpcChannelsProperties;
 import net.devh.boot.grpc.client.inject.GrpcClientBeanPostProcessor;
 import net.devh.boot.grpc.client.interceptor.AnnotationGlobalClientInterceptorConfigurer;
-import net.devh.boot.grpc.client.interceptor.GlobalClientInterceptorConfigurer;
 import net.devh.boot.grpc.client.interceptor.GlobalClientInterceptorRegistry;
 import net.devh.boot.grpc.client.nameresolver.CompositeNameResolverFactory;
 import net.devh.boot.grpc.client.nameresolver.ConfigMappedNameResolverFactory;
 import net.devh.boot.grpc.client.nameresolver.NameResolverConstants;
 import net.devh.boot.grpc.client.nameresolver.StaticNameResolverProvider;
 import net.devh.boot.grpc.common.autoconfigure.GrpcCommonCodecAutoConfiguration;
-import net.devh.boot.grpc.common.autoconfigure.GrpcCommonTraceAutoConfiguration;
 
 /**
  * The auto configuration used by Spring-Boot that contains all beans to create and inject grpc clients into beans.
@@ -181,20 +176,6 @@ public class GrpcClientAutoConfiguration {
             final GlobalClientInterceptorRegistry globalClientInterceptorRegistry,
             final List<GrpcChannelConfigurer> channelConfigurers) {
         return new InProcessChannelFactory(properties, globalClientInterceptorRegistry, channelConfigurers);
-    }
-
-    @Configuration
-    @ConditionalOnProperty(value = "spring.sleuth.grpc.enabled", matchIfMissing = true)
-    @AutoConfigureAfter({TraceAutoConfiguration.class, GrpcCommonTraceAutoConfiguration.class})
-    @ConditionalOnBean(GrpcTracing.class)
-    protected static class TraceClientAutoConfiguration {
-
-        @Bean
-        public GlobalClientInterceptorConfigurer globalTraceClientInterceptorConfigurerAdapter(
-                final GrpcTracing grpcTracing) {
-            return registry -> registry.addClientInterceptors(grpcTracing.newClientInterceptor());
-        }
-
     }
 
 }

--- a/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/autoconfigure/GrpcClientTraceAutoConfiguration.java
+++ b/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/autoconfigure/GrpcClientTraceAutoConfiguration.java
@@ -15,29 +15,28 @@
  * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package net.devh.boot.grpc.common.autoconfigure;
+package net.devh.boot.grpc.client.autoconfigure;
 
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.cloud.sleuth.autoconfig.TraceAutoConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-import brave.Tracing;
 import brave.grpc.GrpcTracing;
+import net.devh.boot.grpc.client.interceptor.GlobalClientInterceptorConfigurer;
+import net.devh.boot.grpc.common.autoconfigure.GrpcCommonTraceAutoConfiguration;
 
 @Configuration
 @ConditionalOnProperty(value = "spring.sleuth.grpc.enabled", matchIfMissing = true)
-@AutoConfigureAfter(TraceAutoConfiguration.class)
-@ConditionalOnClass(value = {Tracing.class, GrpcTracing.class})
-public class GrpcCommonTraceAutoConfiguration {
+@AutoConfigureAfter(GrpcCommonTraceAutoConfiguration.class)
+@ConditionalOnBean(GrpcTracing.class)
+public class GrpcClientTraceAutoConfiguration {
 
     @Bean
-    @ConditionalOnMissingBean
-    public GrpcTracing grpcTracing(final Tracing tracing) {
-        return GrpcTracing.create(tracing);
+    public GlobalClientInterceptorConfigurer globalTraceClientInterceptorConfigurerAdapter(
+            final GrpcTracing grpcTracing) {
+        return registry -> registry.addClientInterceptors(grpcTracing.newClientInterceptor());
     }
 
 }

--- a/grpc-client-spring-boot-autoconfigure/src/main/resources/META-INF/spring.factories
+++ b/grpc-client-spring-boot-autoconfigure/src/main/resources/META-INF/spring.factories
@@ -3,4 +3,5 @@ org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
 net.devh.boot.grpc.client.autoconfigure.GrpcClientAutoConfiguration,\
 net.devh.boot.grpc.client.autoconfigure.GrpcClientMetricAutoConfiguration,\
 net.devh.boot.grpc.client.autoconfigure.GrpcClientSecurityAutoConfiguration,\
+net.devh.boot.grpc.client.autoconfigure.GrpcClientTraceAutoConfiguration,\
 net.devh.boot.grpc.client.autoconfigure.GrpcDiscoveryClientAutoConfiguration

--- a/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/autoconfigure/GrpcServerAutoConfiguration.java
+++ b/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/autoconfigure/GrpcServerAutoConfiguration.java
@@ -24,23 +24,18 @@ import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
-import org.springframework.cloud.sleuth.autoconfig.TraceAutoConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 
-import brave.grpc.GrpcTracing;
 import io.grpc.CompressorRegistry;
 import io.grpc.DecompressorRegistry;
 import io.grpc.Server;
 import io.grpc.services.HealthStatusManager;
 import net.devh.boot.grpc.common.autoconfigure.GrpcCommonCodecAutoConfiguration;
-import net.devh.boot.grpc.common.autoconfigure.GrpcCommonTraceAutoConfiguration;
 import net.devh.boot.grpc.server.config.GrpcServerProperties;
 import net.devh.boot.grpc.server.interceptor.AnnotationGlobalServerInterceptorConfigurer;
-import net.devh.boot.grpc.server.interceptor.GlobalServerInterceptorConfigurer;
 import net.devh.boot.grpc.server.interceptor.GlobalServerInterceptorRegistry;
 import net.devh.boot.grpc.server.security.GrpcSecurityAutoConfiguration;
 import net.devh.boot.grpc.server.serverfactory.GrpcServerConfigurer;
@@ -142,20 +137,6 @@ public class GrpcServerAutoConfiguration {
     @Bean
     public GrpcServerLifecycle grpcServerLifecycle(final GrpcServerFactory factory) {
         return new GrpcServerLifecycle(factory);
-    }
-
-    @Configuration
-    @ConditionalOnProperty(value = "spring.sleuth.grpc.enabled", matchIfMissing = true)
-    @AutoConfigureAfter({TraceAutoConfiguration.class, GrpcCommonTraceAutoConfiguration.class})
-    @ConditionalOnBean(GrpcTracing.class)
-    protected static class TraceServerAutoConfiguration {
-
-        @Bean
-        public GlobalServerInterceptorConfigurer globalTraceServerInterceptorConfigurerAdapter(
-                final GrpcTracing grpcTracing) {
-            return registry -> registry.addServerInterceptors(grpcTracing.newServerInterceptor());
-        }
-
     }
 
 }

--- a/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/autoconfigure/GrpcServerTraceAutoConfiguration.java
+++ b/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/autoconfigure/GrpcServerTraceAutoConfiguration.java
@@ -15,29 +15,28 @@
  * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package net.devh.boot.grpc.common.autoconfigure;
+package net.devh.boot.grpc.server.autoconfigure;
 
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.cloud.sleuth.autoconfig.TraceAutoConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-import brave.Tracing;
 import brave.grpc.GrpcTracing;
+import net.devh.boot.grpc.common.autoconfigure.GrpcCommonTraceAutoConfiguration;
+import net.devh.boot.grpc.server.interceptor.GlobalServerInterceptorConfigurer;
 
 @Configuration
 @ConditionalOnProperty(value = "spring.sleuth.grpc.enabled", matchIfMissing = true)
-@AutoConfigureAfter(TraceAutoConfiguration.class)
-@ConditionalOnClass(value = {Tracing.class, GrpcTracing.class})
-public class GrpcCommonTraceAutoConfiguration {
+@AutoConfigureAfter(GrpcCommonTraceAutoConfiguration.class)
+@ConditionalOnBean(GrpcTracing.class)
+public class GrpcServerTraceAutoConfiguration {
 
     @Bean
-    @ConditionalOnMissingBean
-    public GrpcTracing grpcTracing(final Tracing tracing) {
-        return GrpcTracing.create(tracing);
+    public GlobalServerInterceptorConfigurer globalTraceServerInterceptorConfigurerAdapter(
+            final GrpcTracing grpcTracing) {
+        return registry -> registry.addServerInterceptors(grpcTracing.newServerInterceptor());
     }
 
 }

--- a/grpc-server-spring-boot-autoconfigure/src/main/resources/META-INF/spring.factories
+++ b/grpc-server-spring-boot-autoconfigure/src/main/resources/META-INF/spring.factories
@@ -3,4 +3,5 @@ org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
 net.devh.boot.grpc.server.autoconfigure.GrpcMetadataConsulConfiguration,\
 net.devh.boot.grpc.server.autoconfigure.GrpcMetadataEurekaConfiguration,\
 net.devh.boot.grpc.server.autoconfigure.GrpcServerAutoConfiguration,\
-net.devh.boot.grpc.server.autoconfigure.GrpcServerMetricAutoConfiguration
+net.devh.boot.grpc.server.autoconfigure.GrpcServerMetricAutoConfiguration,\
+net.devh.boot.grpc.server.autoconfigure.GrpcServerTraceAutoConfiguration


### PR DESCRIPTION
**Fixes #194**

The ordering annotations on nested auto configuration classes will be ignored, thus the might be executed in the wrong order. This PR solves the issue by moving all auto configuration classes to their own classes.

Thanks @ramses-gomez for reporting this issue.