### PR TITLE
Add result counter tagged with statuscode

### DIFF
--- a/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/metric/MetricCollectingClientCall.java
+++ b/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/metric/MetricCollectingClientCall.java
@@ -40,6 +40,7 @@ class MetricCollectingClientCall<Q, A> extends SimpleForwardingClientCall<Q, A> 
     private final Counter requestCounter;
     private final Counter responseCounter;
     private final Function<Code, Timer> timerFunction;
+    final Function<Code, Counter> resultFunction;
 
     /**
      * Creates a new delegating ClientCall that will wrap the given client call to collect metrics.
@@ -52,19 +53,21 @@ class MetricCollectingClientCall<Q, A> extends SimpleForwardingClientCall<Q, A> 
      */
     public MetricCollectingClientCall(final ClientCall<Q, A> delegate, final MeterRegistry registry,
             final Counter requestCounter, final Counter responseCounter,
-            final Function<Code, Timer> timerFunction) {
+            final Function<Code, Timer> timerFunction,
+            final Function<Code, Counter> resultFunction) {
         super(delegate);
         this.registry = registry;
         this.requestCounter = requestCounter;
         this.responseCounter = responseCounter;
         this.timerFunction = timerFunction;
+        this.resultFunction = resultFunction;
     }
 
     @Override
     public void start(final ClientCall.Listener<A> responseListener, final Metadata metadata) {
         super.start(
                 new MetricCollectingClientCallListener<>(responseListener, this.registry, this.responseCounter,
-                        this.timerFunction),
+                        this.timerFunction, this.resultFunction),
                 metadata);
     }
 

--- a/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/metric/MetricCollectingClientInterceptor.java
+++ b/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/metric/MetricCollectingClientInterceptor.java
@@ -18,6 +18,7 @@
 package net.devh.boot.grpc.client.metric;
 
 import static net.devh.boot.grpc.common.metric.MetricConstants.METRIC_NAME_CLIENT_PROCESSING_DURATION;
+import static net.devh.boot.grpc.common.metric.MetricConstants.METRIC_NAME_CLIENT_REQUESTS_RESULT;
 import static net.devh.boot.grpc.common.metric.MetricConstants.METRIC_NAME_CLIENT_REQUESTS_SENT;
 import static net.devh.boot.grpc.common.metric.MetricConstants.METRIC_NAME_CLIENT_RESPONSES_RECEIVED;
 import static net.devh.boot.grpc.common.metric.MetricUtils.prepareCounterFor;
@@ -101,6 +102,14 @@ public class MetricCollectingClientInterceptor extends AbstractMetricCollectingI
     }
 
     @Override
+    protected Function<Code, Counter> newResultFunction(final MethodDescriptor<?, ?> method) {
+        return asResultFunction(() -> this.counterCustomizer.apply(
+                prepareCounterFor(method,
+                        METRIC_NAME_CLIENT_REQUESTS_RESULT,
+                        "The request results as observed by the client")));
+    }
+
+    @Override
     public <Q, A> ClientCall<Q, A> interceptCall(final MethodDescriptor<Q, A> methodDescriptor,
             final CallOptions callOptions, final Channel channel) {
         final MetricSet metrics = metricsFor(methodDescriptor);
@@ -109,7 +118,8 @@ public class MetricCollectingClientInterceptor extends AbstractMetricCollectingI
                 this.registry,
                 metrics.getRequestCounter(),
                 metrics.getResponseCounter(),
-                metrics.getTimerFunction());
+                metrics.getTimerFunction(),
+                metrics.getResultFunction());
     }
 
 }

