### PR TITLE
Add support for global client properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,10 +342,15 @@ Read more about these and other natively supported `NameResolverProviders` in th
 #### Example-Properties
 
 ````properties
+grpc.client.GLOBAL.enableKeepAlive=true
+
 grpc.client.(gRPC server name).address=static://localhost:9090
 # Or
 grpc.client.myName.address=static://localhost:9090
 ````
+
+`GLOBAL` is a special constant that will be used as a fallback for configuration options that are not configured per client.
+Order of precedence: Per Client > `GLOBAL` > defaults
 
 #### Customizing a Client
 

--- a/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/channelfactory/InProcessChannelFactory.java
+++ b/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/channelfactory/InProcessChannelFactory.java
@@ -64,4 +64,10 @@ public class InProcessChannelFactory extends AbstractChannelFactory<InProcessCha
         return InProcessChannelBuilder.forName(name);
     }
 
+    @Override
+    protected void configureSecurity(final InProcessChannelBuilder builder, final String name) {
+        // No need to configure security as we are in process only.
+        // There is also no need to throw exceptions if transport security is configured.
+    }
+
 }

--- a/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/config/GrpcChannelProperties.java
+++ b/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/config/GrpcChannelProperties.java
@@ -26,55 +26,59 @@ import java.util.concurrent.TimeUnit;
 
 import org.springframework.boot.convert.DurationUnit;
 
+import io.grpc.ManagedChannelBuilder;
+import io.grpc.NameResolverProvider;
+import io.grpc.internal.DnsNameResolverProvider;
 import io.grpc.internal.GrpcUtil;
 import io.grpc.netty.shaded.io.grpc.netty.NettyChannelBuilder;
 import io.grpc.netty.shaded.io.grpc.netty.NettyServerBuilder;
 import io.grpc.netty.shaded.io.netty.handler.ssl.SslContextBuilder;
-import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 /**
  * The channel properties for a single named gRPC channel or service reference.
  *
  * @author Michael (yidongnan@gmail.com)
+ * @author Daniel Theuke (daniel.theuke@heuboe.de)
  * @since 5/17/16
  */
