### PR TITLE
Fix unnecessary security configuration for NegotitationType.PLAINTEXT_UPGRADE

### DIFF
--- a/README.md
+++ b/README.md
@@ -536,8 +536,8 @@ grpc.client.(gRPC server name).negotiationType=PLAINTEXT
 
 ### Server port already in use during tests
 
-Sometimes you just want to launch your application in your test to test the interaction between your services.
-This will also start the grpc server, however it won't be shut down after each test (class). You can avoid that issue by
+Sometimes you just want to launch your application in your test classes to check the interaction between your services.
+This will also start the grpc server, however it won't be shut down after each test (class) individually. You can avoid that issue by
 adding `@DirtiesContext` to your test classes or methods.
 
 ### No name matching XXX found

--- a/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/channelfactory/NettyChannelFactory.java
+++ b/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/channelfactory/NettyChannelFactory.java
@@ -36,8 +36,11 @@ import net.devh.boot.grpc.client.config.NegotiationType;
 import net.devh.boot.grpc.client.interceptor.GlobalClientInterceptorRegistry;
 
 /**
- * This channel factory creates and manages netty based {@link GrpcChannelFactory}s. This class utilizes connection
- * pooling and thus needs to be {@link #close() closed} after usage.
+ * This channel factory creates and manages netty based {@link GrpcChannelFactory}s.
+ *
+ * <p>
+ * This class utilizes connection pooling and thus needs to be {@link #close() closed} after usage.
+ * </p>
  *
  * @author Michael (yidongnan@gmail.com)
  * @author Daniel Theuke (daniel.theuke@heuboe.de)
@@ -85,7 +88,7 @@ public class NettyChannelFactory extends AbstractChannelFactory<NettyChannelBuil
         final NegotiationType negotiationType = properties.getNegotiationType();
         builder.negotiationType(of(negotiationType));
 
-        if (negotiationType != NegotiationType.PLAINTEXT) {
+        if (negotiationType == NegotiationType.TLS) {
             final Security security = properties.getSecurity();
 
             final String authorityOverwrite = security.getAuthorityOverride();

--- a/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/channelfactory/ShadedNettyChannelFactory.java
+++ b/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/channelfactory/ShadedNettyChannelFactory.java
@@ -36,8 +36,11 @@ import net.devh.boot.grpc.client.config.NegotiationType;
 import net.devh.boot.grpc.client.interceptor.GlobalClientInterceptorRegistry;
 
 /**
- * This channel factory creates and manages shaded netty based {@link GrpcChannelFactory}s. This class utilizes
- * connection pooling and thus needs to be {@link #close() closed} after usage.
+ * This channel factory creates and manages shaded netty based {@link GrpcChannelFactory}s.
+ *
+ * <p>
+ * This class utilizes connection pooling and thus needs to be {@link #close() closed} after usage.
+ * </p>
  *
  * @author Daniel Theuke (daniel.theuke@heuboe.de)
  */
@@ -83,7 +86,7 @@ public class ShadedNettyChannelFactory extends AbstractChannelFactory<NettyChann
         final NegotiationType negotiationType = properties.getNegotiationType();
         builder.negotiationType(of(negotiationType));
 
-        if (negotiationType != NegotiationType.PLAINTEXT) {
+        if (negotiationType == NegotiationType.TLS) {
             final Security security = properties.getSecurity();
 
             final String authorityOverwrite = security.getAuthorityOverride();

--- a/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/config/NegotiationType.java
+++ b/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/config/NegotiationType.java
@@ -19,7 +19,10 @@ package net.devh.boot.grpc.client.config;
 
 /**
  * Identifies the negotiation used for starting up HTTP/2.
+ *
+ * @see io.grpc.netty.shaded.io.grpc.netty.NegotiationType NegotiationType
  */
+// This class needs to be duplicated to avoid direct dependencies to either of the grpc-netty (shaded) libraries.
 public enum NegotiationType {
 
     /**


### PR DESCRIPTION
Fixes #199

The `PLAINTEXT_UPGRADE` setting refers to a plaintext setting and thus does not require the certificate setup steps.
