### PR TITLE
Add some additional/missing javadocs and toString() methods to client security

### DIFF
--- a/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/security/CallCredentialsHelper.java
+++ b/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/security/CallCredentialsHelper.java
@@ -211,6 +211,10 @@ public class CallCredentialsHelper {
         return BASIC_AUTH_PREFIX + new String(encoded, UTF_8);
     }
 
+    /**
+     * The static security header {@link CallCredentials} simply add a set of predefined headers to the call. Their
+     * specific meaning is server specific. This implementation can be used, for example, for BasicAuth.
+     */
     private static final class StaticSecurityHeaderCallCredentials extends CallCredentials {
 
         private final Metadata extraHeaders;
@@ -227,6 +231,11 @@ public class CallCredentialsHelper {
 
         @Override
         public void thisUsesUnstableApi() {} // API evolution in progress
+
+        @Override
+        public String toString() {
+            return "StaticSecurityHeaderCallCredentials [extraHeaders=" + this.extraHeaders + "]";
+        }
 
     }
 
@@ -260,6 +269,12 @@ public class CallCredentialsHelper {
         return new RequirePrivacyCallCredentials(callCredentials);
     }
 
+    /**
+     * A call credentials implementation with slightly increased security requirements. It ensures that the credentials
+     * aren't send via an insecure connection. However, it does not prevent requests via insecure connections. This
+     * wrapper does not have any other influence on the security of the underlying {@link CallCredentials}
+     * implementation.
+     */
     private static final class RequirePrivacyCallCredentials extends CallCredentials {
 
         private static final Status STATUS_LACKING_PRIVACY = Status.UNAUTHENTICATED
@@ -284,8 +299,12 @@ public class CallCredentialsHelper {
         @Override
         public void thisUsesUnstableApi() {} // API evolution in progress
 
-    }
+        @Override
+        public String toString() {
+            return "RequirePrivacyCallCredentials [callCredentials=" + this.callCredentials + "]";
+        }
 
+    }
 
     /**
      * Wraps the given call credentials in a new layer, that will only include the credentials if the connection
@@ -302,6 +321,11 @@ public class CallCredentialsHelper {
         return new IncludeWhenPrivateCallCredentials(callCredentials);
     }
 
+    /**
+     * A call credentials implementation with increased security requirements. It ensures that the credentials and
+     * requests aren't send via an insecure connection. This wrapper does not have any other influence on the security
+     * of the underlying {@link CallCredentials} implementation.
+     */
     private static final class IncludeWhenPrivateCallCredentials extends CallCredentials {
 
         private final CallCredentials callCredentials;
@@ -320,6 +344,11 @@ public class CallCredentialsHelper {
 
         @Override
         public void thisUsesUnstableApi() {} // API evolution in progress
+
+        @Override
+        public String toString() {
+            return "IncludeWhenPrivateCallCredentials [callCredentials=" + this.callCredentials + "]";
+        }
 
     }
 

--- a/tests/src/test/java/net/devh/boot/grpc/test/security/ConcurrentSecurityTest.java
+++ b/tests/src/test/java/net/devh/boot/grpc/test/security/ConcurrentSecurityTest.java
@@ -48,6 +48,13 @@ import net.devh.boot.grpc.test.proto.SomeType;
 import net.devh.boot.grpc.test.proto.TestServiceGrpc.TestServiceStub;
 import net.devh.boot.grpc.test.util.GrpcAssertions;
 
+/**
+ * Test that ensures that the security also works in concurrent environments. This seems to be a common problem in many
+ * security examples. This test can also be used to simulate heavy load on the server, you just have to increase the
+ * {@code parallelCount} drastically.
+ *
+ * @author Daniel Theuke (daniel.theuke@heuboe.de)
+ */
 @Slf4j
 @SpringBootTest
 @SpringJUnitConfig(
@@ -68,7 +75,7 @@ public class ConcurrentSecurityTest {
     /**
      * Test secured call.
      *
-     * @throws Throwable
+     * @throws Throwable Should never happen.
      */
     @Test
     @DirtiesContext


### PR DESCRIPTION
I found a stale branch with some additional javadocs and methods that may be useful during debugging.