### PR TITLE
Adds simultaneous support for in- and inter-process channels/servers

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -108,6 +108,7 @@ public class GrpcServerService extends GreeterGrpc.GreeterImplBase {
 ````properties
 grpc.server.port=9090
 grpc.server.address=0.0.0.0
+#grpc.server.inProcessName=test
 ````
 
 #### 对 Server 进行自定义
@@ -325,6 +326,10 @@ HelloReply response = stub.sayHello(HelloRequest.newBuilder().setName(name).buil
 此外，你也可以使用 DNS 的方式去获取目标地址
 
 * `dns:///example.com`
+
+同时，你也可以使用如下方式直接进程内访问
+
+* `in-process:test`
 
 它会通过DNS将域名解析出所有真实的 IP 地址，通过使用这些真实的IP地址去做负载均衡。
 需要注意的是 `grpc-java` 出于性能的考虑对 DNS 返回的结果做缓存。

--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ can be changed via Spring's property mechanism. The server uses the `grpc.server
 ````properties
 grpc.server.port=9090
 grpc.server.address=0.0.0.0
+#grpc.server.inProcessName=test
 ````
 
 #### Customizing a Server
@@ -334,6 +335,10 @@ You can also use service discovery based address resolution like this (requires 
 Additionally, you can use DNS based address resolution like this:
 
 * `dns:///example.com`
+
+Or access the in-process-server like this:
+
+* `in-process:test`
 
 This will automatically read all IP addresses from that domain and use them for load balancing.
 Please note that `grpc-java` caches the DNS response for performance reasons.

--- a/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/autoconfigure/GrpcClientAutoConfiguration.java
+++ b/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/autoconfigure/GrpcClientAutoConfiguration.java
@@ -40,6 +40,7 @@ import io.grpc.NameResolverProvider;
 import net.devh.boot.grpc.client.channelfactory.GrpcChannelConfigurer;
 import net.devh.boot.grpc.client.channelfactory.GrpcChannelFactory;
 import net.devh.boot.grpc.client.channelfactory.InProcessChannelFactory;
+import net.devh.boot.grpc.client.channelfactory.InProcessOrAlternativeChannelFactory;
 import net.devh.boot.grpc.client.channelfactory.NettyChannelFactory;
 import net.devh.boot.grpc.client.channelfactory.ShadedNettyChannelFactory;
 import net.devh.boot.grpc.client.config.GrpcChannelProperties;
@@ -158,8 +159,12 @@ public class GrpcClientAutoConfiguration {
             final NameResolver.Factory nameResolverFactory,
             final GlobalClientInterceptorRegistry globalClientInterceptorRegistry,
             final List<GrpcChannelConfigurer> channelConfigurers) {
-        return new ShadedNettyChannelFactory(properties, nameResolverFactory,
-                globalClientInterceptorRegistry, channelConfigurers);
+        final ShadedNettyChannelFactory channelFactory =
+                new ShadedNettyChannelFactory(properties, nameResolverFactory,
+                        globalClientInterceptorRegistry, channelConfigurers);
+        final InProcessChannelFactory inProcessChannelFactory =
+                new InProcessChannelFactory(properties, globalClientInterceptorRegistry, channelConfigurers);
+        return new InProcessOrAlternativeChannelFactory(properties, inProcessChannelFactory, channelFactory);
     }
 
     // Then try the normal netty channel factory
@@ -170,8 +175,12 @@ public class GrpcClientAutoConfiguration {
             final NameResolver.Factory nameResolverFactory,
             final GlobalClientInterceptorRegistry globalClientInterceptorRegistry,
             final List<GrpcChannelConfigurer> channelConfigurers) {
-        return new NettyChannelFactory(properties, nameResolverFactory,
-                globalClientInterceptorRegistry, channelConfigurers);
+        final NettyChannelFactory channelFactory =
+                new NettyChannelFactory(properties, nameResolverFactory,
+                        globalClientInterceptorRegistry, channelConfigurers);
+        final InProcessChannelFactory inProcessChannelFactory =
+                new InProcessChannelFactory(properties, globalClientInterceptorRegistry, channelConfigurers);
+        return new InProcessOrAlternativeChannelFactory(properties, inProcessChannelFactory, channelFactory);
     }
 
     // Finally try the in process channel factory

--- a/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/channelfactory/InProcessOrAlternativeChannelFactory.java
+++ b/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/channelfactory/InProcessOrAlternativeChannelFactory.java
@@ -52,20 +52,20 @@ public class InProcessOrAlternativeChannelFactory implements GrpcChannelFactory 
 
     private final GrpcChannelsProperties properties;
     private final InProcessChannelFactory inProcessChannelFactory;
-    private final GrpcChannelFactory alternatveChannelFactory;
+    private final GrpcChannelFactory alternativeChannelFactory;
 
     /**
      * Creates a new InProcessOrAlternativeChannelFactory with the given properties and channel factories.
      *
      * @param properties The properties used to resolved the target scheme
      * @param inProcessChannelFactory The in process channel factory implementation to use.
-     * @param alternatveChannelFactory The alternative channel factory implementation to use.
+     * @param alternativeChannelFactory The alternative channel factory implementation to use.
      */
     public InProcessOrAlternativeChannelFactory(final GrpcChannelsProperties properties,
-            final InProcessChannelFactory inProcessChannelFactory, final GrpcChannelFactory alternatveChannelFactory) {
+            final InProcessChannelFactory inProcessChannelFactory, final GrpcChannelFactory alternativeChannelFactory) {
         this.properties = requireNonNull(properties, "properties");
         this.inProcessChannelFactory = requireNonNull(inProcessChannelFactory, "inProcessChannelFactory");
-        this.alternatveChannelFactory = requireNonNull(alternatveChannelFactory, "alternatveChannelFactory");
+        this.alternativeChannelFactory = requireNonNull(alternativeChannelFactory, "alternativeChannelFactory");
     }
 
     @Override
@@ -74,7 +74,7 @@ public class InProcessOrAlternativeChannelFactory implements GrpcChannelFactory 
         if (address != null && IN_PROCESS_SCHEME.equals(address.getScheme())) {
             return this.inProcessChannelFactory.createChannel(address.getSchemeSpecificPart(), interceptors);
         }
-        return this.alternatveChannelFactory.createChannel(name, interceptors);
+        return this.alternativeChannelFactory.createChannel(name, interceptors);
     }
 
     @Override
@@ -82,7 +82,7 @@ public class InProcessOrAlternativeChannelFactory implements GrpcChannelFactory 
         try {
             this.inProcessChannelFactory.close();
         } finally {
-            this.alternatveChannelFactory.close();
+            this.alternativeChannelFactory.close();
         }
     }
 

--- a/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/channelfactory/InProcessOrAlternativeChannelFactory.java
+++ b/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/channelfactory/InProcessOrAlternativeChannelFactory.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2016-2019 Michael Zhang <yidongnan@gmail.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package net.devh.boot.grpc.client.channelfactory;
+
+import static java.util.Objects.requireNonNull;
+
+import java.net.URI;
+import java.util.List;
+
+import io.grpc.Channel;
+import io.grpc.ClientInterceptor;
+import net.devh.boot.grpc.client.config.GrpcChannelsProperties;
+
+/**
+ * This channel factory is a switch between the {@link InProcessChannelFactory} and an alternative implementation. All
+ * channels that are configured with the {@code inProcess} scheme will be handled by the in-process-channel-factory, the
+ * other channels will be handled by the alternative implementation.
+ *
+ * <p>
+ * <b>The following examples show how the configured address will be mapped to an actual channel:</b>
+ * </p>
+ *
+ * <ul>
+ * <li><code>inProcess:foobar</code> -&gt; will use the <code>foobar</code> in-process-channel.</li>
+ * <li><code>inProcess:foo/bar</code> -&gt; will use the <code>foo/bar</code> in-process-channel.</li>
+ * <li><code>static://127.0.0.1</code> -&gt; will be handled by the alternative grpc channel factory.</li>
+ * </ul>
+ *
+ * <p>
+ * Using this class does not incur any additional performance or resource costs, as the actual channels (in-process or
+ * other) are only created on demand.
+ * </p>
+ */
+public class InProcessOrAlternativeChannelFactory implements GrpcChannelFactory {
+
+    private static final String IN_PROCESS_SCHEME = "inProcess";
+
+    private final GrpcChannelsProperties properties;
+    private final InProcessChannelFactory inProcessChannelFactory;
+    private final GrpcChannelFactory alternatveChannelFactory;
+
+    /**
+     * Creates a new InProcessOrAlternativeChannelFactory with the given properties and channel factories.
+     *
+     * @param properties The properties used to resolved the target scheme
+     * @param inProcessChannelFactory The in process channel factory implementation to use.
+     * @param alternatveChannelFactory The alternative channel factory implementation to use.
+     */
+    public InProcessOrAlternativeChannelFactory(final GrpcChannelsProperties properties,
+            final InProcessChannelFactory inProcessChannelFactory, final GrpcChannelFactory alternatveChannelFactory) {
+        this.properties = requireNonNull(properties, "properties");
+        this.inProcessChannelFactory = requireNonNull(inProcessChannelFactory, "inProcessChannelFactory");
+        this.alternatveChannelFactory = requireNonNull(alternatveChannelFactory, "alternatveChannelFactory");
+    }
+
+    @Override
+    public Channel createChannel(final String name, final List<ClientInterceptor> interceptors) {
+        final URI address = this.properties.getChannel(name).getAddress();
+        if (address != null && IN_PROCESS_SCHEME.equals(address.getScheme())) {
+            return this.inProcessChannelFactory.createChannel(address.getSchemeSpecificPart(), interceptors);
+        }
+        return this.alternatveChannelFactory.createChannel(name, interceptors);
+    }
+
+    @Override
+    public void close() {
+        try {
+            this.inProcessChannelFactory.close();
+        } finally {
+            this.alternatveChannelFactory.close();
+        }
+    }
+
+}

--- a/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/channelfactory/InProcessOrAlternativeChannelFactory.java
+++ b/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/channelfactory/InProcessOrAlternativeChannelFactory.java
@@ -28,16 +28,16 @@ import net.devh.boot.grpc.client.config.GrpcChannelsProperties;
 
 /**
  * This channel factory is a switch between the {@link InProcessChannelFactory} and an alternative implementation. All
- * channels that are configured with the {@code inProcess} scheme will be handled by the in-process-channel-factory, the
- * other channels will be handled by the alternative implementation.
+ * channels that are configured with the {@code in-process} scheme will be handled by the in-process-channel-factory,
+ * the other channels will be handled by the alternative implementation.
  *
  * <p>
  * <b>The following examples show how the configured address will be mapped to an actual channel:</b>
  * </p>
  *
  * <ul>
- * <li><code>inProcess:foobar</code> -&gt; will use the <code>foobar</code> in-process-channel.</li>
- * <li><code>inProcess:foo/bar</code> -&gt; will use the <code>foo/bar</code> in-process-channel.</li>
+ * <li><code>in-process:foobar</code> -&gt; will use the <code>foobar</code> in-process-channel.</li>
+ * <li><code>in-process:foo/bar</code> -&gt; will use the <code>foo/bar</code> in-process-channel.</li>
  * <li><code>static://127.0.0.1</code> -&gt; will be handled by the alternative grpc channel factory.</li>
  * </ul>
  *
@@ -48,7 +48,7 @@ import net.devh.boot.grpc.client.config.GrpcChannelsProperties;
  */
 public class InProcessOrAlternativeChannelFactory implements GrpcChannelFactory {
 
-    private static final String IN_PROCESS_SCHEME = "inProcess";
+    private static final String IN_PROCESS_SCHEME = "in-process";
 
     private final GrpcChannelsProperties properties;
     private final InProcessChannelFactory inProcessChannelFactory;

--- a/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/autoconfigure/GrpcServerAutoConfiguration.java
+++ b/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/autoconfigure/GrpcServerAutoConfiguration.java
@@ -39,10 +39,7 @@ import net.devh.boot.grpc.server.interceptor.GlobalServerInterceptorRegistry;
 import net.devh.boot.grpc.server.serverfactory.GrpcServerConfigurer;
 import net.devh.boot.grpc.server.serverfactory.GrpcServerFactory;
 import net.devh.boot.grpc.server.serverfactory.GrpcServerLifecycle;
-import net.devh.boot.grpc.server.serverfactory.NettyGrpcServerFactory;
-import net.devh.boot.grpc.server.serverfactory.ShadedNettyGrpcServerFactory;
 import net.devh.boot.grpc.server.service.AnnotationGrpcServiceDiscoverer;
-import net.devh.boot.grpc.server.service.GrpcServiceDefinition;
 import net.devh.boot.grpc.server.service.GrpcServiceDiscoverer;
 
 /**
@@ -54,7 +51,7 @@ import net.devh.boot.grpc.server.service.GrpcServiceDiscoverer;
 @Configuration
 @EnableConfigurationProperties
 @ConditionalOnClass(Server.class)
-@AutoConfigureAfter({GrpcCommonCodecAutoConfiguration.class})
+@AutoConfigureAfter(GrpcCommonCodecAutoConfiguration.class)
 public class GrpcServerAutoConfiguration {
 
     @ConditionalOnMissingBean
@@ -103,34 +100,8 @@ public class GrpcServerAutoConfiguration {
         return Collections.emptyList();
     }
 
-    // First try the shaded netty server
     @ConditionalOnMissingBean
-    @ConditionalOnClass(name = {"io.grpc.netty.shaded.io.netty.channel.Channel",
-            "io.grpc.netty.shaded.io.grpc.netty.NettyServerBuilder"})
-    @Bean
-    public GrpcServerFactory shadedNettyGrpcServerFactory(final GrpcServerProperties properties,
-            final GrpcServiceDiscoverer serviceDiscoverer, final List<GrpcServerConfigurer> serverConfigurers) {
-        final GrpcServerFactory factory = new ShadedNettyGrpcServerFactory(properties, serverConfigurers);
-        for (final GrpcServiceDefinition service : serviceDiscoverer.findGrpcServices()) {
-            factory.addService(service);
-        }
-        return factory;
-    }
-
-    // Then try the normal netty server
-    @ConditionalOnMissingBean
-    @ConditionalOnClass(name = {"io.netty.channel.Channel", "io.grpc.netty.NettyServerBuilder"})
-    @Bean
-    public GrpcServerFactory nettyGrpcServerFactory(final GrpcServerProperties properties,
-            final GrpcServiceDiscoverer serviceDiscoverer, final List<GrpcServerConfigurer> serverConfigurers) {
-        final GrpcServerFactory factory = new NettyGrpcServerFactory(properties, serverConfigurers);
-        for (final GrpcServiceDefinition service : serviceDiscoverer.findGrpcServices()) {
-            factory.addService(service);
-        }
-        return factory;
-    }
-
-    @ConditionalOnMissingBean
+    @ConditionalOnBean(GrpcServerFactory.class)
     @Bean
     public GrpcServerLifecycle grpcServerLifecycle(final GrpcServerFactory factory) {
         return new GrpcServerLifecycle(factory);

--- a/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/autoconfigure/GrpcServerFactoryAutoConfiguration.java
+++ b/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/autoconfigure/GrpcServerFactoryAutoConfiguration.java
@@ -142,7 +142,7 @@ public class GrpcServerFactoryAutoConfiguration {
      */
     @ConditionalOnBean(InProcessGrpcServerFactory.class)
     @Bean
-    public GrpcServerLifecycle inProcessgrpcServerLifecycle(final InProcessGrpcServerFactory factory) {
+    public GrpcServerLifecycle inProcessGrpcServerLifecycle(final InProcessGrpcServerFactory factory) {
         return new GrpcServerLifecycle(factory);
     }
 

--- a/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/autoconfigure/GrpcServerFactoryAutoConfiguration.java
+++ b/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/autoconfigure/GrpcServerFactoryAutoConfiguration.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright (c) 2016-2019 Michael Zhang <yidongnan@gmail.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package net.devh.boot.grpc.server.autoconfigure;
+
+import java.util.List;
+
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import net.devh.boot.grpc.server.config.GrpcServerProperties;
+import net.devh.boot.grpc.server.serverfactory.GrpcServerConfigurer;
+import net.devh.boot.grpc.server.serverfactory.GrpcServerFactory;
+import net.devh.boot.grpc.server.serverfactory.GrpcServerLifecycle;
+import net.devh.boot.grpc.server.serverfactory.InProcessGrpcServerFactory;
+import net.devh.boot.grpc.server.serverfactory.NettyGrpcServerFactory;
+import net.devh.boot.grpc.server.serverfactory.ShadedNettyGrpcServerFactory;
+import net.devh.boot.grpc.server.service.GrpcServiceDefinition;
+import net.devh.boot.grpc.server.service.GrpcServiceDiscoverer;
+
+/**
+ * The auto configuration that will create the {@link GrpcServerFactory}s and {@link GrpcServerLifecycle}s, if the
+ * developer hasn't specified their own variant.
+ *
+ * @author Daniel Theuke (daniel.theuke@heuboe.de)
+ */
+@Configuration
+@ConditionalOnMissingBean({GrpcServerFactory.class, GrpcServerLifecycle.class})
+@AutoConfigureAfter(GrpcServerAutoConfiguration.class)
+public class GrpcServerFactoryAutoConfiguration {
+
+    // First try the shaded netty server
+    /**
+     * Creates a GrpcServerFactory using the shaded netty. This is the recommended default for gRPC.
+     *
+     * @param properties The properties used to configure the server.
+     * @param serviceDiscoverer The discoverer used to identify the services that should be served.
+     * @param serverConfigurers The server configurers that contain additional configuration for the server.
+     * @return The shadedNettyGrpcServerFactory bean.
+     */
+    @ConditionalOnClass(name = {"io.grpc.netty.shaded.io.netty.channel.Channel",
+            "io.grpc.netty.shaded.io.grpc.netty.NettyServerBuilder"})
+    @Bean
+    public ShadedNettyGrpcServerFactory shadedNettyGrpcServerFactory(final GrpcServerProperties properties,
+            final GrpcServiceDiscoverer serviceDiscoverer, final List<GrpcServerConfigurer> serverConfigurers) {
+        final ShadedNettyGrpcServerFactory factory = new ShadedNettyGrpcServerFactory(properties, serverConfigurers);
+        for (final GrpcServiceDefinition service : serviceDiscoverer.findGrpcServices()) {
+            factory.addService(service);
+        }
+        return factory;
+    }
+
+    /**
+     * The server lifecycle bean for a shaded netty based server.
+     *
+     * @param factory The factory used to create the lifecycle.
+     * @return The inter-process server lifecycle bean.
+     */
+    @ConditionalOnClass(name = {"io.grpc.netty.shaded.io.netty.channel.Channel",
+            "io.grpc.netty.shaded.io.grpc.netty.NettyServerBuilder"})
+    @Bean
+    public GrpcServerLifecycle shadedNettyGrpcServerLifecycle(ShadedNettyGrpcServerFactory factory) {
+        return new GrpcServerLifecycle(factory);
+    }
+
+    // Then try the normal netty server
+    /**
+     * Creates a GrpcServerFactory using the non-shaded netty. This is the fallback, if the shaded one is not present.
+     *
+     * @param properties The properties used to configure the server.
+     * @param serviceDiscoverer The discoverer used to identify the services that should be served.
+     * @param serverConfigurers The server configurers that contain additional configuration for the server.
+     * @return The shadedNettyGrpcServerFactory bean.
+     */
+    @ConditionalOnMissingBean
+    @ConditionalOnClass(name = {"io.netty.channel.Channel", "io.grpc.netty.NettyServerBuilder"})
+    @Bean
+    public NettyGrpcServerFactory nettyGrpcServerFactory(final GrpcServerProperties properties,
+            final GrpcServiceDiscoverer serviceDiscoverer, final List<GrpcServerConfigurer> serverConfigurers) {
+        final NettyGrpcServerFactory factory = new NettyGrpcServerFactory(properties, serverConfigurers);
+        for (final GrpcServiceDefinition service : serviceDiscoverer.findGrpcServices()) {
+            factory.addService(service);
+        }
+        return factory;
+    }
+
+    /**
+     * The server lifecycle bean for netty based server.
+     *
+     * @param factory The factory used to create the lifecycle.
+     * @return The inter-process server lifecycle bean.
+     */
+    @ConditionalOnMissingBean
+    @ConditionalOnClass(name = {"io.netty.channel.Channel", "io.grpc.netty.NettyServerBuilder"})
+    @Bean
+    public GrpcServerLifecycle nettyGrpcServerLifecycle(final NettyGrpcServerFactory factory) {
+        return new GrpcServerLifecycle(factory);
+    }
+
+    /**
+     * Creates a GrpcServerFactory using the in-process-server, if a name is specified.
+     *
+     * @param properties The properties used to configure the server.
+     * @param serviceDiscoverer The discoverer used to identify the services that should be served.
+     * @return The shadedNettyGrpcServerFactory bean.
+     */
+    @ConditionalOnProperty(prefix = "grpc.server", name = "inProcessName")
+    @Bean
+    public InProcessGrpcServerFactory inProcessGrpcServerFactory(final GrpcServerProperties properties,
+            final GrpcServiceDiscoverer serviceDiscoverer) {
+        final InProcessGrpcServerFactory factory = new InProcessGrpcServerFactory(properties);
+        for (final GrpcServiceDefinition service : serviceDiscoverer.findGrpcServices()) {
+            factory.addService(service);
+        }
+        return factory;
+    }
+
+    /**
+     * The server lifecycle bean for the in-process-server.
+     *
+     * @param factory The factory used to create the lifecycle.
+     * @return The in-process server lifecycle bean.
+     */
+    @ConditionalOnBean(InProcessGrpcServerFactory.class)
+    @Bean
+    public GrpcServerLifecycle inProcessgrpcServerLifecycle(final InProcessGrpcServerFactory factory) {
+        return new GrpcServerLifecycle(factory);
+    }
+
+}

--- a/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/config/GrpcServerProperties.java
+++ b/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/config/GrpcServerProperties.java
@@ -77,6 +77,14 @@ public class GrpcServerProperties {
     private int port = 9090;
 
     /**
+     * The name of the in-process server. If not set, then the in process server won't be started.
+     *
+     * @param inProcessName The name of the in-process server.
+     * @return The name of the in-process server or null if isn't configured.
+     */
+    private String inProcessName;
+
+    /**
      * Setting to enable keepAlive. Default to {@code false}.
      *
      * @param enableKeepAlive Whether keep alive should be enabled.

--- a/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/serverfactory/InProcessGrpcServerFactory.java
+++ b/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/serverfactory/InProcessGrpcServerFactory.java
@@ -84,7 +84,7 @@ public class InProcessGrpcServerFactory extends AbstractGrpcServerFactory<InProc
 
     @Override
     public String getAddress() {
-        return "inProcess:" + this.name;
+        return "in-process:" + this.name;
     }
 
     @Override

--- a/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/serverfactory/InProcessGrpcServerFactory.java
+++ b/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/serverfactory/InProcessGrpcServerFactory.java
@@ -37,6 +37,26 @@ public class InProcessGrpcServerFactory extends AbstractGrpcServerFactory<InProc
     /**
      * Creates a new in process server factory with the given properties.
      *
+     * @param properties The properties used to configure the server.
+     */
+    public InProcessGrpcServerFactory(final GrpcServerProperties properties) {
+        this(properties.getInProcessName(), properties);
+    }
+
+    /**
+     * Creates a new in process server factory with the given properties.
+     *
+     * @param properties The properties used to configure the server.
+     * @param serverConfigurers The server configurers to use. Can be empty.
+     */
+    public InProcessGrpcServerFactory(final GrpcServerProperties properties,
+            final List<GrpcServerConfigurer> serverConfigurers) {
+        this(properties.getInProcessName(), properties, serverConfigurers);
+    }
+
+    /**
+     * Creates a new in process server factory with the given properties.
+     *
      * @param name The name of the in process server.
      * @param properties The properties used to configure the server.
      */

--- a/grpc-server-spring-boot-autoconfigure/src/main/resources/META-INF/spring.factories
+++ b/grpc-server-spring-boot-autoconfigure/src/main/resources/META-INF/spring.factories
@@ -3,6 +3,7 @@ org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
 net.devh.boot.grpc.server.autoconfigure.GrpcMetadataConsulConfiguration,\
 net.devh.boot.grpc.server.autoconfigure.GrpcMetadataEurekaConfiguration,\
 net.devh.boot.grpc.server.autoconfigure.GrpcServerAutoConfiguration,\
+net.devh.boot.grpc.server.autoconfigure.GrpcServerFactoryAutoConfiguration,\
 net.devh.boot.grpc.server.autoconfigure.GrpcServerSecurityAutoConfiguration,\
 net.devh.boot.grpc.server.autoconfigure.GrpcServerMetricAutoConfiguration,\
 net.devh.boot.grpc.server.autoconfigure.GrpcServerTraceAutoConfiguration

--- a/tests/src/test/java/net/devh/boot/grpc/test/InterAndInProcessSetupTest.java
+++ b/tests/src/test/java/net/devh/boot/grpc/test/InterAndInProcessSetupTest.java
@@ -1,0 +1,183 @@
+/*
+ * Copyright (c) 2016-2019 Michael Zhang <yidongnan@gmail.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package net.devh.boot.grpc.test;
+
+import static io.grpc.Status.Code.UNIMPLEMENTED;
+import static net.devh.boot.grpc.test.proto.TestServiceGrpc.newBlockingStub;
+import static net.devh.boot.grpc.test.util.GrpcAssertions.assertFutureThrowsStatus;
+import static net.devh.boot.grpc.test.util.GrpcAssertions.assertThrowsStatus;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+
+import javax.annotation.PostConstruct;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+import com.google.protobuf.Empty;
+
+import io.grpc.Channel;
+import io.grpc.internal.testing.StreamRecorder;
+import lombok.extern.slf4j.Slf4j;
+import net.devh.boot.grpc.client.inject.GrpcClient;
+import net.devh.boot.grpc.server.config.GrpcServerProperties;
+import net.devh.boot.grpc.test.config.BaseAutoConfiguration;
+import net.devh.boot.grpc.test.config.ServiceConfiguration;
+import net.devh.boot.grpc.test.proto.SomeType;
+import net.devh.boot.grpc.test.proto.TestServiceGrpc.TestServiceBlockingStub;
+import net.devh.boot.grpc.test.proto.TestServiceGrpc.TestServiceFutureStub;
+import net.devh.boot.grpc.test.proto.TestServiceGrpc.TestServiceStub;
+
+/**
+ * Tests whether the parallel setup of inter- and in-process-server/client works.
+ *
+ * @author Daniel Theuke (daniel.theuke@heuboe.de)
+ */
+@Slf4j
+@SpringBootTest(properties = {
+        "grpc.server.inProcessName=test",
+        "grpc.server.port=9191",
+        "grpc.client.GLOBAL.negotiationType=PLAINTEXT",
+        "grpc.client.inProcess.address=inProcess:test",
+        "grpc.client.interProcess.address=static://localhost:9191"})
+@EnableConfigurationProperties(GrpcServerProperties.class)
+@SpringJUnitConfig(classes = {ServiceConfiguration.class, BaseAutoConfiguration.class})
+@DirtiesContext
+public class InterAndInProcessSetupTest {
+
+    private static final Empty EMPTY = Empty.getDefaultInstance();
+
+    @GrpcClient("interProcess")
+    protected Channel interProcessChannel;
+    @GrpcClient("interProcess")
+    protected TestServiceStub interProcessServiceStub;
+    @GrpcClient("interProcess")
+    protected TestServiceBlockingStub interProcessServiceBlockingStub;
+    @GrpcClient("interProcess")
+    protected TestServiceFutureStub interProcessServiceFutureStub;
+
+    @GrpcClient("inProcess")
+    protected Channel inProcessChannel;
+    @GrpcClient("inProcess")
+    protected TestServiceStub inProcessServiceStub;
+    @GrpcClient("inProcess")
+    protected TestServiceBlockingStub inProcessServiceBlockingStub;
+    @GrpcClient("inProcess")
+    protected TestServiceFutureStub inProcessServiceFutureStub;
+
+    public InterAndInProcessSetupTest() {
+        log.info("--- InterAndInProcessSetupTest ---");
+    }
+
+    @PostConstruct
+    public void init() {
+        // Test injection
+        assertNotNull(this.interProcessChannel, "interProcessChannel");
+        assertNotNull(this.interProcessServiceBlockingStub, "interProcessServiceBlockingStub");
+        assertNotNull(this.interProcessServiceFutureStub, "interProcessServiceFutureStub");
+        assertNotNull(this.interProcessServiceStub, "interProcessServiceStub");
+
+        assertNotNull(this.inProcessChannel, "inProcessChannel");
+        assertNotNull(this.inProcessServiceBlockingStub, "inProcessServiceBlockingStub");
+        assertNotNull(this.inProcessServiceFutureStub, "inProcessServiceFutureStub");
+        assertNotNull(this.inProcessServiceStub, "inProcessServiceStub");
+    }
+
+    /**
+     * Test successful call for inter-process server.
+     *
+     * @throws ExecutionException Should never happen.
+     * @throws InterruptedException Should never happen.
+     */
+    @Test
+    @DirtiesContext
+    public void testSuccessfulInterProcessCall() throws InterruptedException, ExecutionException {
+        log.info("--- Starting tests with successful inter-process call ---");
+        assertEquals("1.2.3", newBlockingStub(this.interProcessChannel).normal(EMPTY).getVersion());
+
+        final StreamRecorder<SomeType> streamRecorder = StreamRecorder.create();
+        this.interProcessServiceStub.normal(EMPTY, streamRecorder);
+        assertEquals("1.2.3", streamRecorder.firstValue().get().getVersion());
+        assertEquals("1.2.3", this.interProcessServiceBlockingStub.normal(EMPTY).getVersion());
+        assertEquals("1.2.3", this.interProcessServiceFutureStub.normal(EMPTY).get().getVersion());
+        log.info("--- Test completed ---");
+    }
+
+    /**
+     * Test successful call for in-process server.
+     *
+     * @throws ExecutionException Should never happen.
+     * @throws InterruptedException Should never happen.
+     */
+    @Test
+    @DirtiesContext
+    public void testSuccessfulInProcessCall() throws InterruptedException, ExecutionException {
+        log.info("--- Starting tests with successful in-process call ---");
+        assertEquals("1.2.3", newBlockingStub(this.inProcessChannel).normal(EMPTY).getVersion());
+
+        final StreamRecorder<SomeType> streamRecorder = StreamRecorder.create();
+        this.inProcessServiceStub.normal(EMPTY, streamRecorder);
+        assertEquals("1.2.3", streamRecorder.firstValue().get().getVersion());
+        assertEquals("1.2.3", this.inProcessServiceBlockingStub.normal(EMPTY).getVersion());
+        assertEquals("1.2.3", this.inProcessServiceFutureStub.normal(EMPTY).get().getVersion());
+        log.info("--- Test completed ---");
+    }
+
+    /**
+     * Test failing call for inter-process server.
+     */
+    @Test
+    @DirtiesContext
+    public void testFailingInterProcessCall() {
+        log.info("--- Starting tests with failing inter-process call ---");
+        assertThrowsStatus(UNIMPLEMENTED, () -> newBlockingStub(this.interProcessChannel).unimplemented(EMPTY));
+
+        final StreamRecorder<SomeType> streamRecorder = StreamRecorder.create();
+        this.interProcessServiceStub.unimplemented(EMPTY, streamRecorder);
+        assertFutureThrowsStatus(UNIMPLEMENTED, streamRecorder.firstValue(), 5, TimeUnit.SECONDS);
+        assertThrowsStatus(UNIMPLEMENTED, () -> this.interProcessServiceBlockingStub.unimplemented(EMPTY));
+        assertFutureThrowsStatus(UNIMPLEMENTED, this.interProcessServiceFutureStub.unimplemented(EMPTY),
+                5, TimeUnit.SECONDS);
+        log.info("--- Test completed ---");
+    }
+
+    /**
+     * Test failing call for in-process server.
+     */
+    @Test
+    @DirtiesContext
+    public void testFailingInProcessCall() {
+        log.info("--- Starting tests with failing in-process call ---");
+        assertThrowsStatus(UNIMPLEMENTED, () -> newBlockingStub(this.inProcessChannel).unimplemented(EMPTY));
+
+        final StreamRecorder<SomeType> streamRecorder = StreamRecorder.create();
+        this.inProcessServiceStub.unimplemented(EMPTY, streamRecorder);
+        assertFutureThrowsStatus(UNIMPLEMENTED, streamRecorder.firstValue(), 5, TimeUnit.SECONDS);
+        assertThrowsStatus(UNIMPLEMENTED, () -> this.inProcessServiceBlockingStub.unimplemented(EMPTY));
+        assertFutureThrowsStatus(UNIMPLEMENTED, this.inProcessServiceFutureStub.unimplemented(EMPTY),
+                5, TimeUnit.SECONDS);
+        log.info("--- Test completed ---");
+    }
+
+}

--- a/tests/src/test/java/net/devh/boot/grpc/test/InterAndInProcessSetupTest.java
+++ b/tests/src/test/java/net/devh/boot/grpc/test/InterAndInProcessSetupTest.java
@@ -59,7 +59,7 @@ import net.devh.boot.grpc.test.proto.TestServiceGrpc.TestServiceStub;
         "grpc.server.inProcessName=test",
         "grpc.server.port=9191",
         "grpc.client.GLOBAL.negotiationType=PLAINTEXT",
-        "grpc.client.inProcess.address=inProcess:test",
+        "grpc.client.inProcess.address=in-process:test",
         "grpc.client.interProcess.address=static://localhost:9191"})
 @EnableConfigurationProperties(GrpcServerProperties.class)
 @SpringJUnitConfig(classes = {ServiceConfiguration.class, BaseAutoConfiguration.class})

--- a/tests/src/test/java/net/devh/boot/grpc/test/config/BaseAutoConfiguration.java
+++ b/tests/src/test/java/net/devh/boot/grpc/test/config/BaseAutoConfiguration.java
@@ -23,11 +23,13 @@ import org.springframework.context.annotation.Configuration;
 import net.devh.boot.grpc.client.autoconfigure.GrpcClientAutoConfiguration;
 import net.devh.boot.grpc.common.autoconfigure.GrpcCommonCodecAutoConfiguration;
 import net.devh.boot.grpc.server.autoconfigure.GrpcServerAutoConfiguration;
+import net.devh.boot.grpc.server.autoconfigure.GrpcServerFactoryAutoConfiguration;
 import net.devh.boot.grpc.server.autoconfigure.GrpcServerSecurityAutoConfiguration;
 
 @Configuration
 @ImportAutoConfiguration({GrpcCommonCodecAutoConfiguration.class, GrpcServerAutoConfiguration.class,
-        GrpcServerSecurityAutoConfiguration.class, GrpcClientAutoConfiguration.class})
+        GrpcServerFactoryAutoConfiguration.class, GrpcServerSecurityAutoConfiguration.class,
+        GrpcClientAutoConfiguration.class})
 public class BaseAutoConfiguration {
 
 }


### PR DESCRIPTION
Adds #176 

This PR adds simultaneous support for in- and inter-process channels/servers.

----------------------------------

For the client side you just have to use the `inProcess:` prefix to target an inProcess service, at the same time you can also define the inter-process connections.

**Note:** This only works if you either use the default `GrpcChannelFactory` or wrap your own factory appropriately.

````properties
grpc.client.inProcess.address=inProcess:test
grpc.client.interProcess.address=static://localhost:9191
````

------------------------------------

For the server side you just have to use the new `grpc.server.inProcessName` property.

````properties
grpc.server.inProcessName=test
````

**Note:** The server auto configuration will only be used, if you don't define any of the server beans ( `GrpcServerFactory`/`GrpcServerLifecycle`) yourself.

------------------------------------

**Limitations**

Currently it is not possible to disable the inter-process server beans with property files alone. Using the server port 0 (random) will reduce the chance of collisions during tests that don't need the inter-process server. Another alternative could be creating a test configuration similar to `net.devh.boot.grpc.test.config.InProcessConfiguration` from the tests module. Maybe I'll improve that in the future.