-@Data
-@SuppressWarnings("javadoc")
+@ToString
+@EqualsAndHashCode
 public class GrpcChannelProperties {
 
-    public static final GrpcChannelProperties DEFAULT = new GrpcChannelProperties();
+    // --------------------------------------------------
+    // Target Address
+    // --------------------------------------------------
 
-    /**
-     * The target uri in the format: {@code schema:[//[authority]][/path]}. If nothing is configured then the
-     * {@link io.grpc.NameResolver.Factory} will decide on the default.
-     *
-     * <p>
-     * <b>Examples</b>
-     * </p>
-     *
-     * <ul>
-     * <li>{@code static://localhost:9090} (refers to exactly one IPv4 or IPv6 address, dependent on the jre
-     * configuration, it does not check whether there is actually someone listening on that network interface)</li>
-     * <li>{@code static://10.0.0.10}</li>
-     * <li>{@code static://10.0.0.10,10.11.12.11}</li>
-     * <li>{@code static://10.0.0.10:9090,10.0.0.11:80,10.0.0.12:1234,[::1]:8080}</li>
-     * <li>{@code dns:/localhost (might refer to the IPv4 or the IPv6 address or both, dependent on the system
-     * configuration, it does not check whether there is actually someone listening on that network interface)}</li>
-     * <li>{@code dns:/example.com}</li>
-     * <li>{@code dns:/example.com:9090}</li>
-     * <li>{@code dns:///example.com:9090}</li>
-     * <li>{@code discovery:/foo-service}</li>
-     * <li>{@code discovery:///foo-service}</li>
-     * </ul>
-     *
-     * @param address The address to connect to.
-     * @return The address to connect to.
-     */
     private URI address = null;
 
     /**
-     * Sets the target address uri. The target uri must be in the format: {@code schema:[//[authority]][/path]}. If
-     * nothing is configured then the {@link io.grpc.NameResolver.Factory} will decide on the default.
+     * Gets the target address uri.
+     *
+     * @return The address to connect to or null
+     * @see #setAddress(String)
+     */
+    public URI getAddress() {
+        return this.address;
+    }
+
+    /**
+     * Set the address uri for the channel. If nothing is configured then the {@link io.grpc.NameResolver.Factory} will
+     * decide on the default.
+     *
+     * @param address The address to use for the channel or null to default to the fallback.
+     *
+     * @see #setAddress(String)
+     */
+    public void setAddress(final URI address) {
+        this.address = address;
+    }
+
+    /**
+     * Sets the target address uri for the channel. The target uri must be in the format:
+     * {@code schema:[//[authority]][/path]}. If nothing is configured then the {@link io.grpc.NameResolver.Factory}
+     * will decide on the default.
      *
      * <p>
      * <b>Examples</b>
@@ -95,10 +99,22 @@ public class GrpcChannelProperties {
      * <li>{@code discovery:///foo-service}</li>
      * </ul>
      *
-     * @param uri The string representation of an uri to use as target address.
+     * <p>
+     * <b>Note:</b> It is possible to use dns based service discovery. The address {@code dns:/example.com} will check
+     * the DNS for {@code SVC} entries with the key {@code _grpclb._tcp.example.com}. See also
+     * {@link DnsNameResolverProvider}. E.g. in Kubernetes, if you define a service with a port spec called
+     * {@code grpclb} and configure the channel address as {@code <service>.<namespace>.svc.cluster.local}, then the
+     * DNS-resolver will pickup all available endpoints (including the correct port). Must be enable with:
+     * {@code -Dio.grpc.internal.DnsNameResolverProvider.enable_grpclb=true}.
+     * </p>
+     *
+     * @param address The string representation of an uri to use as target address or null to use a fallback.
+     *
+     * @see <a href="https://github.com/grpc/grpc/blob/master/doc/naming.md">gRPC Name Resolution</a>
+     * @see NameResolverProvider
      */
-    public void setAddress(final String uri) {
-        this.address = URI.create(uri);
+    public void setAddress(final String address) {
+        this.address = address == null ? null : URI.create(address);
     }
 
     /**
@@ -149,147 +165,433 @@ public class GrpcChannelProperties {
                 "Use the 'address' attribute with 'static://host1:port1,...,hostn:portn' instead");
     }
 
+    // --------------------------------------------------
+    // KeepAlive
+    // --------------------------------------------------
+
+    private Boolean enableKeepAlive;
+    private static final boolean DEFAULT_ENABLE_KEEP_ALIVE = false;
+
     /**
-     * Setting to enable keepAlive. Default to {@code false}.
+     * Gets whether keepAlive is enabled.
      *
-     * @param enableKeepAlive Whether keep alive should be enabled.
      * @return True, if keep alive should be enabled. False otherwise.
+     *
+     * @see #setEnableKeepAlive(Boolean)
      */
-    private boolean enableKeepAlive = false;
+    public boolean isEnableKeepAlive() {
+        return this.enableKeepAlive == null ? DEFAULT_ENABLE_KEEP_ALIVE : this.enableKeepAlive;
+    }
+
+    /**
+     * Sets whether keepAlive should be enabled. Defaults to false.
+     *
+     * @param enableKeepAlive True, to enable. False, to disable. Null, to use the fallback.
+     */
+    public void setEnableKeepAlive(final Boolean enableKeepAlive) {
+        this.enableKeepAlive = enableKeepAlive;
+    }
+
+    // --------------------------------------------------
+
+    @DurationUnit(ChronoUnit.SECONDS)
+    private Duration keepAliveTime;
+    private static final Duration DEFAULT_KEEP_ALIVE_TIME = Duration.of(60, ChronoUnit.SECONDS);
+
+    /**
+     * Gets the default delay before we send a keepAlive.
+     *
+     * @return The default delay before sending keepAlives.
+     *
+     * @see #setKeepAliveTime(Duration)
+     */
+    public Duration getKeepAliveTime() {
+        return this.keepAliveTime == null ? DEFAULT_KEEP_ALIVE_TIME : this.keepAliveTime;
+    }
 
     /**
      * The default delay before we send a keepAlives. Defaults to {@code 60s}. Default unit {@link ChronoUnit#SECONDS
-     * SECONDS}.
+     * SECONDS}. Please note that shorter intervals increase the network burden for the server.
      *
-     * @see #setEnableKeepAlive(boolean)
+     * @param keepAliveTime The new default delay before sending keepAlives, or null to use the fallback.
+     *
+     * @see #setEnableKeepAlive(Boolean)
      * @see NettyServerBuilder#keepAliveTime(long, TimeUnit)
-     *
-     * @param keepAliveTime The new default delay before sending keepAlives.
-     * @return The default delay before sending keepAlives.
      */
+    public void setKeepAliveTime(final Duration keepAliveTime) {
+        this.keepAliveTime = keepAliveTime;
+    }
+
+    // --------------------------------------------------
+
     @DurationUnit(ChronoUnit.SECONDS)
-    private Duration keepAliveTime = Duration.of(60, ChronoUnit.SECONDS);
+    private Duration keepAliveTimeout;
+    private static final Duration DEFAULT_KEEP_ALIVE_TIMEOUT = Duration.of(20, ChronoUnit.SECONDS);
+
+    /**
+     * The default timeout for a keepAlives ping request.
+     *
+     * @return The default timeout for a keepAlives ping request.
+     *
+     * @see #setKeepAliveTimeout(Duration)
+     */
+    public Duration getKeepAliveTimeout() {
+        return this.keepAliveTimeout == null ? DEFAULT_KEEP_ALIVE_TIMEOUT : this.keepAliveTimeout;
+    }
 
     /**
      * The default timeout for a keepAlives ping request. Defaults to {@code 20s}. Default unit
      * {@link ChronoUnit#SECONDS SECONDS}.
      *
-     * @see #setEnableKeepAlive(boolean)
-     * @see NettyServerBuilder#keepAliveTimeout(long, TimeUnit)
+     * @param keepAliveTimeout The default timeout for a keepAlives ping request.
      *
-     * @param keepAliveTimeout Sets the default timeout for a keepAlives ping request.
-     * @return The default timeout for a keepAlives ping request.
+     * @see #setEnableKeepAlive(Boolean)
+     * @see NettyServerBuilder#keepAliveTimeout(long, TimeUnit)
      */
-    @DurationUnit(ChronoUnit.SECONDS)
-    private Duration keepAliveTimeout = Duration.of(20, ChronoUnit.SECONDS);
+    public void setKeepAliveTimeout(final Duration keepAliveTimeout) {
+        this.keepAliveTimeout = keepAliveTimeout;
+    }
+
+    // --------------------------------------------------
+
+    private Boolean keepAliveWithoutCalls;
+    private static final boolean DEFAULT_KEEP_ALIVE_WITHOUT_CALLS = false;
+
+    /**
+     * Gets whether keepAlive will be performed when there are no outstanding RPC on a connection.
+     *
+     * @return True, if keepAlives should be performed even when there are no RPCs. False otherwise.
+     *
+     * @see #setKeepAliveWithoutCalls(Boolean)
+     */
+    public boolean isKeepAliveWithoutCalls() {
+        return this.keepAliveWithoutCalls == null ? DEFAULT_KEEP_ALIVE_WITHOUT_CALLS : this.keepAliveWithoutCalls;
+    }
 
     /**
      * Sets whether keepAlive will be performed when there are no outstanding RPC on a connection. Defaults to
      * {@code false}.
      *
-     * @see #setEnableKeepAlive(boolean)
-     * @see NettyChannelBuilder#keepAliveWithoutCalls(boolean)
-     *
      * @param keepAliveWithoutCalls whether keepAlive will be performed when there are no outstanding RPC on a
      *        connection.
-     * @return True, if keepAlives should be performed even when there are no RPCs. False otherwise.
-     */
-    private boolean keepAliveWithoutCalls = false;
-
-    /**
-     * The maximum message size in bytes allowed to be received by the channel. If not set ({@code null}) then it will
-     * default to {@link GrpcUtil#DEFAULT_MAX_MESSAGE_SIZE gRPC's default}. If set to {@code -1} then it will use the
-     * highest possible limit (not recommended).
      *
-     * @param maxInboundMessageSize The maximum message size.
-     * @return The maximum message size allowed.
+     * @see #setEnableKeepAlive(Boolean)
+     * @see NettyChannelBuilder#keepAliveWithoutCalls(boolean)
      */
-    private Integer maxInboundMessageSize = null;
-
-    private boolean fullStreamDecompression = false;
-
-    /**
-     * The negotiation type to use on the connection. Either of {@link NegotiationType#TLS TLS} (recommended),
-     * {@link NegotiationType#PLAINTEXT_UPGRADE PLAINTEXT_UPGRADE} or {@link NegotiationType#PLAINTEXT PLAINTEXT}.
-     * Defaults to TLS.
-     *
-     * @param negotiationType The negotiation type to use.
-     * @return The negotiation type that the channel will use.
-     */
-    private NegotiationType negotiationType = NegotiationType.TLS;
-
-    /**
-     * Security options for transport security.
-     *
-     * @return The security options for transport security.
-     */
-    private final Security security = new Security();
-
-    @Data
-    public static class Security {
-
-        /**
-         * Flag that controls whether client can authenticate using certificates. Defaults to {@code false}.
-         *
-         * @param clientAuthEnabled Whether the client can authenticate itself using certificates.
-         * @return True, if the client can authenticate itself using certificates.
-         */
-        private boolean clientAuthEnabled = false;
-
-        /**
-         * Path to SSL certificate chain. Required if {@link #isClientAuthEnabled()} is true.
-         *
-         * @see SslContextBuilder#keyManager(File, File)
-         *
-         * @param certificateChainPath The path to the certificate chain.
-         * @return The path to the certificate chain or null, if security is not enabled.
-         */
-        private String certificateChainPath = null;
-
-        /**
-         * Path to private key. Required if {@link #isClientAuthEnabled} is true.
-         *
-         * @see SslContextBuilder#keyManager(File, File)
-         *
-         * @param privateKeyPath The path to the private key.
-         * @return The path to the private key or null, if security is not enabled.
-         */
-        private String privateKeyPath = null;
-
-        /**
-         * Path to the trusted certificate collection. If {@code null} or empty it will use the system's default
-         * collection (Default). This collection will be used to verify client certificates.
-         *
-         * @see SslContextBuilder#trustManager(File)
-         *
-         * @param trustCertCollectionPath The path to the trusted certificate collection.
-         * @return The path to the trusted certificate collection or null.
-         */
-        private String trustCertCollectionPath = null;
-
-        /**
-         * The authority to check for during certificate checks. By default the clients will use the name of the client
-         * to check the server certificate's common + alternative names.
-         *
-         * @param authorityOverride The authority to check for in the certificate.
-         * @return The override for the authority to check for or null, there is no override configured.
-         */
-        private String authorityOverride = null;
-
+    public void setKeepAliveWithoutCalls(final Boolean keepAliveWithoutCalls) {
+        this.keepAliveWithoutCalls = keepAliveWithoutCalls;
     }
+
+    // --------------------------------------------------
+    // Message Transfer
+    // --------------------------------------------------
+
+    private Integer maxInboundMessageSize = null;
 
     /**
      * Gets the maximum message size in bytes allowed to be received by the channel. If not set ({@code null}) then it
-     * will default to {@link GrpcUtil#DEFAULT_MAX_MESSAGE_SIZE DEFAULT_MAX_MESSAGE_SIZE}. If set to {@code -1} then it
-     * will use the highest possible limit (not recommended).
+     * {@link GrpcUtil#DEFAULT_MAX_MESSAGE_SIZE gRPC's default} should be used.
      *
      * @return The maximum message size allowed or null if the default should be used.
+     *
+     * @see #setMaxInboundMessageSize(Integer)
      */
     public Integer getMaxInboundMessageSize() {
-        if (this.maxInboundMessageSize != null && this.maxInboundMessageSize == -1) {
-            this.maxInboundMessageSize = Integer.MAX_VALUE;
-        }
         return this.maxInboundMessageSize;
+    }
+
+    /**
+     * Sets the maximum message size in bytes allowed to be received by the channel. If not set ({@code null}) then it
+     * will default to {@link GrpcUtil#DEFAULT_MAX_MESSAGE_SIZE gRPC's default}. If set to {@code -1} then it will use
+     * the highest possible limit (not recommended).
+     *
+     * @param maxInboundMessageSize The new maximum size in bytes allowed for incoming messages. {@code -1} for max
+     *        possible. Null to use the gRPC's default.
+     *
+     * @see ManagedChannelBuilder#maxInboundMessageSize(int)
+     */
+    public void setMaxInboundMessageSize(final Integer maxInboundMessageSize) {
+        if (maxInboundMessageSize == null || maxInboundMessageSize >= 0) {
+            this.maxInboundMessageSize = maxInboundMessageSize;
+        } else if (maxInboundMessageSize == -1) {
+            this.maxInboundMessageSize = Integer.MAX_VALUE;
+        } else {
+            throw new IllegalArgumentException("Unsupported maxInboundMessageSize: " + maxInboundMessageSize);
+        }
+    }
+
+    // --------------------------------------------------
+
+    private Boolean fullStreamDecompression;
+    private static final boolean DEFAULT_FULL_STREAM_DECOMPRESSION = false;
+
+    /**
+     * Gets whether full-stream decompression of inbound streams should be enabled.
+     *
+     * @return True, if full-stream decompression of inbound streams should be enabled. False otherwise.
+     *
+     * @see #setFullStreamDecompression(Boolean)
+     */
+    public boolean isFullStreamDecompression() {
+        return this.fullStreamDecompression == null ? DEFAULT_FULL_STREAM_DECOMPRESSION : this.fullStreamDecompression;
+    }
+
+    /**
+     * Sets whether full-stream decompression of inbound streams should be enabled. This will cause the channel's
+     * outbound headers to advertise support for GZIP compressed streams, and gRPC servers which support the feature may
+     * respond with a GZIP compressed stream.
+     *
+     * @param fullStreamDecompression Whether full stream decompression should be enabled or null to use the fallback.
+     *
+     * @see ManagedChannelBuilder#enableFullStreamDecompression()
+     */
+    public void setFullStreamDecompression(final Boolean fullStreamDecompression) {
+        this.fullStreamDecompression = fullStreamDecompression;
+    }
+
+    // --------------------------------------------------
+
+    private NegotiationType negotiationType;
+    private static final NegotiationType DEFAULT_NEGOTIATION_TYPE = NegotiationType.TLS;
+
+    /**
+     * Gets the negotiation type to use on the connection.
+     *
+     * @return The negotiation type that the channel will use.
+     *
+     * @see #setNegotiationType(NegotiationType)
+     */
+    public NegotiationType getNegotiationType() {
+        return this.negotiationType == null ? DEFAULT_NEGOTIATION_TYPE : this.negotiationType;
+    }
+
+    /**
+     * Sets the negotiation type to use on the connection. Either of {@link NegotiationType#TLS TLS} (recommended),
+     * {@link NegotiationType#PLAINTEXT_UPGRADE PLAINTEXT_UPGRADE} or {@link NegotiationType#PLAINTEXT PLAINTEXT}.
+     * Defaults to TLS.
+     *
+     * @param negotiationType The negotiation type to use or null to use the fallback.
+     */
+    public void setNegotiationType(final NegotiationType negotiationType) {
+        this.negotiationType = negotiationType;
+    }
+
+    // --------------------------------------------------
+
+    private final Security security = new Security();
+
+    /**
+     * Gets the options for transport security.
+     *
+     * @return The options for transport security.
+     */
+    public Security getSecurity() {
+        return this.security;
+    }
+
+    /**
+     * Copies the defaults from the given configuration. Values are considered "default" if they are null. Please note
+     * that the getters might return fallback values instead.
+     *
+     * @param config The config to copy the defaults from.
+     */
+    public void copyDefaultsFrom(final GrpcChannelProperties config) {
+        if (this == config) {
+            return;
+        }
+        if (this.address == null) {
+            this.address = config.address;
+        }
+        if (this.enableKeepAlive == null) {
+            this.enableKeepAlive = config.enableKeepAlive;
+        }
+        if (this.keepAliveTime == null) {
+            this.keepAliveTime = config.keepAliveTime;
+        }
+        if (this.keepAliveTimeout == null) {
+            this.keepAliveTimeout = config.keepAliveTimeout;
+        }
+        if (this.keepAliveWithoutCalls == null) {
+            this.keepAliveWithoutCalls = config.keepAliveWithoutCalls;
+        }
+        if (this.maxInboundMessageSize == null) {
+            this.maxInboundMessageSize = config.maxInboundMessageSize;
+        }
+        if (this.fullStreamDecompression == null) {
+            this.fullStreamDecompression = config.fullStreamDecompression;
+        }
+        if (this.negotiationType == null) {
+            this.negotiationType = config.negotiationType;
+        }
+        this.security.copyDefaultsFrom(config.security);
+    }
+
+    /**
+     * A container with options for the channel's transport security.
+     */
+    @ToString
+    @EqualsAndHashCode
+    public static class Security {
+
+        private Boolean clientAuthEnabled;
+        private static final boolean DEFAULT_CLIENT_AUTH_ENABLED = false;
+
+        /**
+         * Gets whether client can authenticate using certificates.
+         *
+         * @return True, if the client can authenticate itself using certificates.
+         *
+         * @see #setClientAuthEnabled(Boolean)
+         */
+        public boolean isClientAuthEnabled() {
+            return this.clientAuthEnabled == null ? DEFAULT_CLIENT_AUTH_ENABLED : this.clientAuthEnabled;
+        }
+
+        /**
+         * Set whether client can authenticate using certificates. Defaults to {@code false}.
+         *
+         * @param clientAuthEnabled Whether the client can authenticate itself using certificates.
+         */
+        public void setClientAuthEnabled(final Boolean clientAuthEnabled) {
+            this.clientAuthEnabled = clientAuthEnabled;
+        }
+
+        // --------------------------------------------------
+
+        private String certificateChainPath = null;
+
+        /**
+         * Gets the path to SSL certificate chain.
+         *
+         * @return The path to the certificate chain or null, if security is not enabled.
+         * @see #setCertificateChainPath(String)
+         */
+        public String getCertificateChainPath() {
+            return this.certificateChainPath;
+        }
+
+        /**
+         * Sets the path to SSL certificate chain. Required if {@link #isClientAuthEnabled()} is true. The linked
+         * certificate will be used to authenticate the client.
+         *
+         * @param certificateChainPath The path to the certificate chain.
+         *
+         * @see SslContextBuilder#keyManager(File, File)
+         */
+        public void setCertificateChainPath(final String certificateChainPath) {
+            this.certificateChainPath = certificateChainPath;
+        }
+
+        // --------------------------------------------------
+
+        private String privateKeyPath = null;
+
+        /**
+         * Gets the path to the private key.
+         *
+         * @return The path to the private key or null, if security is not enabled.
+         *
+         * @see #setPrivateKeyPath(String)
+         */
+        public String getPrivateKeyPath() {
+            return this.privateKeyPath;
+        }
+
+        /**
+         * Sets the path to the private key. Required if {@link #isClientAuthEnabled} is true.
+         *
+         * @param privateKeyPath The path to the private key.
+         *
+         * @see SslContextBuilder#keyManager(File, File)
+         */
+        public void setPrivateKeyPath(final String privateKeyPath) {
+            this.privateKeyPath = privateKeyPath;
+        }
+
+        // --------------------------------------------------
+
+        private String trustCertCollectionPath = null;
+
+        /**
+         * Gets the path to the trusted certificate collection. If {@code null} or empty the use the system's default
+         * collection should be used.
+         *
+         * @return The path to the trusted certificate collection or null.
+         *
+         * @see #setTrustCertCollectionPath(String)
+         */
+        public String getTrustCertCollectionPath() {
+            return this.trustCertCollectionPath;
+        }
+
+        /**
+         * Sets the path to the trusted certificate collection. If not set ({@code null}) it will use the system's
+         * default collection (Default). This collection will be used to verify server certificates.
+         *
+         * @param trustCertCollectionPath The path to the trusted certificate collection.
+         *
+         * @see SslContextBuilder#trustManager(File)
+         */
+        public void setTrustCertCollectionPath(final String trustCertCollectionPath) {
+            this.trustCertCollectionPath = trustCertCollectionPath;
+        }
+
+        // --------------------------------------------------
+
+        private String authorityOverride = null;
+
+        /**
+         * Gets the authority to check for during server certificate verification.
+         *
+         * @return The override for the authority to check for or null, there is no override configured.
+         *
+         * @see #setAuthorityOverride(String)
+         */
+        public String getAuthorityOverride() {
+            return this.authorityOverride;
+        }
+
+        /**
+         * Sets the authority to check for during server certificate verification. By default the clients will use the
+         * name of the client to check the server certificate's common + alternative names.
+         *
+         * @param authorityOverride The authority to check for in the certificate, or null to use the default checks.
+         *
+         * @see NettyChannelBuilder#overrideAuthority(String)
+         */
+        public void setAuthorityOverride(final String authorityOverride) {
+            this.authorityOverride = authorityOverride;
+        }
+
+        // --------------------------------------------------
+
+        /**
+         * Copies the defaults from the given configuration. Values are considered "default" if they are null. Please
+         * note that the getters might return fallback values instead.
+         *
+         * @param config The config to copy the defaults from.
+         */
+        public void copyDefaultsFrom(final Security config) {
+            if (this == config) {
+                return;
+            }
+            if (this.clientAuthEnabled == null) {
+                this.clientAuthEnabled = config.clientAuthEnabled;
+            }
+            if (this.certificateChainPath == null) {
+                this.certificateChainPath = config.certificateChainPath;
+            }
+            if (this.privateKeyPath == null) {
+                this.privateKeyPath = config.privateKeyPath;
+            }
+            if (this.trustCertCollectionPath == null) {
+                this.trustCertCollectionPath = config.trustCertCollectionPath;
+            }
+            if (this.authorityOverride == null) {
+                this.authorityOverride = config.authorityOverride;
+            }
+        }
+
     }
 
 }

--- a/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/config/GrpcChannelsProperties.java
+++ b/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/config/GrpcChannelsProperties.java
@@ -21,7 +21,6 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
@@ -46,7 +45,6 @@ public class GrpcChannelsProperties {
      */
     public static final String GLOBAL_PROPERTIES_KEY = "GLOBAL";
 
-    @NestedConfigurationProperty
     private final Map<String, GrpcChannelProperties> client = new ConcurrentHashMap<>();;
 
     /**

--- a/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/config/GrpcChannelsProperties.java
+++ b/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/config/GrpcChannelsProperties.java
@@ -18,43 +18,80 @@
 package net.devh.boot.grpc.client.config;
 
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
-import com.google.common.collect.Maps;
-
-import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 /**
- * The container for named channel properties.
+ * A container for named channel properties. Each channel has its own configuration. If you try to get a channel that
+ * does not have a configuration yet, it will be created. If something is not configured in the channel properties, it
+ * will be copied from the global config during the first retrieval. If some property is configured in neither the
+ * channel properties nor the global properties then a default value will be used.
  *
  * @author Michael (yidongnan@gmail.com)
+ * @author Daniel Theuke (daniel.theuke@heuboe.de)
  * @since 5/17/16
  */
-@Data
+@ToString
+@EqualsAndHashCode
 @ConfigurationProperties("grpc")
-@SuppressWarnings("javadoc")
 public class GrpcChannelsProperties {
 
     /**
-     * The configuration mapping for each client.
-     *
-     * @param client The client mappings to use.
-     * @return The client mappings to use.
+     * The key that will be used for the {@code GLOBAL} properties.
      */
+    public static final String GLOBAL_PROPERTIES_KEY = "GLOBAL";
+
     @NestedConfigurationProperty
-    private final Map<String, GrpcChannelProperties> client = Maps.newHashMap();
+    private final Map<String, GrpcChannelProperties> client = new ConcurrentHashMap<>();;
 
     /**
-     * Gets the properties for the given channel. This will return an instance with default values, if the channel does
-     * not have any configuration.
+     * Gets the configuration mapping for each client.
+     *
+     * @return The client configuration mappings.
+     */
+    public final Map<String, GrpcChannelProperties> getClient() {
+        return this.client;
+    }
+
+    /**
+     * Gets the properties for the given channel. If the properties for the specified channel name do not yet exist,
+     * they are created automatically. Before the instance is returned, the unset values are filled with values from the
+     * global properties.
      *
      * @param name The name of the channel to get the properties for.
-     * @return The properties for the given channel name or an instance with default value, if it does not exist.
+     * @return The properties for the given channel name.
      */
     public GrpcChannelProperties getChannel(final String name) {
-        return this.client.getOrDefault(name, GrpcChannelProperties.DEFAULT);
+        final GrpcChannelProperties properties = getRawChannel(name);
+        properties.copyDefaultsFrom(getGlobalChannel());
+        return properties;
+    }
+
+    /**
+     * Gets the global channel properties. Global properties are used, if the channel properties don't overwrite them.
+     * If neither the global nor the per client properties are set then default values will be used.
+     *
+     * @return The global channel properties.
+     */
+    public final GrpcChannelProperties getGlobalChannel() {
+        // This cannot be moved to its own field,
+        // as Spring replaces the instance in the map and inconsistencies would occur.
+        return getRawChannel(GLOBAL_PROPERTIES_KEY);
+    }
+
+    /**
+     * Gets or creates the channel properties for the given client.
+     *
+     * @param name The name of the channel to get the properties for.
+     * @return The properties for the given channel name.
+     */
+    private GrpcChannelProperties getRawChannel(final String name) {
+        return this.client.computeIfAbsent(name, key -> new GrpcChannelProperties());
     }
 
 }

--- a/grpc-client-spring-boot-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/grpc-client-spring-boot-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -32,7 +32,7 @@
 			"name": "grpc.client.GLOBAL.address",
 			"type": "java.net.URI",
 			"sourceType": "net.devh.boot.grpc.client.config.GrpcChannelProperties",
-			"description": "Sets the target address uri for the channel.\nThe target uri must be in the format: schema:[\/\/[authority]][\/path].\nIf nothing is configured then the io.grpc.NameResolver.Factory will decide on the default.\nExamples:\n\t\"static:\/\/10.0.0.10:9090,10.11.12.11:9091\",\n\t\"dns:\/example.com:9090\",\n\t\"discovery:\/foo-service\""
+			"description": "The target address uri for the channel.\nThe target uri must be in the format: schema:[\/\/[authority]][\/path].\nIf nothing is configured then the io.grpc.NameResolver.Factory will decide on the default.\nExamples:\n\t\"static:\/\/10.0.0.10:9090,10.11.12.11:9091\",\n\t\"dns:\/example.com:9090\",\n\t\"discovery:\/foo-service\""
 		},
 		{
 			"name": "grpc.client.GLOBAL.enable-keep-alive",
@@ -111,7 +111,7 @@
 			"name": "grpc.client.GLOBAL.security.authority-override",
 			"type": "java.lang.String",
 			"sourceType": "net.devh.boot.grpc.client.config.GrpcChannelProperties$Security",
-			"description": "Sets the authority to check for during server certificate verification. By default the clients will use the name of the client to check the server certificate's common + alternative names."
+			"description": "The authority to check for during server certificate verification. By default the clients will use the name of the client to check the server certificate's common + alternative names."
 		}
 	]
 }

