### PR TITLE
Make GrpcServerSecurityAutoConfiguration a proper auto configuration

### DIFF
--- a/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/autoconfigure/GrpcServerAutoConfiguration.java
+++ b/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/autoconfigure/GrpcServerAutoConfiguration.java
@@ -27,7 +27,6 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Import;
 
 import io.grpc.CompressorRegistry;
 import io.grpc.DecompressorRegistry;
@@ -37,7 +36,6 @@ import net.devh.boot.grpc.common.autoconfigure.GrpcCommonCodecAutoConfiguration;
 import net.devh.boot.grpc.server.config.GrpcServerProperties;
 import net.devh.boot.grpc.server.interceptor.AnnotationGlobalServerInterceptorConfigurer;
 import net.devh.boot.grpc.server.interceptor.GlobalServerInterceptorRegistry;
-import net.devh.boot.grpc.server.security.GrpcSecurityAutoConfiguration;
 import net.devh.boot.grpc.server.serverfactory.GrpcServerConfigurer;
 import net.devh.boot.grpc.server.serverfactory.GrpcServerFactory;
 import net.devh.boot.grpc.server.serverfactory.GrpcServerLifecycle;
@@ -56,8 +54,7 @@ import net.devh.boot.grpc.server.service.GrpcServiceDiscoverer;
 @Configuration
 @EnableConfigurationProperties
 @ConditionalOnClass(Server.class)
-@AutoConfigureAfter(GrpcCommonCodecAutoConfiguration.class)
-@Import(GrpcSecurityAutoConfiguration.class)
+@AutoConfigureAfter({GrpcCommonCodecAutoConfiguration.class})
 public class GrpcServerAutoConfiguration {
 
     @ConditionalOnMissingBean

--- a/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/autoconfigure/GrpcServerSecurityAutoConfiguration.java
+++ b/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/autoconfigure/GrpcServerSecurityAutoConfiguration.java
@@ -15,15 +15,18 @@
  * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package net.devh.boot.grpc.server.security;
+package net.devh.boot.grpc.server.autoconfigure;
 
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.security.servlet.WebSecurityEnablerConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.access.AccessDecisionManager;
 import org.springframework.security.authentication.AuthenticationManager;
 
+import lombok.extern.slf4j.Slf4j;
 import net.devh.boot.grpc.server.security.authentication.GrpcAuthenticationReader;
 import net.devh.boot.grpc.server.security.check.GrpcSecurityMetadataSource;
 import net.devh.boot.grpc.server.security.interceptors.AuthenticatingServerInterceptor;
@@ -54,9 +57,11 @@ import net.devh.boot.grpc.server.security.interceptors.ExceptionTranslatingServe
  *
  * @author Daniel Theuke (daniel.theuke@heuboe.de)
  */
+@Slf4j
 @Configuration
 @ConditionalOnBean(AuthenticationManager.class)
-public class GrpcSecurityAutoConfiguration {
+@AutoConfigureAfter(WebSecurityEnablerConfiguration.class)
+public class GrpcServerSecurityAutoConfiguration {
 
     @Bean
     @ConditionalOnMissingBean
@@ -64,6 +69,7 @@ public class GrpcSecurityAutoConfiguration {
     public AuthorizationCheckingServerInterceptor authorizationCheckingServerInterceptor(
             final AccessDecisionManager accessDecisionManager,
             final GrpcSecurityMetadataSource securityMetadataSource) {
+        log.warn("Create AuthorizationCheckingServerInterceptor");
         return new AuthorizationCheckingServerInterceptor(accessDecisionManager, securityMetadataSource);
     }
 

--- a/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/autoconfigure/GrpcServerSecurityAutoConfiguration.java
+++ b/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/autoconfigure/GrpcServerSecurityAutoConfiguration.java
@@ -26,7 +26,6 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.security.access.AccessDecisionManager;
 import org.springframework.security.authentication.AuthenticationManager;
 
-import lombok.extern.slf4j.Slf4j;
 import net.devh.boot.grpc.server.security.authentication.GrpcAuthenticationReader;
 import net.devh.boot.grpc.server.security.check.GrpcSecurityMetadataSource;
 import net.devh.boot.grpc.server.security.interceptors.AuthenticatingServerInterceptor;
@@ -57,7 +56,6 @@ import net.devh.boot.grpc.server.security.interceptors.ExceptionTranslatingServe
  *
  * @author Daniel Theuke (daniel.theuke@heuboe.de)
  */
-@Slf4j
 @Configuration
 @ConditionalOnBean(AuthenticationManager.class)
 @AutoConfigureAfter(WebSecurityEnablerConfiguration.class)
@@ -69,7 +67,6 @@ public class GrpcServerSecurityAutoConfiguration {
     public AuthorizationCheckingServerInterceptor authorizationCheckingServerInterceptor(
             final AccessDecisionManager accessDecisionManager,
             final GrpcSecurityMetadataSource securityMetadataSource) {
-        log.warn("Create AuthorizationCheckingServerInterceptor");
         return new AuthorizationCheckingServerInterceptor(accessDecisionManager, securityMetadataSource);
     }
 

--- a/grpc-server-spring-boot-autoconfigure/src/main/resources/META-INF/spring.factories
+++ b/grpc-server-spring-boot-autoconfigure/src/main/resources/META-INF/spring.factories
@@ -3,5 +3,6 @@ org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
 net.devh.boot.grpc.server.autoconfigure.GrpcMetadataConsulConfiguration,\
 net.devh.boot.grpc.server.autoconfigure.GrpcMetadataEurekaConfiguration,\
 net.devh.boot.grpc.server.autoconfigure.GrpcServerAutoConfiguration,\
+net.devh.boot.grpc.server.autoconfigure.GrpcServerSecurityAutoConfiguration,\
 net.devh.boot.grpc.server.autoconfigure.GrpcServerMetricAutoConfiguration,\
 net.devh.boot.grpc.server.autoconfigure.GrpcServerTraceAutoConfiguration

--- a/tests/src/test/java/net/devh/boot/grpc/test/config/BaseAutoConfiguration.java
+++ b/tests/src/test/java/net/devh/boot/grpc/test/config/BaseAutoConfiguration.java
@@ -23,10 +23,11 @@ import org.springframework.context.annotation.Configuration;
 import net.devh.boot.grpc.client.autoconfigure.GrpcClientAutoConfiguration;
 import net.devh.boot.grpc.common.autoconfigure.GrpcCommonCodecAutoConfiguration;
 import net.devh.boot.grpc.server.autoconfigure.GrpcServerAutoConfiguration;
+import net.devh.boot.grpc.server.autoconfigure.GrpcServerSecurityAutoConfiguration;
 
 @Configuration
 @ImportAutoConfiguration({GrpcCommonCodecAutoConfiguration.class, GrpcServerAutoConfiguration.class,
-        GrpcClientAutoConfiguration.class})
+        GrpcServerSecurityAutoConfiguration.class, GrpcClientAutoConfiguration.class})
 public class BaseAutoConfiguration {
 
 }


### PR DESCRIPTION
Fixes #205 

Instead of importing the configuration, it is referenced via `spring.factories` this enables the users of the library to explicitly exclude the auto configuration from applying.