### PR TITLE
Fix wrong BeanPostProcessor bean definition

### DIFF
--- a/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/autoconfigure/GrpcClientAutoConfiguration.java
+++ b/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/autoconfigure/GrpcClientAutoConfiguration.java
@@ -64,7 +64,7 @@ import net.devh.boot.grpc.common.autoconfigure.GrpcCommonCodecAutoConfiguration;
 public class GrpcClientAutoConfiguration {
 
     @Bean
-    public GrpcClientBeanPostProcessor grpcClientBeanPostProcessor(final ApplicationContext applicationContext) {
+    public static GrpcClientBeanPostProcessor grpcClientBeanPostProcessor(final ApplicationContext applicationContext) {
         return new GrpcClientBeanPostProcessor(applicationContext);
     }
 


### PR DESCRIPTION
Previously the bean definition was non-static, which required spring to first instantiate the configuration class and then the post processor. This causes issues with the other required configuration classes, because beans created in those classes won't be processed by all post processors such as the `GrpcClientBeanPostProcessor` in question.

Spring logs this behaviour with the following message:

````
2019-04-18 12:02:41.867  INFO 17664 --- [           main] trationDelegate$BeanPostProcessorChecker : Bean 'net.devh.boot.grpc.client.autoconfigure.GrpcClientAutoConfiguration' of type [net.devh.boot.grpc.client.autoconfigure.GrpcClientAutoConfiguration$$EnhancerBySpringCGLIB$$1750076a] is not eligible for getting processed by all BeanPostProcessors (for example: not eligible for auto-proxying)
````

Making the method static allows spring to first instantiate the `BeanPostProcessor` and then independently create the configuration at some later point in time.

**Note:** This might result in a behavior change since spring isn't forced to load the containing configuration class that early. (I don't expect any relevant conflicts here)

This PR was extracted from #217 