### PR TITLE
Update example dependencies to fix compilation error

### DIFF
--- a/examples/security-grpc-bearerAuth-server/build.gradle
+++ b/examples/security-grpc-bearerAuth-server/build.gradle
@@ -15,9 +15,9 @@ dependencies {
     compile('com.nimbusds:nimbus-jose-jwt:6.4.2')
     compile('org.springframework.security.oauth:spring-security-oauth2:2.3.4.RELEASE')
     compile('org.springframework.security:spring-security-web')
-    compile('org.springframework.security:spring-security-oauth2-resource-server:5.2.0.BUILD-SNAPSHOT')
-    compile('org.springframework.security:spring-security-oauth2-jose:5.2.0.BUILD-SNAPSHOT')
-    compile('org.springframework.security:spring-security-oauth2-core:5.2.0.BUILD-SNAPSHOT')
+    compile('org.springframework.security:spring-security-oauth2-resource-server:5.2.0.M1')
+    compile('org.springframework.security:spring-security-oauth2-jose:5.2.0.M1')
+    compile('org.springframework.security:spring-security-oauth2-core:5.2.0.M1')
 }
 
 buildscript {


### PR DESCRIPTION
The previously used `BUILD-SNAPSHOT` version cause compilation errors, this PR updates them to a milestone release and thus fixes the build errors.