--- a/grpc-common-spring-boot/src/main/java/net/devh/boot/grpc/common/metric/MetricConstants.java
+++ b/grpc-common-spring-boot/src/main/java/net/devh/boot/grpc/common/metric/MetricConstants.java
@@ -27,9 +27,11 @@ public final class MetricConstants {
     public static final String METRIC_NAME_SERVER_PROCESSING_DURATION = "grpc.server.processing.duration";
     public static final String METRIC_NAME_SERVER_RESPONSES_SENT = "grpc.server.responses.sent";
     public static final String METRIC_NAME_SERVER_REQUESTS_RECEIVED = "grpc.server.requests.received";
+    public static final String METRIC_NAME_SERVER_REQUESTS_RESULT = "grpc.server.requests.result";
 
     public static final String METRIC_NAME_CLIENT_PROCESSING_DURATION = "grpc.client.processing.duration";
     public static final String METRIC_NAME_CLIENT_RESPONSES_RECEIVED = "grpc.client.responses.received";
+    public static final String METRIC_NAME_CLIENT_REQUESTS_RESULT = "grpc.client.requests.result";
     public static final String METRIC_NAME_CLIENT_REQUESTS_SENT = "grpc.client.requests.sent";
 
     /**

--- a/tests/src/test/java/net/devh/boot/grpc/test/metric/MetricAutoConfigurationTest.java
+++ b/tests/src/test/java/net/devh/boot/grpc/test/metric/MetricAutoConfigurationTest.java
@@ -59,7 +59,7 @@ public class MetricAutoConfigurationTest {
         for (final Meter meter : meterRegistry.getMeters()) {
             log.debug("Found meter: {}", meter.getId());
         }
-        assertEquals(METHOD_COUNT * 2,
+        assertEquals(METHOD_COUNT * 3,
                 this.meterRegistry.getMeters().stream().filter(Counter.class::isInstance).count());
         assertEquals(METHOD_COUNT, this.meterRegistry.getMeters().stream().filter(Timer.class::isInstance).count());
         log.info("--- Test completed ---");

--- a/tests/src/test/java/net/devh/boot/grpc/test/metric/MetricCollectingClientInterceptorTest.java
+++ b/tests/src/test/java/net/devh/boot/grpc/test/metric/MetricCollectingClientInterceptorTest.java
@@ -20,6 +20,7 @@ package net.devh.boot.grpc.test.metric;
 import static io.grpc.Status.Code.OK;
 import static io.grpc.Status.Code.UNKNOWN;
 import static net.devh.boot.grpc.common.metric.MetricConstants.METRIC_NAME_CLIENT_PROCESSING_DURATION;
+import static net.devh.boot.grpc.common.metric.MetricConstants.METRIC_NAME_CLIENT_REQUESTS_RESULT;
 import static net.devh.boot.grpc.common.metric.MetricConstants.METRIC_NAME_CLIENT_REQUESTS_SENT;
 import static net.devh.boot.grpc.test.server.TestServiceImpl.METHOD_COUNT;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -47,7 +48,7 @@ class MetricCollectingClientInterceptorTest {
         mcci.preregisterService(TestServiceGrpc.getServiceDescriptor());
 
         MetricTestHelper.logMeters(meterRegistry.getMeters());
-        assertEquals(METHOD_COUNT * 3, meterRegistry.getMeters().size());
+        assertEquals(METHOD_COUNT * 4, meterRegistry.getMeters().size());
         log.info("--- Test completed ---");
     }
 
@@ -63,7 +64,7 @@ class MetricCollectingClientInterceptorTest {
         mcci.preregisterService(TestServiceGrpc.getServiceDescriptor());
 
         MetricTestHelper.logMeters(meterRegistry.getMeters());
-        assertEquals(METHOD_COUNT * 10, meterRegistry.getMeters().size());
+        assertEquals(METHOD_COUNT * 12, meterRegistry.getMeters().size());
 
         final Counter counter = meterRegistry.find(METRIC_NAME_CLIENT_REQUESTS_SENT).counter();
         assertNotNull(counter);
@@ -72,6 +73,10 @@ class MetricCollectingClientInterceptorTest {
         final Timer timer = meterRegistry.find(METRIC_NAME_CLIENT_PROCESSING_DURATION).timer();
         assertNotNull(timer);
         assertEquals("timer", timer.getId().getTag("type"));
+
+        final Counter resultCounter = meterRegistry.find(METRIC_NAME_CLIENT_REQUESTS_RESULT).counter();
+        assertNotNull(resultCounter);
+        assertEquals("counter", counter.getId().getTag("type"));
         log.info("--- Test completed ---");
     }
 

--- a/tests/src/test/java/net/devh/boot/grpc/test/metric/MetricCollectingServerInterceptorTest.java
+++ b/tests/src/test/java/net/devh/boot/grpc/test/metric/MetricCollectingServerInterceptorTest.java
@@ -21,6 +21,7 @@ import static io.grpc.Status.Code.OK;
 import static io.grpc.Status.Code.UNKNOWN;
 import static net.devh.boot.grpc.common.metric.MetricConstants.METRIC_NAME_SERVER_PROCESSING_DURATION;
 import static net.devh.boot.grpc.common.metric.MetricConstants.METRIC_NAME_SERVER_REQUESTS_RECEIVED;
+import static net.devh.boot.grpc.common.metric.MetricConstants.METRIC_NAME_SERVER_REQUESTS_RESULT;
 import static net.devh.boot.grpc.test.server.TestServiceImpl.METHOD_COUNT;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -48,7 +49,7 @@ class MetricCollectingServerInterceptorTest {
         mcsi.preregisterService(TestServiceGrpc.getServiceDescriptor());
 
         MetricTestHelper.logMeters(meterRegistry.getMeters());
-        assertEquals(METHOD_COUNT * 3, meterRegistry.getMeters().size());
+        assertEquals(METHOD_COUNT * 4, meterRegistry.getMeters().size());
         log.info("--- Test completed ---");
     }
 
@@ -64,7 +65,7 @@ class MetricCollectingServerInterceptorTest {
         mcsi.preregisterService(new TestServiceImpl());
 
         MetricTestHelper.logMeters(meterRegistry.getMeters());
-        assertEquals(METHOD_COUNT * 10, meterRegistry.getMeters().size());
+        assertEquals(METHOD_COUNT * 12, meterRegistry.getMeters().size());
 
         final Counter counter = meterRegistry.find(METRIC_NAME_SERVER_REQUESTS_RECEIVED).counter();
         assertNotNull(counter);
@@ -73,6 +74,10 @@ class MetricCollectingServerInterceptorTest {
         final Timer timer = meterRegistry.find(METRIC_NAME_SERVER_PROCESSING_DURATION).timer();
         assertNotNull(timer);
         assertEquals("timer", timer.getId().getTag("type"));
+
+        final Counter resultCounter = meterRegistry.find(METRIC_NAME_SERVER_REQUESTS_RESULT).counter();
+        assertNotNull(resultCounter);
+        assertEquals("counter", counter.getId().getTag("type"));
         log.info("--- Test completed ---");
     }
 

--- a/tests/src/test/java/net/devh/boot/grpc/test/metric/MetricCustomAutoConfigurationTest.java
+++ b/tests/src/test/java/net/devh/boot/grpc/test/metric/MetricCustomAutoConfigurationTest.java
@@ -65,7 +65,7 @@ public class MetricCustomAutoConfigurationTest {
     @DirtiesContext
     public void testAutoDiscovery() {
         log.info("--- Starting tests with custom auto discovery ---");
-        assertEquals(METHOD_COUNT * 2,
+        assertEquals(METHOD_COUNT * 4,
                 this.meterRegistry.getMeters().stream().filter(Counter.class::isInstance).count());
         assertEquals(METHOD_COUNT * 2,
                 this.meterRegistry.getMeters().stream().filter(Timer.class::isInstance).count());

--- a/tests/src/test/java/net/devh/boot/grpc/test/metric/MetricFullAutoConfigurationTest.java
+++ b/tests/src/test/java/net/devh/boot/grpc/test/metric/MetricFullAutoConfigurationTest.java
@@ -52,7 +52,7 @@ public class MetricFullAutoConfigurationTest {
     @DirtiesContext
     public void testAutoDiscovery() {
         log.info("--- Starting tests with full auto discovery ---");
-        assertEquals(METHOD_COUNT * 2, this.meterRegistry.getMeters().stream()
+        assertEquals(METHOD_COUNT * 3, this.meterRegistry.getMeters().stream()
                 .filter(Counter.class::isInstance)
                 .filter(m -> m.getId().getName().startsWith("grpc.")) // Only count grpc metrics
                 .count());


### PR DESCRIPTION
Adds new counters that counts the results of each request and tags with a status code

New counters
`grpc.server.requests.result`
`grpc.client.requests.result`