### PR TITLE
Turn off inter process server

### DIFF
--- a/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/autoconfigure/GrpcMetadataEurekaConfiguration.java
+++ b/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/autoconfigure/GrpcMetadataEurekaConfiguration.java
@@ -52,7 +52,10 @@ public class GrpcMetadataEurekaConfiguration {
         if (this.instance == null) {
             return;
         }
-        this.instance.getMetadataMap().put("gRPC.port", String.valueOf(this.grpcProperties.getPort()));
+        final int port = this.grpcProperties.getPort();
+        if (port != -1) {
+            this.instance.getMetadataMap().put("gRPC.port", Integer.toString(port));
+        }
     }
 
 }

--- a/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/autoconfigure/GrpcServerFactoryAutoConfiguration.java
+++ b/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/autoconfigure/GrpcServerFactoryAutoConfiguration.java
@@ -25,8 +25,10 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
 
+import net.devh.boot.grpc.server.condition.ConditionalOnInterprocessServer;
 import net.devh.boot.grpc.server.config.GrpcServerProperties;
 import net.devh.boot.grpc.server.serverfactory.GrpcServerConfigurer;
 import net.devh.boot.grpc.server.serverfactory.GrpcServerFactory;
@@ -59,6 +61,7 @@ public class GrpcServerFactoryAutoConfiguration {
      */
     @ConditionalOnClass(name = {"io.grpc.netty.shaded.io.netty.channel.Channel",
             "io.grpc.netty.shaded.io.grpc.netty.NettyServerBuilder"})
+    @Conditional(ConditionalOnInterprocessServer.class)
     @Bean
     public ShadedNettyGrpcServerFactory shadedNettyGrpcServerFactory(final GrpcServerProperties properties,
             final GrpcServiceDiscoverer serviceDiscoverer, final List<GrpcServerConfigurer> serverConfigurers) {
@@ -75,8 +78,7 @@ public class GrpcServerFactoryAutoConfiguration {
      * @param factory The factory used to create the lifecycle.
      * @return The inter-process server lifecycle bean.
      */
-    @ConditionalOnClass(name = {"io.grpc.netty.shaded.io.netty.channel.Channel",
-            "io.grpc.netty.shaded.io.grpc.netty.NettyServerBuilder"})
+    @ConditionalOnBean(ShadedNettyGrpcServerFactory.class)
     @Bean
     public GrpcServerLifecycle shadedNettyGrpcServerLifecycle(ShadedNettyGrpcServerFactory factory) {
         return new GrpcServerLifecycle(factory);
@@ -91,7 +93,8 @@ public class GrpcServerFactoryAutoConfiguration {
      * @param serverConfigurers The server configurers that contain additional configuration for the server.
      * @return The shadedNettyGrpcServerFactory bean.
      */
-    @ConditionalOnMissingBean
+    @ConditionalOnMissingBean(ShadedNettyGrpcServerFactory.class)
+    @Conditional(ConditionalOnInterprocessServer.class)
     @ConditionalOnClass(name = {"io.netty.channel.Channel", "io.grpc.netty.NettyServerBuilder"})
     @Bean
     public NettyGrpcServerFactory nettyGrpcServerFactory(final GrpcServerProperties properties,
@@ -109,8 +112,7 @@ public class GrpcServerFactoryAutoConfiguration {
      * @param factory The factory used to create the lifecycle.
      * @return The inter-process server lifecycle bean.
      */
-    @ConditionalOnMissingBean
-    @ConditionalOnClass(name = {"io.netty.channel.Channel", "io.grpc.netty.NettyServerBuilder"})
+    @ConditionalOnBean(NettyGrpcServerFactory.class)
     @Bean
     public GrpcServerLifecycle nettyGrpcServerLifecycle(final NettyGrpcServerFactory factory) {
         return new GrpcServerLifecycle(factory);

--- a/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/cloud/ConsulGrpcRegistrationCustomizer.java
+++ b/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/cloud/ConsulGrpcRegistrationCustomizer.java
@@ -51,8 +51,11 @@ public class ConsulGrpcRegistrationCustomizer implements ConsulRegistrationCusto
         if (tags == null) {
             tags = new ArrayList<>();
         }
-        tags.add("gRPC.port=" + this.grpcServerProperties.getPort());
-        registration.getService().setTags(tags);
+        final int port = this.grpcServerProperties.getPort();
+        if (port != -1) {
+            tags.add("gRPC.port=" + port);
+            registration.getService().setTags(tags);
+        }
     }
 
 }

--- a/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/condition/ConditionalOnInterprocessServer.java
+++ b/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/condition/ConditionalOnInterprocessServer.java
@@ -15,29 +15,24 @@
  * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package net.devh.boot.grpc.test;
+package net.devh.boot.grpc.server.condition;
 
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
-
-import lombok.extern.slf4j.Slf4j;
-import net.devh.boot.grpc.test.config.BaseAutoConfiguration;
-import net.devh.boot.grpc.test.config.ServiceConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.autoconfigure.condition.NoneNestedConditions;
 
 /**
- * A test checking that the server and client can start and connect to each other with minimal config.
+ * A condition that matches if the {@code grpc.server.port} does not have the value {@code -1}.
  *
  * @author Daniel Theuke (daniel.theuke@heuboe.de)
  */
-@Slf4j
-@SpringBootTest(properties = "grpc.client.test.negotiationType=PLAINTEXT")
-@SpringJUnitConfig(classes = {ServiceConfiguration.class, BaseAutoConfiguration.class})
-@DirtiesContext
-public class PlaintextSetupTest extends AbstractSimpleServerClientTest {
+public class ConditionalOnInterprocessServer extends NoneNestedConditions {
 
-    public PlaintextSetupTest() {
-        log.info("--- PlaintextSetupTest ---");
+    ConditionalOnInterprocessServer() {
+        super(ConfigurationPhase.REGISTER_BEAN);
+    }
+
+    @ConditionalOnProperty(name = "grpc.server.port", havingValue = "-1")
+    static class NoServerPortCondition {
     }
 
 }

--- a/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/config/GrpcServerProperties.java
+++ b/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/config/GrpcServerProperties.java
@@ -71,7 +71,8 @@ public class GrpcServerProperties {
 
     /**
      * Server port to listen on. Defaults to {@code 9090}. If set to {@code 0} a random available port will be selected
-     * and used.
+     * and used. Use {@code -1} to disable the inter-process server (for example if you only want to use the in-process
+     * server).
      *
      * @param port The port the server should listen on.
      * @return The port the server will listen on.

--- a/tests/src/test/java/net/devh/boot/grpc/test/setup/AbstractSimpleServerClientTest.java
+++ b/tests/src/test/java/net/devh/boot/grpc/test/setup/AbstractSimpleServerClientTest.java
@@ -15,13 +15,18 @@
  * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package net.devh.boot.grpc.test;
+package net.devh.boot.grpc.test.setup;
 
-import static io.grpc.Status.Code.UNAVAILABLE;
+import static io.grpc.Status.Code.UNIMPLEMENTED;
 import static net.devh.boot.grpc.test.util.GrpcAssertions.assertFutureThrowsStatus;
 import static net.devh.boot.grpc.test.util.GrpcAssertions.assertThrowsStatus;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+
+import javax.annotation.PostConstruct;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.test.annotation.DirtiesContext;
@@ -38,10 +43,14 @@ import net.devh.boot.grpc.test.proto.TestServiceGrpc.TestServiceBlockingStub;
 import net.devh.boot.grpc.test.proto.TestServiceGrpc.TestServiceFutureStub;
 import net.devh.boot.grpc.test.proto.TestServiceGrpc.TestServiceStub;
 
+/**
+ * A test checking that the server and client can start and connect to each other with minimal config.
+ *
+ * @author Daniel Theuke (daniel.theuke@heuboe.de)
+ */
 @Slf4j
-public abstract class AbstractBrokenServerClientTest {
+public abstract class AbstractSimpleServerClientTest {
 
-    // Don't configure client
     @GrpcClient("test")
     protected Channel channel;
     @GrpcClient("test")
@@ -51,40 +60,51 @@ public abstract class AbstractBrokenServerClientTest {
     @GrpcClient("test")
     protected TestServiceFutureStub testServiceFutureStub;
 
+    @PostConstruct
+    public void init() {
+        // Test injection
+        assertNotNull(this.channel, "channel");
+        assertNotNull(this.testServiceBlockingStub, "testServiceBlockingStub");
+        assertNotNull(this.testServiceFutureStub, "testServiceFutureStub");
+        assertNotNull(this.testServiceStub, "testServiceStub");
+    }
+
     /**
-     * Test successful call with broken setup.
+     * Test successful call.
+     *
+     * @throws ExecutionException Should never happen.
+     * @throws InterruptedException Should never happen.
      */
     @Test
     @DirtiesContext
-    public void testSuccessfulCallWithBrokenSetup() {
-        log.info("--- Starting tests with successful call with broken setup ---");
-        assertThrowsStatus(UNAVAILABLE,
-                () -> TestServiceGrpc.newBlockingStub(this.channel).normal(Empty.getDefaultInstance()));
+    public void testSuccessfulCall() throws InterruptedException, ExecutionException {
+        log.info("--- Starting tests with successful call ---");
+        assertEquals("1.2.3",
+                TestServiceGrpc.newBlockingStub(this.channel).normal(Empty.getDefaultInstance()).getVersion());
 
         final StreamRecorder<SomeType> streamRecorder = StreamRecorder.create();
         this.testServiceStub.normal(Empty.getDefaultInstance(), streamRecorder);
-        assertFutureThrowsStatus(UNAVAILABLE, streamRecorder.firstValue(), 5, TimeUnit.SECONDS);
-        assertThrowsStatus(UNAVAILABLE, () -> this.testServiceBlockingStub.normal(Empty.getDefaultInstance()));
-        assertFutureThrowsStatus(UNAVAILABLE, this.testServiceFutureStub.normal(Empty.getDefaultInstance()),
-                5, TimeUnit.SECONDS);
+        assertEquals("1.2.3", streamRecorder.firstValue().get().getVersion());
+        assertEquals("1.2.3", this.testServiceBlockingStub.normal(Empty.getDefaultInstance()).getVersion());
+        assertEquals("1.2.3", this.testServiceFutureStub.normal(Empty.getDefaultInstance()).get().getVersion());
         log.info("--- Test completed ---");
     }
 
     /**
-     * Test failing call with broken setup.
+     * Test failing call.
      */
     @Test
     @DirtiesContext
-    public void testFailingCallWithBrokenSetup() {
-        log.info("--- Starting tests with failing call with broken setup ---");
-        assertThrowsStatus(UNAVAILABLE,
+    public void testFailingCall() {
+        log.info("--- Starting tests with failing call ---");
+        assertThrowsStatus(UNIMPLEMENTED,
                 () -> TestServiceGrpc.newBlockingStub(this.channel).unimplemented(Empty.getDefaultInstance()));
 
         final StreamRecorder<SomeType> streamRecorder = StreamRecorder.create();
         this.testServiceStub.unimplemented(Empty.getDefaultInstance(), streamRecorder);
-        assertFutureThrowsStatus(UNAVAILABLE, streamRecorder.firstValue(), 5, TimeUnit.SECONDS);
-        assertThrowsStatus(UNAVAILABLE, () -> this.testServiceBlockingStub.unimplemented(Empty.getDefaultInstance()));
-        assertFutureThrowsStatus(UNAVAILABLE, this.testServiceFutureStub.unimplemented(Empty.getDefaultInstance()),
+        assertFutureThrowsStatus(UNIMPLEMENTED, streamRecorder.firstValue(), 5, TimeUnit.SECONDS);
+        assertThrowsStatus(UNIMPLEMENTED, () -> this.testServiceBlockingStub.unimplemented(Empty.getDefaultInstance()));
+        assertFutureThrowsStatus(UNIMPLEMENTED, this.testServiceFutureStub.unimplemented(Empty.getDefaultInstance()),
                 5, TimeUnit.SECONDS);
         log.info("--- Test completed ---");
     }

--- a/tests/src/test/java/net/devh/boot/grpc/test/setup/BrokenClientSelfSignedMutualSetupTest.java
+++ b/tests/src/test/java/net/devh/boot/grpc/test/setup/BrokenClientSelfSignedMutualSetupTest.java
@@ -15,7 +15,7 @@
  * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package net.devh.boot.grpc.test;
+package net.devh.boot.grpc.test.setup;
 
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.annotation.DirtiesContext;

--- a/tests/src/test/java/net/devh/boot/grpc/test/setup/BrokenServerSelfSignedMutualSetupTest.java
+++ b/tests/src/test/java/net/devh/boot/grpc/test/setup/BrokenServerSelfSignedMutualSetupTest.java
@@ -15,7 +15,7 @@
  * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package net.devh.boot.grpc.test;
+package net.devh.boot.grpc.test.setup;
 
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.annotation.DirtiesContext;
@@ -23,22 +23,31 @@ import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
 import lombok.extern.slf4j.Slf4j;
 import net.devh.boot.grpc.test.config.BaseAutoConfiguration;
-import net.devh.boot.grpc.test.config.InProcessConfiguration;
 import net.devh.boot.grpc.test.config.ServiceConfiguration;
 
 /**
- * A test checking that the server and client can start and connect to each other in process.
+ * A test checking that the server and client can start and connect to each other with minimal config.
  *
  * @author Daniel Theuke (daniel.theuke@heuboe.de)
  */
 @Slf4j
-@SpringBootTest
-@SpringJUnitConfig(classes = {InProcessConfiguration.class, ServiceConfiguration.class, BaseAutoConfiguration.class})
+@SpringBootTest(properties = {
+        "grpc.server.security.enabled=true",
+        "grpc.server.security.certificateChainPath=src/test/resources/certificates/server.crt",
+        "grpc.server.security.privateKeyPath=src/test/resources/certificates/server.key",
+        "grpc.server.security.trustCertCollectionPath=src/test/resources/certificates/client2.crt", // Wrong certs
+        "grpc.server.security.clientAuth=REQUIRE",
+        "grpc.client.test.security.authorityOverride=localhost",
+        "grpc.client.test.security.trustCertCollectionPath=src/test/resources/certificates/trusted-servers-collection",
+        "grpc.client.test.security.clientAuthEnabled=true",
+        "grpc.client.test.security.certificateChainPath=src/test/resources/certificates/client1.crt",
+        "grpc.client.test.security.privateKeyPath=src/test/resources/certificates/client1.key"})
+@SpringJUnitConfig(classes = {ServiceConfiguration.class, BaseAutoConfiguration.class})
 @DirtiesContext
-public class InProcessSetupTest extends AbstractSimpleServerClientTest {
+public class BrokenServerSelfSignedMutualSetupTest extends AbstractBrokenServerClientTest {
 
-    public InProcessSetupTest() {
-        log.info("--- InProcessSetupTest ---");
+    public BrokenServerSelfSignedMutualSetupTest() {
+        log.info("--- BrokenServerSelfSignedMutualSetupTest ---");
     }
 
 }

--- a/tests/src/test/java/net/devh/boot/grpc/test/setup/CustomCiphersAndProtocolsSetupTest.java
+++ b/tests/src/test/java/net/devh/boot/grpc/test/setup/CustomCiphersAndProtocolsSetupTest.java
@@ -15,7 +15,7 @@
  * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package net.devh.boot.grpc.test;
+package net.devh.boot.grpc.test.setup;
 
 import static org.junit.jupiter.api.Assertions.*;
 

--- a/tests/src/test/java/net/devh/boot/grpc/test/setup/InProcessSetupTest.java
+++ b/tests/src/test/java/net/devh/boot/grpc/test/setup/InProcessSetupTest.java
@@ -15,7 +15,7 @@
  * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package net.devh.boot.grpc.test;
+package net.devh.boot.grpc.test.setup;
 
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.annotation.DirtiesContext;
@@ -23,31 +23,22 @@ import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
 import lombok.extern.slf4j.Slf4j;
 import net.devh.boot.grpc.test.config.BaseAutoConfiguration;
+import net.devh.boot.grpc.test.config.InProcessConfiguration;
 import net.devh.boot.grpc.test.config.ServiceConfiguration;
 
 /**
- * A test checking that the server and client can start and connect to each other with minimal config.
+ * A test checking that the server and client can start and connect to each other in process.
  *
  * @author Daniel Theuke (daniel.theuke@heuboe.de)
  */
 @Slf4j
-@SpringBootTest(properties = {
-        "grpc.server.security.enabled=true",
-        "grpc.server.security.certificateChainPath=src/test/resources/certificates/server.crt",
-        "grpc.server.security.privateKeyPath=src/test/resources/certificates/server.key",
-        "grpc.server.security.trustCertCollectionPath=src/test/resources/certificates/client2.crt", // Wrong certs
-        "grpc.server.security.clientAuth=REQUIRE",
-        "grpc.client.test.security.authorityOverride=localhost",
-        "grpc.client.test.security.trustCertCollectionPath=src/test/resources/certificates/trusted-servers-collection",
-        "grpc.client.test.security.clientAuthEnabled=true",
-        "grpc.client.test.security.certificateChainPath=src/test/resources/certificates/client1.crt",
-        "grpc.client.test.security.privateKeyPath=src/test/resources/certificates/client1.key"})
-@SpringJUnitConfig(classes = {ServiceConfiguration.class, BaseAutoConfiguration.class})
+@SpringBootTest
+@SpringJUnitConfig(classes = {InProcessConfiguration.class, ServiceConfiguration.class, BaseAutoConfiguration.class})
 @DirtiesContext
-public class BrokenServerSelfSignedMutualSetupTest extends AbstractBrokenServerClientTest {
+public class InProcessSetupTest extends AbstractSimpleServerClientTest {
 
-    public BrokenServerSelfSignedMutualSetupTest() {
-        log.info("--- BrokenServerSelfSignedMutualSetupTest ---");
+    public InProcessSetupTest() {
+        log.info("--- InProcessSetupTest ---");
     }
 
 }

--- a/tests/src/test/java/net/devh/boot/grpc/test/setup/InterAndInProcessSetupTest.java
+++ b/tests/src/test/java/net/devh/boot/grpc/test/setup/InterAndInProcessSetupTest.java
@@ -1,0 +1,183 @@
+/*
+ * Copyright (c) 2016-2019 Michael Zhang <yidongnan@gmail.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package net.devh.boot.grpc.test.setup;
+
+import static io.grpc.Status.Code.UNIMPLEMENTED;
+import static net.devh.boot.grpc.test.proto.TestServiceGrpc.newBlockingStub;
+import static net.devh.boot.grpc.test.util.GrpcAssertions.assertFutureThrowsStatus;
+import static net.devh.boot.grpc.test.util.GrpcAssertions.assertThrowsStatus;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+
+import javax.annotation.PostConstruct;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+import com.google.protobuf.Empty;
+
+import io.grpc.Channel;
+import io.grpc.internal.testing.StreamRecorder;
+import lombok.extern.slf4j.Slf4j;
+import net.devh.boot.grpc.client.inject.GrpcClient;
+import net.devh.boot.grpc.server.config.GrpcServerProperties;
+import net.devh.boot.grpc.test.config.BaseAutoConfiguration;
+import net.devh.boot.grpc.test.config.ServiceConfiguration;
+import net.devh.boot.grpc.test.proto.SomeType;
+import net.devh.boot.grpc.test.proto.TestServiceGrpc.TestServiceBlockingStub;
+import net.devh.boot.grpc.test.proto.TestServiceGrpc.TestServiceFutureStub;
+import net.devh.boot.grpc.test.proto.TestServiceGrpc.TestServiceStub;
+
+/**
+ * Tests whether the parallel setup of inter- and in-process-server/client works.
+ *
+ * @author Daniel Theuke (daniel.theuke@heuboe.de)
+ */
+@Slf4j
+@SpringBootTest(properties = {
+        "grpc.server.inProcessName=test",
+        "grpc.server.port=9191",
+        "grpc.client.GLOBAL.negotiationType=PLAINTEXT",
+        "grpc.client.inProcess.address=in-process:test",
+        "grpc.client.interProcess.address=static://localhost:9191"})
+@EnableConfigurationProperties(GrpcServerProperties.class)
+@SpringJUnitConfig(classes = {ServiceConfiguration.class, BaseAutoConfiguration.class})
+@DirtiesContext
+public class InterAndInProcessSetupTest {
+
+    private static final Empty EMPTY = Empty.getDefaultInstance();
+
+    @GrpcClient("interProcess")
+    protected Channel interProcessChannel;
+    @GrpcClient("interProcess")
+    protected TestServiceStub interProcessServiceStub;
+    @GrpcClient("interProcess")
+    protected TestServiceBlockingStub interProcessServiceBlockingStub;
+    @GrpcClient("interProcess")
+    protected TestServiceFutureStub interProcessServiceFutureStub;
+
+    @GrpcClient("inProcess")
+    protected Channel inProcessChannel;
+    @GrpcClient("inProcess")
+    protected TestServiceStub inProcessServiceStub;
+    @GrpcClient("inProcess")
+    protected TestServiceBlockingStub inProcessServiceBlockingStub;
+    @GrpcClient("inProcess")
+    protected TestServiceFutureStub inProcessServiceFutureStub;
+
+    public InterAndInProcessSetupTest() {
+        log.info("--- InterAndInProcessSetupTest ---");
+    }
+
+    @PostConstruct
+    public void init() {
+        // Test injection
+        assertNotNull(this.interProcessChannel, "interProcessChannel");
+        assertNotNull(this.interProcessServiceBlockingStub, "interProcessServiceBlockingStub");
+        assertNotNull(this.interProcessServiceFutureStub, "interProcessServiceFutureStub");
+        assertNotNull(this.interProcessServiceStub, "interProcessServiceStub");
+
+        assertNotNull(this.inProcessChannel, "inProcessChannel");
+        assertNotNull(this.inProcessServiceBlockingStub, "inProcessServiceBlockingStub");
+        assertNotNull(this.inProcessServiceFutureStub, "inProcessServiceFutureStub");
+        assertNotNull(this.inProcessServiceStub, "inProcessServiceStub");
+    }
+
+    /**
+     * Test successful call for inter-process server.
+     *
+     * @throws ExecutionException Should never happen.
+     * @throws InterruptedException Should never happen.
+     */
+    @Test
+    @DirtiesContext
+    public void testSuccessfulInterProcessCall() throws InterruptedException, ExecutionException {
+        log.info("--- Starting tests with successful inter-process call ---");
+        assertEquals("1.2.3", newBlockingStub(this.interProcessChannel).normal(EMPTY).getVersion());
+
+        final StreamRecorder<SomeType> streamRecorder = StreamRecorder.create();
+        this.interProcessServiceStub.normal(EMPTY, streamRecorder);
+        assertEquals("1.2.3", streamRecorder.firstValue().get().getVersion());
+        assertEquals("1.2.3", this.interProcessServiceBlockingStub.normal(EMPTY).getVersion());
+        assertEquals("1.2.3", this.interProcessServiceFutureStub.normal(EMPTY).get().getVersion());
+        log.info("--- Test completed ---");
+    }
+
+    /**
+     * Test successful call for in-process server.
+     *
+     * @throws ExecutionException Should never happen.
+     * @throws InterruptedException Should never happen.
+     */
+    @Test
+    @DirtiesContext
+    public void testSuccessfulInProcessCall() throws InterruptedException, ExecutionException {
+        log.info("--- Starting tests with successful in-process call ---");
+        assertEquals("1.2.3", newBlockingStub(this.inProcessChannel).normal(EMPTY).getVersion());
+
+        final StreamRecorder<SomeType> streamRecorder = StreamRecorder.create();
+        this.inProcessServiceStub.normal(EMPTY, streamRecorder);
+        assertEquals("1.2.3", streamRecorder.firstValue().get().getVersion());
+        assertEquals("1.2.3", this.inProcessServiceBlockingStub.normal(EMPTY).getVersion());
+        assertEquals("1.2.3", this.inProcessServiceFutureStub.normal(EMPTY).get().getVersion());
+        log.info("--- Test completed ---");
+    }
+
+    /**
+     * Test failing call for inter-process server.
+     */
+    @Test
+    @DirtiesContext
+    public void testFailingInterProcessCall() {
+        log.info("--- Starting tests with failing inter-process call ---");
+        assertThrowsStatus(UNIMPLEMENTED, () -> newBlockingStub(this.interProcessChannel).unimplemented(EMPTY));
+
+        final StreamRecorder<SomeType> streamRecorder = StreamRecorder.create();
+        this.interProcessServiceStub.unimplemented(EMPTY, streamRecorder);
+        assertFutureThrowsStatus(UNIMPLEMENTED, streamRecorder.firstValue(), 5, TimeUnit.SECONDS);
+        assertThrowsStatus(UNIMPLEMENTED, () -> this.interProcessServiceBlockingStub.unimplemented(EMPTY));
+        assertFutureThrowsStatus(UNIMPLEMENTED, this.interProcessServiceFutureStub.unimplemented(EMPTY),
+                5, TimeUnit.SECONDS);
+        log.info("--- Test completed ---");
+    }
+
+    /**
+     * Test failing call for in-process server.
+     */
+    @Test
+    @DirtiesContext
+    public void testFailingInProcessCall() {
+        log.info("--- Starting tests with failing in-process call ---");
+        assertThrowsStatus(UNIMPLEMENTED, () -> newBlockingStub(this.inProcessChannel).unimplemented(EMPTY));
+
+        final StreamRecorder<SomeType> streamRecorder = StreamRecorder.create();
+        this.inProcessServiceStub.unimplemented(EMPTY, streamRecorder);
+        assertFutureThrowsStatus(UNIMPLEMENTED, streamRecorder.firstValue(), 5, TimeUnit.SECONDS);
+        assertThrowsStatus(UNIMPLEMENTED, () -> this.inProcessServiceBlockingStub.unimplemented(EMPTY));
+        assertFutureThrowsStatus(UNIMPLEMENTED, this.inProcessServiceFutureStub.unimplemented(EMPTY),
+                5, TimeUnit.SECONDS);
+        log.info("--- Test completed ---");
+    }
+
+}

--- a/tests/src/test/java/net/devh/boot/grpc/test/setup/NameResolverIPv4ConnectionTest.java
+++ b/tests/src/test/java/net/devh/boot/grpc/test/setup/NameResolverIPv4ConnectionTest.java
@@ -15,9 +15,8 @@
  * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package net.devh.boot.grpc.test;
+package net.devh.boot.grpc.test.setup;
 
-import static net.devh.boot.grpc.test.util.GrpcAssertions.assertThrowsStatus;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.junit.jupiter.api.Test;
@@ -32,12 +31,15 @@ import net.devh.boot.grpc.client.inject.GrpcClient;
 import net.devh.boot.grpc.test.config.BaseAutoConfiguration;
 import net.devh.boot.grpc.test.config.ServiceConfiguration;
 import net.devh.boot.grpc.test.proto.TestServiceGrpc.TestServiceBlockingStub;
-import net.devh.boot.grpc.test.util.EnableOnIPv6;
+import net.devh.boot.grpc.test.util.GrpcAssertions;
 
 @SpringBootTest(properties = {
-        "grpc.server.address=::1",
+        "grpc.server.address=127.0.0.1",
+        "grpc.client.default.negotiationType=PLAINTEXT",
         "grpc.client.dns.negotiationType=PLAINTEXT",
         "grpc.client.dns.address=dns:/localhost:9090/",
+        "grpc.client.localhost.negotiationType=PLAINTEXT",
+        "grpc.client.localhost.address=static://localhost:9090",
         "grpc.client.ipv4.negotiationType=PLAINTEXT",
         "grpc.client.ipv4.address=static://127.0.0.1:9090",
         "grpc.client.ipv6.negotiationType=PLAINTEXT",
@@ -45,8 +47,7 @@ import net.devh.boot.grpc.test.util.EnableOnIPv6;
 })
 @SpringJUnitConfig(classes = {ServiceConfiguration.class, BaseAutoConfiguration.class})
 @DirtiesContext
-@EnableOnIPv6
-public class NameResolverIPv6ConnectionTest {
+public class NameResolverIPv4ConnectionTest {
 
     private static final Empty EMPTY = Empty.getDefaultInstance();
 
@@ -64,12 +65,12 @@ public class NameResolverIPv6ConnectionTest {
 
     @Test
     public void testIpv4Connection() {
-        assertThrowsStatus(Code.UNAVAILABLE, () -> this.ipv4Stub.normal(EMPTY));
+        assertEquals("1.2.3", this.ipv4Stub.normal(EMPTY).getVersion());
     }
 
     @Test
     public void testIpv6Connection() {
-        assertEquals("1.2.3", this.ipv6Stub.normal(EMPTY).getVersion());
+        GrpcAssertions.assertThrowsStatus(Code.UNAVAILABLE, () -> this.ipv6Stub.normal(EMPTY));
     }
 
 }

--- a/tests/src/test/java/net/devh/boot/grpc/test/setup/NameResolverIPv6ConnectionTest.java
+++ b/tests/src/test/java/net/devh/boot/grpc/test/setup/NameResolverIPv6ConnectionTest.java
@@ -15,8 +15,9 @@
  * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package net.devh.boot.grpc.test;
+package net.devh.boot.grpc.test.setup;
 
+import static net.devh.boot.grpc.test.util.GrpcAssertions.assertThrowsStatus;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.junit.jupiter.api.Test;
@@ -26,6 +27,7 @@ import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
 import com.google.protobuf.Empty;
 
+import io.grpc.Status.Code;
 import net.devh.boot.grpc.client.inject.GrpcClient;
 import net.devh.boot.grpc.test.config.BaseAutoConfiguration;
 import net.devh.boot.grpc.test.config.ServiceConfiguration;
@@ -33,11 +35,9 @@ import net.devh.boot.grpc.test.proto.TestServiceGrpc.TestServiceBlockingStub;
 import net.devh.boot.grpc.test.util.EnableOnIPv6;
 
 @SpringBootTest(properties = {
-        "grpc.client.default.negotiationType=PLAINTEXT",
+        "grpc.server.address=::1",
         "grpc.client.dns.negotiationType=PLAINTEXT",
-        "grpc.client.dns.address=dns:///localhost:9090",
-        "grpc.client.localhost.negotiationType=PLAINTEXT",
-        "grpc.client.localhost.address=static://localhost:9090",
+        "grpc.client.dns.address=dns:/localhost:9090/",
         "grpc.client.ipv4.negotiationType=PLAINTEXT",
         "grpc.client.ipv4.address=static://127.0.0.1:9090",
         "grpc.client.ipv6.negotiationType=PLAINTEXT",
@@ -45,25 +45,17 @@ import net.devh.boot.grpc.test.util.EnableOnIPv6;
 })
 @SpringJUnitConfig(classes = {ServiceConfiguration.class, BaseAutoConfiguration.class})
 @DirtiesContext
-public class NameResolverConnectionTest {
+@EnableOnIPv6
+public class NameResolverIPv6ConnectionTest {
 
     private static final Empty EMPTY = Empty.getDefaultInstance();
 
-    @GrpcClient("default")
-    private TestServiceBlockingStub defaultStub;
     @GrpcClient("dns")
     private TestServiceBlockingStub dnsStub;
-    @GrpcClient("localhost")
-    private TestServiceBlockingStub localhostStub;
     @GrpcClient("ipv4")
     private TestServiceBlockingStub ipv4Stub;
     @GrpcClient("ipv6")
     private TestServiceBlockingStub ipv6Stub;
-
-    @Test
-    public void testDefaultConnection() {
-        assertEquals("1.2.3", this.defaultStub.normal(EMPTY).getVersion());
-    }
 
     @Test
     public void testDNSConnection() {
@@ -71,17 +63,11 @@ public class NameResolverConnectionTest {
     }
 
     @Test
-    public void testLocalhostConnection() {
-        assertEquals("1.2.3", this.localhostStub.normal(EMPTY).getVersion());
-    }
-
-    @Test
     public void testIpv4Connection() {
-        assertEquals("1.2.3", this.ipv4Stub.normal(EMPTY).getVersion());
+        assertThrowsStatus(Code.UNAVAILABLE, () -> this.ipv4Stub.normal(EMPTY));
     }
 
     @Test
-    @EnableOnIPv6
     public void testIpv6Connection() {
         assertEquals("1.2.3", this.ipv6Stub.normal(EMPTY).getVersion());
     }

--- a/tests/src/test/java/net/devh/boot/grpc/test/setup/PlaintextSetupTest.java
+++ b/tests/src/test/java/net/devh/boot/grpc/test/setup/PlaintextSetupTest.java
@@ -15,7 +15,7 @@
  * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package net.devh.boot.grpc.test;
+package net.devh.boot.grpc.test.setup;
 
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.annotation.DirtiesContext;
@@ -31,19 +31,13 @@ import net.devh.boot.grpc.test.config.ServiceConfiguration;
  * @author Daniel Theuke (daniel.theuke@heuboe.de)
  */
 @Slf4j
-@SpringBootTest(properties = {
-        "grpc.server.security.enabled=true",
-        "grpc.server.security.certificateChainPath=src/test/resources/certificates/server.crt",
-        "grpc.server.security.privateKeyPath=src/test/resources/certificates/server.key",
-        "grpc.client.test.security.authorityOverride=localhost",
-        "grpc.client.test.security.trustCertCollectionPath=src/test/resources/certificates/trusted-servers-collection"
-})
+@SpringBootTest(properties = "grpc.client.test.negotiationType=PLAINTEXT")
 @SpringJUnitConfig(classes = {ServiceConfiguration.class, BaseAutoConfiguration.class})
 @DirtiesContext
-public class SelfSignedServerSetupTest extends AbstractSimpleServerClientTest {
+public class PlaintextSetupTest extends AbstractSimpleServerClientTest {
 
-    public SelfSignedServerSetupTest() {
-        log.info("--- SelfSignedServerSetupTest ---");
+    public PlaintextSetupTest() {
+        log.info("--- PlaintextSetupTest ---");
     }
 
 }

--- a/tests/src/test/java/net/devh/boot/grpc/test/setup/SelfSignedMutualSetupTest.java
+++ b/tests/src/test/java/net/devh/boot/grpc/test/setup/SelfSignedMutualSetupTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2016-2019 Michael Zhang <yidongnan@gmail.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package net.devh.boot.grpc.test.setup;
+
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+import lombok.extern.slf4j.Slf4j;
+import net.devh.boot.grpc.test.config.BaseAutoConfiguration;
+import net.devh.boot.grpc.test.config.ServiceConfiguration;
+
+/**
+ * A test checking that the server and client can start and connect to each other with minimal config.
+ *
+ * @author Daniel Theuke (daniel.theuke@heuboe.de)
+ */
+@Slf4j
+@SpringBootTest(properties = {
+        "grpc.server.security.enabled=true",
+        "grpc.server.security.certificateChainPath=src/test/resources/certificates/server.crt",
+        "grpc.server.security.privateKeyPath=src/test/resources/certificates/server.key",
+        "grpc.server.security.trustCertCollectionPath=src/test/resources/certificates/trusted-clients-collection",
+        "grpc.server.security.clientAuth=REQUIRE",
+        "grpc.client.test.security.authorityOverride=localhost",
+        "grpc.client.test.security.trustCertCollectionPath=src/test/resources/certificates/trusted-servers-collection",
+        "grpc.client.test.security.clientAuthEnabled=true",
+        "grpc.client.test.security.certificateChainPath=src/test/resources/certificates/client1.crt",
+        "grpc.client.test.security.privateKeyPath=src/test/resources/certificates/client1.key"})
+@SpringJUnitConfig(classes = {ServiceConfiguration.class, BaseAutoConfiguration.class})
+@DirtiesContext
+public class SelfSignedMutualSetupTest extends AbstractSimpleServerClientTest {
+
+    public SelfSignedMutualSetupTest() {
+        log.info("--- SelfSignedMutualSetupTest ---");
+    }
+
+}

--- a/tests/src/test/java/net/devh/boot/grpc/test/setup/SelfSignedServerSetupTest.java
+++ b/tests/src/test/java/net/devh/boot/grpc/test/setup/SelfSignedServerSetupTest.java
@@ -15,7 +15,7 @@
  * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package net.devh.boot.grpc.test;
+package net.devh.boot.grpc.test.setup;
 
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.annotation.DirtiesContext;
@@ -35,19 +35,15 @@ import net.devh.boot.grpc.test.config.ServiceConfiguration;
         "grpc.server.security.enabled=true",
         "grpc.server.security.certificateChainPath=src/test/resources/certificates/server.crt",
         "grpc.server.security.privateKeyPath=src/test/resources/certificates/server.key",
-        "grpc.server.security.trustCertCollectionPath=src/test/resources/certificates/trusted-clients-collection",
-        "grpc.server.security.clientAuth=REQUIRE",
         "grpc.client.test.security.authorityOverride=localhost",
-        "grpc.client.test.security.trustCertCollectionPath=src/test/resources/certificates/trusted-servers-collection",
-        "grpc.client.test.security.clientAuthEnabled=true",
-        "grpc.client.test.security.certificateChainPath=src/test/resources/certificates/client1.crt",
-        "grpc.client.test.security.privateKeyPath=src/test/resources/certificates/client1.key"})
+        "grpc.client.test.security.trustCertCollectionPath=src/test/resources/certificates/trusted-servers-collection"
+})
 @SpringJUnitConfig(classes = {ServiceConfiguration.class, BaseAutoConfiguration.class})
 @DirtiesContext
-public class SelfSignedMutualSetupTest extends AbstractSimpleServerClientTest {
+public class SelfSignedServerSetupTest extends AbstractSimpleServerClientTest {
 
-    public SelfSignedMutualSetupTest() {
-        log.info("--- SelfSignedMutualSetupTest ---");
+    public SelfSignedServerSetupTest() {
+        log.info("--- SelfSignedServerSetupTest ---");
     }
 
 }


### PR DESCRIPTION
Added the ability to turn of the inter-process server by setting the bind port to `-1`.

With this it is possible to only use the in-process-server with config-options alone.

Related issues:
* #174
* #181