--- a/grpc-client-spring-boot-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/grpc-client-spring-boot-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -1,0 +1,117 @@
+{
+	"groups": [
+		{
+			"name": "grpc",
+			"type": "net.devh.boot.grpc.client.config.GrpcChannelsProperties",
+			"sourceType": "net.devh.boot.grpc.client.config.GrpcChannelsProperties",
+			"description": ""
+		},
+		{
+			"name": "grpc.client",
+			"type": "java.util.Map<java.util.String,net.devh.boot.grpc.client.config.GrpcChannelProperties>",
+			"sourceType": "net.devh.boot.grpc.client.config.GrpcChannelsProperties",
+			"sourceMethod": "getClient()",
+			"description": "A container for named channel properties.\nEach channel has its own configuration. If you try to get a channel that does not have a configuration yet, it will be created. If something is not configured in the channel properties, it will be copied from the global config during the first retrieval. If some property is configured in neither the channel properties nor the global properties then a default value will be used."
+		},
+		{
+			"name": "grpc.client.GLOBAL",
+			"type": "net.devh.boot.grpc.client.config.GrpcChannelProperties",
+			"sourceType": "net.devh.boot.grpc.client.config.GrpcChannelProperties",
+			"description": "The channel properties for a single named gRPC channel or service reference. In this case the GLOBAL channel."
+		},
+		{
+			"name": "grpc.client.GLOBAL.security",
+			"type": "net.devh.boot.grpc.client.config.GrpcChannelProperties$Security",
+			"sourceType": "net.devh.boot.grpc.client.config.GrpcChannelProperties",
+			"sourceMethod": "getSecurity()",
+			"description": "A container with options for the channel's transport security. In this case the GLOBAL channel's ones."
+		}
+	],
+	"properties": [
+		{
+			"name": "grpc.client.GLOBAL.address",
+			"type": "java.net.URI",
+			"sourceType": "net.devh.boot.grpc.client.config.GrpcChannelProperties",
+			"description": "Sets the target address uri for the channel.\nThe target uri must be in the format: schema:[\/\/[authority]][\/path].\nIf nothing is configured then the io.grpc.NameResolver.Factory will decide on the default.\nExamples:\n\t\"static:\/\/10.0.0.10:9090,10.11.12.11:9091\",\n\t\"dns:\/example.com:9090\",\n\t\"discovery:\/foo-service\""
+		},
+		{
+			"name": "grpc.client.GLOBAL.enable-keep-alive",
+			"type": "java.lang.Boolean",
+			"sourceType": "net.devh.boot.grpc.client.config.GrpcChannelProperties",
+			"description": "Whether keepAlive should be enabled.",
+			"defaultValue": false
+		},
+		{
+			"name": "grpc.client.GLOBAL.keep-alive-time",
+			"type": "java.time.Duration",
+			"sourceType": "net.devh.boot.grpc.client.config.GrpcChannelProperties",
+			"description": "The default delay before we send a keepAlive.\nDefault unit is seconds.",
+			"defaultValue": "60s"
+		},
+		{
+			"name": "grpc.client.GLOBAL.keep-alive-timeout",
+			"type": "java.time.Duration",
+			"sourceType": "net.devh.boot.grpc.client.config.GrpcChannelProperties",
+			"description": "The default timeout for a keepAlives ping request.\nDefault unit is seconds.",
+			"defaultValue": "20s"
+		},
+		{
+			"name": "grpc.client.GLOBAL.keep-alive-without-calls",
+			"type": "java.lang.Boolean",
+			"sourceType": "net.devh.boot.grpc.client.config.GrpcChannelProperties",
+			"description": "Whether keepAlive will be performed when there are no outstanding RPC on a connection.",
+			"defaultValue": false
+		},
+		{
+			"name": "grpc.client.GLOBAL.max-inbound-message-size",
+			"type": "java.lang.Integer",
+			"sourceType": "net.devh.boot.grpc.client.config.GrpcChannelProperties",
+			"description": "The maximum message size in bytes allowed to be received by the channel.\nIf not set (null) then it will default to gRPC's default.\nIf set to -1 then it will use the highest possible limit (not recommended)."
+		},
+		{
+			"name": "grpc.client.GLOBAL.full-stream-decompression",
+			"type": "java.lang.Boolean",
+			"sourceType": "net.devh.boot.grpc.client.config.GrpcChannelProperties",
+			"description": "Whether full-stream decompression of inbound streams should be enabled.",
+			"defaultValue": false
+		},
+		{
+			"name": "grpc.client.GLOBAL.negotiation-type",
+			"type": "net.devh.boot.grpc.client.config.NegotiationType",
+			"sourceType": "net.devh.boot.grpc.client.config.GrpcChannelProperties",
+			"description": "The negotiation type to use on the connection.",
+			"defaultValue": "TLS"
+		},
+		{
+			"name": "grpc.client.GLOBAL.security.client-auth-enabled",
+			"type": "java.lang.Boolean",
+			"sourceType": "net.devh.boot.grpc.client.config.GrpcChannelProperties$Security",
+			"description": "Whether client can authenticate using certificates.",
+			"defaultValue": false
+		},
+		{
+			"name": "grpc.client.GLOBAL.security.certificate-chain-path",
+			"type": "java.lang.String",
+			"sourceType": "net.devh.boot.grpc.client.config.GrpcChannelProperties$Security",
+			"description": "The path to SSL certificate chain. Required if \"client-auth-enabled\" is enabled.\nThe linked certificate will be used to authenticate the client."
+		},
+		{
+			"name": "grpc.client.GLOBAL.security.private-key-path",
+			"type": "java.lang.String",
+			"sourceType": "net.devh.boot.grpc.client.config.GrpcChannelProperties$Security",
+			"description": "The path to the private key. Required if \"client-auth-enabled\" is enabled."
+		},
+		{
+			"name": "grpc.client.GLOBAL.security.trust-cert-collection-path",
+			"type": "java.lang.String",
+			"sourceType": "net.devh.boot.grpc.client.config.GrpcChannelProperties$Security",
+			"description": "The path to the trusted certificate collection.\nIf not set (null) it will use the system's default collection (Default).\nThis collection will be used to verify server certificates."
+		},
+		{
+			"name": "grpc.client.GLOBAL.security.authority-override",
+			"type": "java.lang.String",
+			"sourceType": "net.devh.boot.grpc.client.config.GrpcChannelProperties$Security",
+			"description": "Sets the authority to check for during server certificate verification. By default the clients will use the name of the client to check the server certificate's common + alternative names."
+		}
+	]
+}

