### PR TITLE
Order interceptors based on Spring's Order annotation

### DIFF
--- a/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/interceptor/AnnotationGlobalClientInterceptorConfigurer.java
+++ b/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/interceptor/AnnotationGlobalClientInterceptorConfigurer.java
@@ -17,8 +17,15 @@
 
 package net.devh.boot.grpc.client.interceptor;
 
+import java.util.List;
+import java.util.Map;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
+import org.springframework.core.annotation.Order;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
 
 import io.grpc.ClientInterceptor;
 import lombok.extern.slf4j.Slf4j;
@@ -37,11 +44,29 @@ public class AnnotationGlobalClientInterceptorConfigurer implements GlobalClient
     @Override
     public void addClientInterceptors(final GlobalClientInterceptorRegistry registry) {
         final String[] names = this.context.getBeanNamesForAnnotation(GrpcGlobalClientInterceptor.class);
-        for (final String name : names) {
+        final List<String> sortedInterceptorNames = sortBasedOnOrder(names);
+        for (final String name : sortedInterceptorNames) {
             final ClientInterceptor interceptor = this.context.getBean(name, ClientInterceptor.class);
             log.debug("Registering GlobalClientInterceptor: {} ({})", name, interceptor);
             registry.addClientInterceptors(interceptor);
         }
+    }
+
+    private List<String> sortBasedOnOrder(final String[] interceptorNames) {
+        Map<Integer, String> orderedInterceptorNames = Maps.newTreeMap();
+        List<String> unorderedInterceptorNames = Lists.newArrayList();
+        for (final String name : interceptorNames) {
+            Order interceptorOrder = this.context.findAnnotationOnBean(name, Order.class);
+            if (interceptorOrder != null) {
+                orderedInterceptorNames.put(Integer.valueOf(interceptorOrder.value()), name);
+            } else {
+                unorderedInterceptorNames.add(name);
+            }
+        }
+        List<String> sortedInterceptorNames = Lists.newArrayList();
+        sortedInterceptorNames.addAll(unorderedInterceptorNames);
+        sortedInterceptorNames.addAll(orderedInterceptorNames.values());
+        return sortedInterceptorNames;
     }
 
 }


### PR DESCRIPTION
Addresses #214 

Both server and client interceptors will now be registered based on the order specified by the `@Order` annotation. Interceptors without the annotation will be registered first. Annotated interceptors will be registered in ascending order of precedence.