### PR TITLE
Adds configurable ciphers and protocols for clients and servers

### DIFF
--- a/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/channelfactory/NettyChannelFactory.java
+++ b/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/channelfactory/NettyChannelFactory.java
@@ -104,15 +104,11 @@ public class NettyChannelFactory extends AbstractChannelFactory<NettyChannelBuil
             }
 
             if (security.getCiphers() != null && !security.getCiphers().isEmpty()) {
-                // splits the cipher list at colons, commas or spaces
-                String[] extractedCiphers = security.getCiphers().split("[:, ]");
-                sslContextBuilder.ciphers(Arrays.asList(extractedCiphers));
+                sslContextBuilder.ciphers(security.getCiphers());
             }
 
-            if (security.getProtocols() != null && !security.getProtocols().isEmpty()) {
-                // splits the protocol list at colons, commas or spaces
-                String[] extractedProtocols = security.getProtocols().split("[:, ]");
-                sslContextBuilder.protocols(extractedProtocols);
+            if (security.getProtocols() != null && security.getProtocols().length > 0) {
+                sslContextBuilder.protocols(security.getProtocols());
             }
 
             try {

--- a/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/channelfactory/NettyChannelFactory.java
+++ b/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/channelfactory/NettyChannelFactory.java
@@ -20,7 +20,6 @@ package net.devh.boot.grpc.client.channelfactory;
 import static java.util.Objects.requireNonNull;
 
 import java.io.File;
-import java.util.Arrays;
 import java.util.List;
 
 import javax.net.ssl.SSLException;

--- a/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/channelfactory/NettyChannelFactory.java
+++ b/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/channelfactory/NettyChannelFactory.java
@@ -103,13 +103,13 @@ public class NettyChannelFactory extends AbstractChannelFactory<NettyChannelBuil
                 sslContextBuilder.trustManager(trustCertCollectionFile);
             }
 
-            if(security.getCiphers() != null && !security.getCiphers().isEmpty()) {
+            if (security.getCiphers() != null && !security.getCiphers().isEmpty()) {
                 // splits the cipher list at colons, commas or spaces
                 String[] extractedCiphers = security.getCiphers().split("[:, ]");
                 sslContextBuilder.ciphers(Arrays.asList(extractedCiphers));
             }
 
-            if(security.getProtocols() != null && !security.getProtocols().isEmpty()) {
+            if (security.getProtocols() != null && !security.getProtocols().isEmpty()) {
                 // splits the protocol list at colons, commas or spaces
                 String[] extractedProtocols = security.getProtocols().split("[:, ]");
                 sslContextBuilder.protocols(extractedProtocols);

--- a/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/channelfactory/NettyChannelFactory.java
+++ b/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/channelfactory/NettyChannelFactory.java
@@ -20,6 +20,7 @@ package net.devh.boot.grpc.client.channelfactory;
 import static java.util.Objects.requireNonNull;
 
 import java.io.File;
+import java.util.Arrays;
 import java.util.List;
 
 import javax.net.ssl.SSLException;
@@ -100,6 +101,18 @@ public class NettyChannelFactory extends AbstractChannelFactory<NettyChannelBuil
             if (trustCertCollectionPath != null && !trustCertCollectionPath.isEmpty()) {
                 final File trustCertCollectionFile = toCheckedFile("trustCertCollection", trustCertCollectionPath);
                 sslContextBuilder.trustManager(trustCertCollectionFile);
+            }
+
+            if(security.getCiphers() != null && !security.getCiphers().isEmpty()) {
+                // splits the cipher list at colons, commas or spaces
+                String[] extractedCiphers = security.getCiphers().split("[:, ]");
+                sslContextBuilder.ciphers(Arrays.asList(extractedCiphers));
+            }
+
+            if(security.getProtocols() != null && !security.getProtocols().isEmpty()) {
+                // splits the protocol list at colons, commas or spaces
+                String[] extractedProtocols = security.getProtocols().split("[:, ]");
+                sslContextBuilder.protocols(extractedProtocols);
             }
 
             try {

--- a/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/channelfactory/ShadedNettyChannelFactory.java
+++ b/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/channelfactory/ShadedNettyChannelFactory.java
@@ -20,6 +20,7 @@ package net.devh.boot.grpc.client.channelfactory;
 import static java.util.Objects.requireNonNull;
 
 import java.io.File;
+import java.util.Arrays;
 import java.util.List;
 
 import javax.net.ssl.SSLException;
@@ -98,6 +99,18 @@ public class ShadedNettyChannelFactory extends AbstractChannelFactory<NettyChann
             if (trustCertCollectionPath != null && !trustCertCollectionPath.isEmpty()) {
                 final File trustCertCollectionFile = toCheckedFile("trustCertCollection", trustCertCollectionPath);
                 sslContextBuilder.trustManager(trustCertCollectionFile);
+            }
+
+            if(security.getCiphers() != null && !security.getCiphers().isEmpty()) {
+                // splits the cipher list at colons, commas or spaces
+                String[] extractedCiphers = security.getCiphers().split("[:, ]");
+                sslContextBuilder.ciphers(Arrays.asList(extractedCiphers));
+            }
+
+            if(security.getProtocols() != null && !security.getProtocols().isEmpty()) {
+                // splits the protocol list at colons, commas or spaces
+                String[] extractedProtocols = security.getProtocols().split("[:, ]");
+                sslContextBuilder.protocols(extractedProtocols);
             }
 
             try {

--- a/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/channelfactory/ShadedNettyChannelFactory.java
+++ b/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/channelfactory/ShadedNettyChannelFactory.java
@@ -20,7 +20,6 @@ package net.devh.boot.grpc.client.channelfactory;
 import static java.util.Objects.requireNonNull;
 
 import java.io.File;
-import java.util.Arrays;
 import java.util.List;
 
 import javax.net.ssl.SSLException;

--- a/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/channelfactory/ShadedNettyChannelFactory.java
+++ b/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/channelfactory/ShadedNettyChannelFactory.java
@@ -101,13 +101,13 @@ public class ShadedNettyChannelFactory extends AbstractChannelFactory<NettyChann
                 sslContextBuilder.trustManager(trustCertCollectionFile);
             }
 
-            if(security.getCiphers() != null && !security.getCiphers().isEmpty()) {
+            if (security.getCiphers() != null && !security.getCiphers().isEmpty()) {
                 // splits the cipher list at colons, commas or spaces
                 String[] extractedCiphers = security.getCiphers().split("[:, ]");
                 sslContextBuilder.ciphers(Arrays.asList(extractedCiphers));
             }
 
-            if(security.getProtocols() != null && !security.getProtocols().isEmpty()) {
+            if (security.getProtocols() != null && !security.getProtocols().isEmpty()) {
                 // splits the protocol list at colons, commas or spaces
                 String[] extractedProtocols = security.getProtocols().split("[:, ]");
                 sslContextBuilder.protocols(extractedProtocols);

--- a/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/channelfactory/ShadedNettyChannelFactory.java
+++ b/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/channelfactory/ShadedNettyChannelFactory.java
@@ -102,15 +102,11 @@ public class ShadedNettyChannelFactory extends AbstractChannelFactory<NettyChann
             }
 
             if (security.getCiphers() != null && !security.getCiphers().isEmpty()) {
-                // splits the cipher list at colons, commas or spaces
-                String[] extractedCiphers = security.getCiphers().split("[:, ]");
-                sslContextBuilder.ciphers(Arrays.asList(extractedCiphers));
+                sslContextBuilder.ciphers(security.getCiphers());
             }
 
-            if (security.getProtocols() != null && !security.getProtocols().isEmpty()) {
-                // splits the protocol list at colons, commas or spaces
-                String[] extractedProtocols = security.getProtocols().split("[:, ]");
-                sslContextBuilder.protocols(extractedProtocols);
+            if (security.getProtocols() != null && security.getProtocols().length > 0) {
+                sslContextBuilder.protocols(security.getProtocols());
             }
 
             try {

--- a/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/config/GrpcChannelProperties.java
+++ b/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/config/GrpcChannelProperties.java
@@ -611,6 +611,12 @@ public class GrpcChannelProperties {
             if (this.authorityOverride == null) {
                 this.authorityOverride = config.authorityOverride;
             }
+            if(this.ciphers == null) {
+                this.ciphers = config.ciphers;
+            }
+            if(this.protocols == null) {
+                this.protocols = config.protocols;
+            }
         }
 
     }

--- a/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/config/GrpcChannelProperties.java
+++ b/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/config/GrpcChannelProperties.java
@@ -21,6 +21,8 @@ import java.io.File;
 import java.net.URI;
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
+import java.util.Arrays;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import org.springframework.boot.convert.DurationUnit;
@@ -550,12 +552,12 @@ public class GrpcChannelProperties {
 
         // --------------------------------------------------
 
-        private String ciphers = null;
+        private List<String> ciphers = null;
 
         /**
          * @return The cipher suite accepted for secure connections or null.
          */
-        public String getCiphers() {
+        public List<String> getCiphers() {
             return ciphers;
         }
 
@@ -563,17 +565,17 @@ public class GrpcChannelProperties {
          * @param ciphers Cipher suite consisting of one or more cipher strings separated by colons, commas or spaces
          */
         public void setCiphers(String ciphers) {
-            this.ciphers = ciphers;
+            this.ciphers = Arrays.asList(ciphers.split("[ :,]"));
         }
 
         // --------------------------------------------------
 
-        private String protocols = null;
+        private String[] protocols = null;
 
         /**
          * @return The protocols accepted for secure connections or null.
          */
-        public String getProtocols() {
+        public String[] getProtocols() {
             return protocols;
         }
 
@@ -581,7 +583,7 @@ public class GrpcChannelProperties {
          * @param protocols Protocol list consisting of one or more protocols separated by colons, commas or spaces.
          */
         public void setProtocols(String protocols) {
-            this.protocols = protocols;
+            this.protocols = protocols.split("[ :,]");
         }
 
         // --------------------------------------------------

--- a/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/config/GrpcChannelProperties.java
+++ b/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/config/GrpcChannelProperties.java
@@ -613,10 +613,10 @@ public class GrpcChannelProperties {
             if (this.authorityOverride == null) {
                 this.authorityOverride = config.authorityOverride;
             }
-            if(this.ciphers == null) {
+            if (this.ciphers == null) {
                 this.ciphers = config.ciphers;
             }
-            if(this.protocols == null) {
+            if (this.protocols == null) {
                 this.protocols = config.protocols;
             }
         }

--- a/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/config/GrpcChannelProperties.java
+++ b/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/config/GrpcChannelProperties.java
@@ -550,6 +550,42 @@ public class GrpcChannelProperties {
 
         // --------------------------------------------------
 
+        private String ciphers = null;
+
+        /**
+         * @return The cipher suite accepted for secure connections or null.
+         */
+        public String getCiphers() {
+            return ciphers;
+        }
+
+        /**
+         * @param ciphers Cipher suite consisting of one or more cipher strings separated by colons, commas or spaces
+         */
+        public void setCiphers(String ciphers) {
+            this.ciphers = ciphers;
+        }
+
+        // --------------------------------------------------
+
+        private String protocols = null;
+
+        /**
+         * @return The protocols accepted for secure connections or null.
+         */
+        public String getProtocols() {
+            return protocols;
+        }
+
+        /**
+         * @param protocols Protocol list consisting of one or more protocols separated by colons, commas or spaces.
+         */
+        public void setProtocols(String protocols) {
+            this.protocols = protocols;
+        }
+
+        // --------------------------------------------------
+
         /**
          * Copies the defaults from the given configuration. Values are considered "default" if they are null. Please
          * note that the getters might return fallback values instead.

--- a/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/config/GrpcServerProperties.java
+++ b/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/config/GrpcServerProperties.java
@@ -237,7 +237,8 @@ public class GrpcServerProperties {
          * Specifies the protocols accepted for secure connections. If {@code null} or empty it will use the system's
          * default (all supported) protocols.
          *
-         * @return The  cipher suites accepted for secure connections or null.
+         * @param protocols Protocol list consisting of one or more protocols separated by colons, commas or spaces.
+         * @return The protocols accepted for secure connections or null.
          */
         private String protocols = null;
 

--- a/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/config/GrpcServerProperties.java
+++ b/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/config/GrpcServerProperties.java
@@ -225,6 +225,22 @@ public class GrpcServerProperties {
          */
         private String trustCertCollectionPath = null;
 
+        /**
+         * Specifies the cipher suite. If {@code null} or empty it will use the system's default cipher suite.
+         *
+         * @param ciphers Cipher suite consisting of one or more cipher strings separated by colons, commas or spaces.
+         * @return The cipher suite accepted for secure connections or null.
+         */
+        private String ciphers = null;
+
+        /**
+         * Specifies the protocols accepted for secure connections. If {@code null} or empty it will use the system's
+         * default (all supported) protocols.
+         *
+         * @return The  cipher suites accepted for secure connections or null.
+         */
+        private String protocols = null;
+
     }
 
     /**

--- a/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/config/GrpcServerProperties.java
+++ b/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/config/GrpcServerProperties.java
@@ -20,6 +20,8 @@ package net.devh.boot.grpc.server.config;
 import java.io.File;
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
+import java.util.Arrays;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -228,10 +230,14 @@ public class GrpcServerProperties {
         /**
          * Specifies the cipher suite. If {@code null} or empty it will use the system's default cipher suite.
          *
-         * @param ciphers Cipher suite consisting of one or more cipher strings separated by colons, commas or spaces.
+         * @param ciphers List of allowed ciphers
          * @return The cipher suite accepted for secure connections or null.
          */
-        private String ciphers = null;
+        private List<String> ciphers = null;
+
+        public void setCiphers(String ciphers) {
+            this.ciphers = Arrays.asList(ciphers.split("[ :,]"));
+        }
 
         /**
          * Specifies the protocols accepted for secure connections. If {@code null} or empty it will use the system's
@@ -240,8 +246,11 @@ public class GrpcServerProperties {
          * @param protocols Protocol list consisting of one or more protocols separated by colons, commas or spaces.
          * @return The protocols accepted for secure connections or null.
          */
-        private String protocols = null;
+        private String[] protocols = null;
 
+        public void setProtocols(String protocols) {
+            this.protocols = protocols.split("[ :,]");
+        }
     }
 
     /**

--- a/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/serverfactory/NettyGrpcServerFactory.java
+++ b/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/serverfactory/NettyGrpcServerFactory.java
@@ -95,15 +95,11 @@ public class NettyGrpcServerFactory extends AbstractGrpcServerFactory<NettyServe
             }
 
             if (security.getCiphers() != null && !security.getCiphers().isEmpty()) {
-                // splits the cipher list at colons, commas or spaces
-                String[] extractedCiphers = security.getCiphers().split("[:, ]");
-                sslContextBuilder.ciphers(Arrays.asList(extractedCiphers));
+                sslContextBuilder.ciphers(security.getCiphers());
             }
 
-            if (security.getProtocols() != null && !security.getProtocols().isEmpty()) {
-                // splits the protocol list at colons, commas or spaces
-                String[] extractedProtocols = security.getProtocols().split("[:, ]");
-                sslContextBuilder.protocols(extractedProtocols);
+            if (security.getProtocols() != null && security.getProtocols().length > 0) {
+                sslContextBuilder.protocols(security.getProtocols());
             }
 
             try {

--- a/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/serverfactory/NettyGrpcServerFactory.java
+++ b/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/serverfactory/NettyGrpcServerFactory.java
@@ -19,7 +19,6 @@ package net.devh.boot.grpc.server.serverfactory;
 
 import java.io.File;
 import java.net.InetSocketAddress;
-import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 

--- a/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/serverfactory/NettyGrpcServerFactory.java
+++ b/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/serverfactory/NettyGrpcServerFactory.java
@@ -94,13 +94,13 @@ public class NettyGrpcServerFactory extends AbstractGrpcServerFactory<NettyServe
                 }
             }
 
-            if(security.getCiphers() != null && !security.getCiphers().isEmpty()) {
+            if (security.getCiphers() != null && !security.getCiphers().isEmpty()) {
                 // splits the cipher list at colons, commas or spaces
                 String[] extractedCiphers = security.getCiphers().split("[:, ]");
                 sslContextBuilder.ciphers(Arrays.asList(extractedCiphers));
             }
 
-            if(security.getProtocols() != null && !security.getProtocols().isEmpty()) {
+            if (security.getProtocols() != null && !security.getProtocols().isEmpty()) {
                 // splits the protocol list at colons, commas or spaces
                 String[] extractedProtocols = security.getProtocols().split("[:, ]");
                 sslContextBuilder.protocols(extractedProtocols);

--- a/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/serverfactory/NettyGrpcServerFactory.java
+++ b/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/serverfactory/NettyGrpcServerFactory.java
@@ -19,6 +19,7 @@ package net.devh.boot.grpc.server.serverfactory;
 
 import java.io.File;
 import java.net.InetSocketAddress;
+import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
@@ -91,6 +92,18 @@ public class NettyGrpcServerFactory extends AbstractGrpcServerFactory<NettyServe
                     final File trustCertCollectionFile = toCheckedFile("trustCertCollection", trustCertCollectionPath);
                     sslContextBuilder.trustManager(trustCertCollectionFile);
                 }
+            }
+
+            if(security.getCiphers() != null && !security.getCiphers().isEmpty()) {
+                // splits the cipher list at colons, commas or spaces
+                String[] extractedCiphers = security.getCiphers().split("[:, ]");
+                sslContextBuilder.ciphers(Arrays.asList(extractedCiphers));
+            }
+
+            if(security.getProtocols() != null && !security.getProtocols().isEmpty()) {
+                // splits the protocol list at colons, commas or spaces
+                String[] extractedProtocols = security.getProtocols().split("[:, ]");
+                sslContextBuilder.protocols(extractedProtocols);
             }
 
             try {

--- a/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/serverfactory/ShadedNettyGrpcServerFactory.java
+++ b/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/serverfactory/ShadedNettyGrpcServerFactory.java
@@ -96,15 +96,11 @@ public class ShadedNettyGrpcServerFactory
             }
 
             if (security.getCiphers() != null && !security.getCiphers().isEmpty()) {
-                // splits the cipher list at colons, commas or spaces
-                String[] extractedCiphers = security.getCiphers().split("[:, ]");
-                sslContextBuilder.ciphers(Arrays.asList(extractedCiphers));
+                sslContextBuilder.ciphers(security.getCiphers());
             }
 
-            if (security.getProtocols() != null && !security.getProtocols().isEmpty()) {
-                // splits the protocol list at colons, commas or spaces
-                String[] extractedProtocols = security.getProtocols().split("[:, ]");
-                sslContextBuilder.protocols(extractedProtocols);
+            if (security.getProtocols() != null && security.getProtocols().length > 0) {
+                sslContextBuilder.protocols(security.getProtocols());
             }
 
             try {

--- a/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/serverfactory/ShadedNettyGrpcServerFactory.java
+++ b/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/serverfactory/ShadedNettyGrpcServerFactory.java
@@ -95,13 +95,13 @@ public class ShadedNettyGrpcServerFactory
                 }
             }
 
-            if(security.getCiphers() != null && !security.getCiphers().isEmpty()) {
+            if (security.getCiphers() != null && !security.getCiphers().isEmpty()) {
                 // splits the cipher list at colons, commas or spaces
                 String[] extractedCiphers = security.getCiphers().split("[:, ]");
                 sslContextBuilder.ciphers(Arrays.asList(extractedCiphers));
             }
 
-            if(security.getProtocols() != null && !security.getProtocols().isEmpty()) {
+            if (security.getProtocols() != null && !security.getProtocols().isEmpty()) {
                 // splits the protocol list at colons, commas or spaces
                 String[] extractedProtocols = security.getProtocols().split("[:, ]");
                 sslContextBuilder.protocols(extractedProtocols);

--- a/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/serverfactory/ShadedNettyGrpcServerFactory.java
+++ b/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/serverfactory/ShadedNettyGrpcServerFactory.java
@@ -19,6 +19,7 @@ package net.devh.boot.grpc.server.serverfactory;
 
 import java.io.File;
 import java.net.InetSocketAddress;
+import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
@@ -92,6 +93,18 @@ public class ShadedNettyGrpcServerFactory
                     final File trustCertCollectionFile = toCheckedFile("trustCertCollection", trustCertCollectionPath);
                     sslContextBuilder.trustManager(trustCertCollectionFile);
                 }
+            }
+
+            if(security.getCiphers() != null && !security.getCiphers().isEmpty()) {
+                // splits the cipher list at colons, commas or spaces
+                String[] extractedCiphers = security.getCiphers().split("[:, ]");
+                sslContextBuilder.ciphers(Arrays.asList(extractedCiphers));
+            }
+
+            if(security.getProtocols() != null && !security.getProtocols().isEmpty()) {
+                // splits the protocol list at colons, commas or spaces
+                String[] extractedProtocols = security.getProtocols().split("[:, ]");
+                sslContextBuilder.protocols(extractedProtocols);
             }
 
             try {

--- a/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/serverfactory/ShadedNettyGrpcServerFactory.java
+++ b/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/serverfactory/ShadedNettyGrpcServerFactory.java
@@ -19,7 +19,6 @@ package net.devh.boot.grpc.server.serverfactory;
 
 import java.io.File;
 import java.net.InetSocketAddress;
-import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 

--- a/tests/src/test/java/net/devh/boot/grpc/test/CustomCiphersAndProtocolsSetupTest.java
+++ b/tests/src/test/java/net/devh/boot/grpc/test/CustomCiphersAndProtocolsSetupTest.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2016-2019 Michael Zhang <yidongnan@gmail.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package net.devh.boot.grpc.test;
+
+import com.google.protobuf.Empty;
+import io.grpc.StatusRuntimeException;
+import net.devh.boot.grpc.client.inject.GrpcClient;
+import net.devh.boot.grpc.test.config.BaseAutoConfiguration;
+import net.devh.boot.grpc.test.config.ServiceConfiguration;
+import net.devh.boot.grpc.test.proto.TestServiceGrpc;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+import javax.net.ssl.SSLHandshakeException;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest(properties = {
+        "grpc.server.security.enabled=true",
+        "grpc.server.security.certificateChainPath=src/test/resources/certificates/server.crt",
+        "grpc.server.security.privateKeyPath=src/test/resources/certificates/server.key",
+        "grpc.server.security.ciphers=TLS_AES_256_GCM_SHA384:ECDHE-RSA-AES256-GCM-SHA384",
+        "grpc.server.security.protocols=TLSv1.3:TLSv1.2",
+
+        "grpc.client.GLOBAL.security.authorityOverride=localhost",
+        "grpc.client.GLOBAL.security.trustCertCollectionPath=src/test/resources/certificates/trusted-servers-collection",
+        "grpc.client.GLOBAL.negotiationType=TLS",
+
+        "grpc.client.tls11.security.protocols=TLSv1.1",
+        "grpc.client.tls11.security.ciphers=ECDHE-RSA-AES256-SHA",
+
+        "grpc.client.tls12.security.protocols=TLSv1.2",
+        "grpc.client.tls12.security.ciphers=ECDHE-RSA-AES256-GCM-SHA384",
+
+        "grpc.client.tls13.security.protocols=TLSv1.3",
+        "grpc.client.tls13.security.ciphers=TLS_AES_256_GCM_SHA384",
+
+        "grpc.client.noSharedCiphers.security.protocols=TLSv1.2:TLSv1.1",
+        "grpc.client.noSharedCiphers.security.ciphers=ECDHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-SHA",
+
+        "grpc.client.noSharedProtocols.security.protocols=TLSv1.1",
+        "grpc.client.noSharedProtocols.security.ciphers=ECDHE-RSA-AES128-SHA",
+})
+@SpringJUnitConfig(classes = {ServiceConfiguration.class, BaseAutoConfiguration.class})
+@DirtiesContext
+class CustomCiphersAndProtocolsSetupTest extends AbstractSimpleServerClientTest {
+
+    @GrpcClient("test")
+    private TestServiceGrpc.TestServiceBlockingStub test;
+    @GrpcClient("tls11")
+    private TestServiceGrpc.TestServiceBlockingStub tlsV11Stub;
+    @GrpcClient("tls12")
+    private TestServiceGrpc.TestServiceBlockingStub tlsV12Stub;
+    @GrpcClient("tls13")
+    private TestServiceGrpc.TestServiceBlockingStub tlsV13Stub;
+    @GrpcClient("noSharedCiphers")
+    private TestServiceGrpc.TestServiceBlockingStub tlsNoSharedCiphersStub;
+    @GrpcClient("noSharedProtocols")
+    private TestServiceGrpc.TestServiceBlockingStub tlsNoSharedProtocolsStub;
+
+    /**
+     * Tests behaviour with TLSv1.1 and shared protocols. Test should succeed, as the server supports TLSv1.1.
+     */
+    @Test
+    public void testTlsV11Stub() {
+
+        Exception exception = assertThrows(StatusRuntimeException.class, () -> {
+            tlsV11Stub.normal(Empty.getDefaultInstance()).getVersion();
+        });
+        assertTrue(exception.getCause() instanceof SSLHandshakeException);
+    }
+
+    /**
+     * Tests behaviour with TLSv1.2 and shared protocols. Test should succeed, as the server supports TLSv1.2.
+     */
+    @Test
+    public void testTlsV12Stub() {
+
+        assertEquals("1.2.3",
+                tlsV12Stub.normal(Empty.getDefaultInstance()).getVersion());
+    }
+
+    /**
+     * Tests behaviour with TLSv1.3 and shared protocols. Test should succeed, as the server supports TLSv1.3.
+     */
+    @Test
+    public void testTlsV13Stub() {
+
+        assertEquals("1.2.3",
+                tlsV13Stub.normal(Empty.getDefaultInstance()).getVersion());
+    }
+
+    /**
+     * Tests behaviour with no shared ciphers. Test should fail with a {@link SSLHandshakeException}
+     */
+    @Test
+    public void testNoSharedCiphersClientStub() {
+
+        Exception exception = assertThrows(StatusRuntimeException.class, () -> {
+            tlsNoSharedCiphersStub.normal(Empty.getDefaultInstance()).getVersion();
+        });
+        assertTrue(exception.getCause() instanceof SSLHandshakeException);
+    }
+
+    /**
+     * Tests behaviour with no shared protocols. Test should fail with a {@link SSLHandshakeException} as the server
+     * does not support TLSv1.1.
+     */
+    @Test
+    public void testNoSharedProtocolsStub() {
+
+        Exception exception = assertThrows(StatusRuntimeException.class, () -> {
+            tlsNoSharedProtocolsStub.normal(Empty.getDefaultInstance()).getVersion();
+        });
+        assertTrue(exception.getCause() instanceof SSLHandshakeException);
+    }
+}

--- a/tests/src/test/java/net/devh/boot/grpc/test/CustomCiphersAndProtocolsSetupTest.java
+++ b/tests/src/test/java/net/devh/boot/grpc/test/CustomCiphersAndProtocolsSetupTest.java
@@ -78,7 +78,7 @@ class CustomCiphersAndProtocolsSetupTest extends AbstractSimpleServerClientTest 
     private TestServiceGrpc.TestServiceBlockingStub tlsNoSharedProtocolsStub;
 
     /**
-     * Tests behaviour with TLSv1.1 and shared protocols. Test should succeed, as the server supports TLSv1.1.
+     * Tests behaviour with TLSv1.1 and shared protocols. Test should fail, as the server does not support TLSv1.1.
      */
     @Test
     public void testTlsV11Stub() {

--- a/tests/src/test/java/net/devh/boot/grpc/test/CustomCiphersAndProtocolsSetupTest.java
+++ b/tests/src/test/java/net/devh/boot/grpc/test/CustomCiphersAndProtocolsSetupTest.java
@@ -17,20 +17,22 @@
 
 package net.devh.boot.grpc.test;
 
-import com.google.protobuf.Empty;
-import io.grpc.StatusRuntimeException;
-import net.devh.boot.grpc.client.inject.GrpcClient;
-import net.devh.boot.grpc.test.config.BaseAutoConfiguration;
-import net.devh.boot.grpc.test.config.ServiceConfiguration;
-import net.devh.boot.grpc.test.proto.TestServiceGrpc;
+import static org.junit.jupiter.api.Assertions.*;
+
+import javax.net.ssl.SSLHandshakeException;
+
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
-import javax.net.ssl.SSLHandshakeException;
+import com.google.protobuf.Empty;
 
-import static org.junit.jupiter.api.Assertions.*;
+import io.grpc.StatusRuntimeException;
+import net.devh.boot.grpc.client.inject.GrpcClient;
+import net.devh.boot.grpc.test.config.BaseAutoConfiguration;
+import net.devh.boot.grpc.test.config.ServiceConfiguration;
+import net.devh.boot.grpc.test.proto.TestServiceGrpc;
 
 @SpringBootTest(properties = {
         "grpc.server.security.enabled=true",


### PR DESCRIPTION
This PR adds support for specifying which protocols and ciphers should be allowed for secure connections. This works for both clients and servers

---
### Configuration

Both the protocols and the ciphers must be specified as a list, separated by either colons, spaces or commas. Colons, commas and spaces could be mixed.

**Valid out of the ordinary examples for protocol lists and cipher suites (lists)**:

```properties
grpc.server.security.protocols="TLSv1.1:TLSv1.2"
grpc.server.security.ciphers="ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-ECDSA-CHACHA20-POLY1305,ECDHE-RSA-AES128-SHA"
grpc.client.myClient.security.protocols="TLSv1.1,TLSv1.2 "
grpc.client.myClient.security.ciphers="ECDHE-ECDSA-AES128-GCM-SHA256,ECDHE-ECDSA-CHACHA20-POLY1305 ECDHE-RSA-AES128-SHA"
```


**Example Server Configuration**
```properties
grpc.server.security.protocols="TLSv1.1:TLSv1.2"
grpc.server.security.ciphers="ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-AES128-SHA"
```

**Example Client Configuration**
```properties
grpc.client.myClient.security.protocols="TLSv1.2"
grpc.client.myClient.security.ciphers="ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-ECDSA-CHACHA20-POLY1305"
```



### Behaviour if not specified

If no or an empty cipher suite or protocol list was specified, the system's default protocols or cipher suite will be used. So this is no breaking change.