--- a/grpc-client-spring-boot-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/grpc-client-spring-boot-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -8,7 +8,7 @@
 		},
 		{
 			"name": "grpc.client",
-			"type": "java.util.Map<java.util.String,net.devh.boot.grpc.client.config.GrpcChannelProperties>",
+			"type": "java.util.Map<java.lang.String,net.devh.boot.grpc.client.config.GrpcChannelProperties>",
 			"sourceType": "net.devh.boot.grpc.client.config.GrpcChannelsProperties",
 			"sourceMethod": "getClient()",
 			"description": "A container for named channel properties.\nEach channel has its own configuration. If you try to get a channel that does not have a configuration yet, it will be created. If something is not configured in the channel properties, it will be copied from the global config during the first retrieval. If some property is configured in neither the channel properties nor the global properties then a default value will be used."

--- a/grpc-client-spring-boot-autoconfigure/src/test/java/net/devh/boot/grpc/client/config/GrpcChannelPropertiesGlobalTest.java
+++ b/grpc-client-spring-boot-autoconfigure/src/test/java/net/devh/boot/grpc/client/config/GrpcChannelPropertiesGlobalTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2016-2018 Michael Zhang <yidongnan@gmail.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package net.devh.boot.grpc.client.config;
+
+import static org.junit.Assert.assertSame;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.time.Duration;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+/**
+ * Tests whether the global property fallback works.
+ */
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(properties = {
+        "grpc.client.GLOBAL.keepAliveTime=23m",
+        "grpc.client.GLOBAL.keepAliveTimeout=31s",
+        "grpc.client.test.keepAliveTime=42m"})
+class GrpcChannelPropertiesGlobalTest {
+
+    @Autowired
+    private GrpcChannelsProperties grpcChannelsProperties;
+
+    @Test
+    void test() {
+        assertSame(this.grpcChannelsProperties.getGlobalChannel(),
+                this.grpcChannelsProperties.getChannel(GrpcChannelsProperties.GLOBAL_PROPERTIES_KEY));
+
+        assertEquals(Duration.ofMinutes(23), this.grpcChannelsProperties.getGlobalChannel().getKeepAliveTime());
+        assertEquals(Duration.ofSeconds(31), this.grpcChannelsProperties.getGlobalChannel().getKeepAliveTimeout());
+
+        assertEquals(Duration.ofMinutes(42), this.grpcChannelsProperties.getChannel("test").getKeepAliveTime());
+        assertEquals(Duration.ofSeconds(31), this.grpcChannelsProperties.getChannel("test").getKeepAliveTimeout());
+    }
+
+}


### PR DESCRIPTION
Adds #183

This PRs adds the `grpc.client.GLOBAL` client configuration that will be used as fallback, if the properties are not configured per client.

Order of precedence: Per Client > `GLOBAL` > defaults

I also attempted to add some metadata for the client side. Unfortunately it still does not show the per client details, but you can use the `GLOBAL` properties as a reference. In eclipse this works up to a certain degree. 

![eclipse-preview](https://user-images.githubusercontent.com/1579362/53484971-5903e680-3a85-11e9-832d-9ed384e28457.png)



I'll test it with IntelliJ IDEA in a few days, but I'm not familiar with it, so can someone else test it with IntelliJ as well? 

Thanks to @andcuevas for suggesting this feature.