### PR TITLE
Order interceptors

### DIFF
--- a/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/autoconfigure/GrpcClientAutoConfiguration.java
+++ b/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/autoconfigure/GrpcClientAutoConfiguration.java
@@ -76,6 +76,7 @@ public class GrpcClientAutoConfiguration {
         return new GrpcChannelsProperties();
     }
 
+    @ConditionalOnMissingBean
     @Bean
     public GlobalClientInterceptorRegistry globalClientInterceptorRegistry() {
         return new GlobalClientInterceptorRegistry();

--- a/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/autoconfigure/GrpcClientTraceAutoConfiguration.java
+++ b/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/autoconfigure/GrpcClientTraceAutoConfiguration.java
@@ -25,18 +25,33 @@ import org.springframework.context.annotation.Configuration;
 
 import brave.grpc.GrpcTracing;
 import net.devh.boot.grpc.client.interceptor.GlobalClientInterceptorConfigurer;
+import net.devh.boot.grpc.client.interceptor.OrderedClientInterceptor;
 import net.devh.boot.grpc.common.autoconfigure.GrpcCommonTraceAutoConfiguration;
+import net.devh.boot.grpc.common.util.InterceptorOrder;
 
+/**
+ * The configuration used to configure brave's tracing for grpc.
+ *
+ * @author Daniel Theuke (daniel.theuke@heuboe.de)
+ */
 @Configuration
 @ConditionalOnProperty(value = "spring.sleuth.grpc.enabled", matchIfMissing = true)
 @AutoConfigureAfter(GrpcCommonTraceAutoConfiguration.class)
 @ConditionalOnBean(GrpcTracing.class)
 public class GrpcClientTraceAutoConfiguration {
 
+    /**
+     * Configures a global client interceptor that applies brave's tracing logic to the requests.
+     *
+     * @param grpcTracing The grpc tracing bean.
+     * @return The globalTraceClientInterceptorConfigurer bean.
+     */
     @Bean
-    public GlobalClientInterceptorConfigurer globalTraceClientInterceptorConfigurerAdapter(
-            final GrpcTracing grpcTracing) {
-        return registry -> registry.addClientInterceptors(grpcTracing.newClientInterceptor());
+    public GlobalClientInterceptorConfigurer globalTraceClientInterceptorConfigurer(final GrpcTracing grpcTracing) {
+        return registry -> registry.addClientInterceptors(
+                new OrderedClientInterceptor(
+                        grpcTracing.newClientInterceptor(),
+                        InterceptorOrder.ORDER_TRACING_METRICS + 1));
     }
 
 }

--- a/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/channelfactory/AbstractChannelFactory.java
+++ b/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/channelfactory/AbstractChannelFactory.java
@@ -104,7 +104,7 @@ public abstract class AbstractChannelFactory<T extends ManagedChannelBuilder<T>>
         if (sortInterceptors) {
             this.globalClientInterceptorRegistry.sortInterceptors(interceptors);
         }
-        return ClientInterceptors.intercept(channel, interceptors);
+        return ClientInterceptors.interceptForward(channel, interceptors);
     }
 
     /**

--- a/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/channelfactory/AbstractChannelFactory.java
+++ b/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/channelfactory/AbstractChannelFactory.java
@@ -89,7 +89,8 @@ public abstract class AbstractChannelFactory<T extends ManagedChannelBuilder<T>>
     }
 
     @Override
-    public Channel createChannel(final String name, final List<ClientInterceptor> customInterceptors) {
+    public Channel createChannel(final String name, final List<ClientInterceptor> customInterceptors,
+            boolean sortInterceptors) {
         final Channel channel;
         synchronized (this) {
             if (this.shutdown) {
@@ -97,13 +98,11 @@ public abstract class AbstractChannelFactory<T extends ManagedChannelBuilder<T>>
             }
             channel = this.channels.computeIfAbsent(name, this::newManagedChannel);
         }
-        final List<ClientInterceptor> interceptors = Lists.newArrayList();
-        final List<ClientInterceptor> globalInterceptors = this.globalClientInterceptorRegistry.getClientInterceptors();
-        if (!globalInterceptors.isEmpty()) {
-            interceptors.addAll(globalInterceptors);
-        }
-        if (!customInterceptors.isEmpty()) {
-            interceptors.addAll(customInterceptors);
+        final List<ClientInterceptor> interceptors =
+                Lists.newArrayList(this.globalClientInterceptorRegistry.getClientInterceptors());
+        interceptors.addAll(customInterceptors);
+        if (sortInterceptors) {
+            this.globalClientInterceptorRegistry.sortInterceptors(interceptors);
         }
         return ClientInterceptors.intercept(channel, interceptors);
     }

--- a/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/channelfactory/GrpcChannelFactory.java
+++ b/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/channelfactory/GrpcChannelFactory.java
@@ -22,6 +22,7 @@ import java.util.List;
 
 import io.grpc.Channel;
 import io.grpc.ClientInterceptor;
+import io.grpc.ClientInterceptors;
 import io.grpc.ManagedChannel;
 
 /**
@@ -57,15 +58,37 @@ public interface GrpcChannelFactory extends AutoCloseable {
      * </p>
      *
      * <p>
-     * <b>Note:</b> The given interceptors will be applied after the global interceptors. But the interceptors that were
-     * applied last, will be called first.
+     * <b>Note:</b> The given interceptors will be appended to the global interceptors and applied using
+     * {@link ClientInterceptors#interceptForward(Channel, ClientInterceptor...)}.
      * </p>
      *
      * @param name The name of the service.
      * @param interceptors A list of additional client interceptors that should be added to the channel.
      * @return The newly created channel for the given service.
      */
-    Channel createChannel(String name, List<ClientInterceptor> interceptors);
+    default Channel createChannel(String name, List<ClientInterceptor> interceptors) {
+        return createChannel(name, interceptors, false);
+    }
+
+    /**
+     * Creates a new channel for the given service name. The returned channel will use all globally registered
+     * {@link ClientInterceptor}s.
+     *
+     * <p>
+     * <b>Note:</b> The underlying implementation might reuse existing {@link ManagedChannel}s allow connection reuse.
+     * </p>
+     *
+     * <p>
+     * <b>Note:</b> The given interceptors will be appended to the global interceptors and applied using
+     * {@link ClientInterceptors#interceptForward(Channel, ClientInterceptor...)}.
+     * </p>
+     *
+     * @param name The name of the service.
+     * @param interceptors A list of additional client interceptors that should be added to the channel.
+     * @param sortInterceptors Whether the interceptors (both global and custom) should be sorted before being applied.
+     * @return The newly created channel for the given service.
+     */
+    Channel createChannel(String name, List<ClientInterceptor> interceptors, boolean sortInterceptors);
 
     @Override
     void close();

--- a/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/channelfactory/InProcessOrAlternativeChannelFactory.java
+++ b/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/channelfactory/InProcessOrAlternativeChannelFactory.java
@@ -69,12 +69,14 @@ public class InProcessOrAlternativeChannelFactory implements GrpcChannelFactory 
     }
 
     @Override
-    public Channel createChannel(final String name, final List<ClientInterceptor> interceptors) {
+    public Channel createChannel(final String name, final List<ClientInterceptor> interceptors,
+            boolean sortInterceptors) {
         final URI address = this.properties.getChannel(name).getAddress();
         if (address != null && IN_PROCESS_SCHEME.equals(address.getScheme())) {
-            return this.inProcessChannelFactory.createChannel(address.getSchemeSpecificPart(), interceptors);
+            return this.inProcessChannelFactory.createChannel(address.getSchemeSpecificPart(), interceptors,
+                    sortInterceptors);
         }
-        return this.alternativeChannelFactory.createChannel(name, interceptors);
+        return this.alternativeChannelFactory.createChannel(name, interceptors, sortInterceptors);
     }
 
     @Override

--- a/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/inject/GrpcClient.java
+++ b/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/inject/GrpcClient.java
@@ -32,6 +32,7 @@ import io.grpc.CallCredentials;
 import io.grpc.CallOptions;
 import io.grpc.Channel;
 import io.grpc.ClientInterceptor;
+import io.grpc.ClientInterceptors;
 import io.grpc.stub.AbstractStub;
 import net.devh.boot.grpc.client.config.GrpcChannelProperties;
 import net.devh.boot.grpc.client.config.GrpcChannelProperties.Security;
@@ -51,6 +52,11 @@ import net.devh.boot.grpc.client.config.GrpcChannelProperties.Security;
  * {@link StubTransformer}s in the application context. These can be used, for example, to configure {@link CallOptions}
  * such as {@link CallCredentials}. Please note that these transformations aren't applied if you inject a
  * {@link Channel} only.
+ * </p>
+ *
+ * <p>
+ * <b>Note:</b> These annotation allows the specification of custom interceptors. These will be appended to the global
+ * interceptors and applied using {@link ClientInterceptors#interceptForward(Channel, ClientInterceptor...)}.
  * </p>
  *
  * @author Michael (yidongnan@gmail.com)
@@ -86,8 +92,7 @@ public @interface GrpcClient {
      * created via no-args constructor.
      *
      * <p>
-     * <b>Note:</b> These interceptors will be applied after the global interceptors. But the interceptors that were
-     * applied last, will be called first.
+     * <b>Note:</b> Please read the javadocs regarding the ordering of interceptors.
      * </p>
      *
      * @return A list of ClientInterceptor classes that should be used.
@@ -99,12 +104,20 @@ public @interface GrpcClient {
      * defined ones.
      *
      * <p>
-     * <b>Note:</b> These interceptors will be applied after the global interceptors and the interceptor classes. But
-     * the interceptors that were applied last, will be called first.
+     * <b>Note:</b> Please read the javadocs regarding the ordering of interceptors.
      * </p>
      *
      * @return A list of ClientInterceptor beans that should be used.
      */
     String[] interceptorNames() default {};
+
+    /**
+     * Whether the custom interceptors should be mixed with the global interceptors and sorted afterwards. Use this
+     * option if you want to add a custom interceptor between global interceptors.
+     *
+     * @return True, if the custom interceptors should be merged with the global ones and sorted afterwards. False
+     *         otherwise.
+     */
+    boolean sortInterceptors() default false;
 
 }

--- a/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/inject/GrpcClientBeanPostProcessor.java
+++ b/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/inject/GrpcClientBeanPostProcessor.java
@@ -110,7 +110,7 @@ public class GrpcClientBeanPostProcessor implements BeanPostProcessor {
         final String name = annotation.value();
         final Channel channel;
         try {
-            channel = getChannelFactory().createChannel(name, interceptors);
+            channel = getChannelFactory().createChannel(name, interceptors, annotation.sortInterceptors());
             if (channel == null) {
                 throw new IllegalStateException("Channel factory created a null channel for " + name);
             }

--- a/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/interceptor/AnnotationGlobalClientInterceptorConfigurer.java
+++ b/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/interceptor/AnnotationGlobalClientInterceptorConfigurer.java
@@ -17,11 +17,8 @@
 
 package net.devh.boot.grpc.client.interceptor;
 
-import java.util.Map;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
-import org.springframework.core.annotation.AnnotationAwareOrderComparator;
 
 import io.grpc.ClientInterceptor;
 import lombok.extern.slf4j.Slf4j;
@@ -40,12 +37,9 @@ public class AnnotationGlobalClientInterceptorConfigurer implements GlobalClient
     @Override
     public void addClientInterceptors(final GlobalClientInterceptorRegistry registry) {
         this.context.getBeansWithAnnotation(GrpcGlobalClientInterceptor.class)
-                .entrySet()
-                .stream()
-                .sorted(Map.Entry.comparingByValue(AnnotationAwareOrderComparator.INSTANCE))
-                .forEach(entry -> {
-                    ClientInterceptor interceptor = (ClientInterceptor) entry.getValue();
-                    log.debug("Registering GlobalClientInterceptor: {} ({})", entry.getKey(), interceptor);
+                .forEach((name, bean) -> {
+                    ClientInterceptor interceptor = (ClientInterceptor) bean;
+                    log.debug("Registering GlobalClientInterceptor: {} ({})", name, interceptor);
                     registry.addClientInterceptors(interceptor);
                 });
     }

--- a/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/interceptor/OrderedClientInterceptor.java
+++ b/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/interceptor/OrderedClientInterceptor.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2016-2019 Michael Zhang <yidongnan@gmail.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package net.devh.boot.grpc.client.interceptor;
+
+import static java.util.Objects.requireNonNull;
+
+import org.springframework.core.Ordered;
+
+import io.grpc.CallOptions;
+import io.grpc.Channel;
+import io.grpc.ClientCall;
+import io.grpc.ClientInterceptor;
+import io.grpc.MethodDescriptor;
+
+/**
+ * A client interceptor wrapper that assigns an order to the underlying client interceptor.
+ *
+ * @author Daniel Theuke (daniel.theuke@heuboe.de)
+ */
+public class OrderedClientInterceptor implements ClientInterceptor, Ordered {
+
+    private final ClientInterceptor clientInterceptor;
+    private final int order;
+
+    /**
+     * Creates a new OrderedClientInterceptor with the given client interceptor and order.
+     *
+     * @param clientInterceptor The client interceptor to delegate to.
+     * @param order The order of this interceptor.
+     */
+    public OrderedClientInterceptor(ClientInterceptor clientInterceptor, int order) {
+        this.clientInterceptor = requireNonNull(clientInterceptor, "clientInterceptor");
+        this.order = order;
+    }
+
+    @Override
+    public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(MethodDescriptor<ReqT, RespT> method,
+            CallOptions callOptions, Channel next) {
+        return this.clientInterceptor.interceptCall(method, callOptions, next);
+    }
+
+    @Override
+    public int getOrder() {
+        return this.order;
+    }
+
+    @Override
+    public String toString() {
+        return "OrderedClientInterceptor [interceptor=" + this.clientInterceptor + ", order=" + this.order + "]";
+    }
+
+}

--- a/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/metric/MetricCollectingClientInterceptor.java
+++ b/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/metric/MetricCollectingClientInterceptor.java
@@ -27,6 +27,7 @@ import java.util.function.Function;
 import java.util.function.UnaryOperator;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.annotation.Order;
 
 import io.grpc.CallOptions;
 import io.grpc.Channel;
@@ -39,6 +40,7 @@ import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
 import net.devh.boot.grpc.client.interceptor.GrpcGlobalClientInterceptor;
 import net.devh.boot.grpc.common.metric.AbstractMetricCollectingInterceptor;
+import net.devh.boot.grpc.common.util.InterceptorOrder;
 
 /**
  * A gRPC client interceptor that will collect metrics for micrometer.
@@ -46,6 +48,7 @@ import net.devh.boot.grpc.common.metric.AbstractMetricCollectingInterceptor;
  * @author Daniel Theuke (daniel.theuke@heuboe.de)
  */
 @GrpcGlobalClientInterceptor
+@Order(InterceptorOrder.ORDER_TRACING_METRICS)
 public class MetricCollectingClientInterceptor extends AbstractMetricCollectingInterceptor
         implements ClientInterceptor {
 

--- a/grpc-common-spring-boot/src/main/java/net/devh/boot/grpc/common/util/InterceptorOrder.java
+++ b/grpc-common-spring-boot/src/main/java/net/devh/boot/grpc/common/util/InterceptorOrder.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2016-2019 Michael Zhang <yidongnan@gmail.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package net.devh.boot.grpc.common.util;
+
+import org.springframework.core.Ordered;
+
+/**
+ * A util class with constants that can be used to configure the order of interceptors.
+ *
+ * <p>
+ * <b>Note:</b> The order constants provided by this class are just a suggestion to simplify the interoperability of
+ * multiple libraries and may be overridden. This library will use them for their own interceptors though.
+ * </p>
+ */
+public final class InterceptorOrder {
+
+    /**
+     * The order value for interceptors that should be executed first. This is equivalent to
+     * {@link Ordered#HIGHEST_PRECEDENCE}.
+     */
+    public static final int ORDER_FIRST = Ordered.HIGHEST_PRECEDENCE;
+    /**
+     * The order value for global exception handling interceptors.
+     */
+    public static final int ORDER_GLOBAL_EXCEPTION_HANDLING = 0;
+    /**
+     * The order value for tracing and metrics collecting interceptors.
+     */
+    public static final int ORDER_TRACING_METRICS = 2500;
+    /**
+     * The order value for interceptors related security exception handling.
+     */
+    public static final int ORDER_SECURITY_EXCEPTION_HANDLING = 5000;
+    /**
+     * The order value for security interceptors related to authentication.
+     */
+    public static final int ORDER_SECURITY_AUTHENTICATION = 5100;
+    /**
+     * The order value for security interceptors related to authorization checks.
+     */
+    public static final int ORDER_SECURITY_AUTHORISATION = 5200;
+    /**
+     * The order value for interceptors that should be executed last. This is equivalent to
+     * {@link Ordered#LOWEST_PRECEDENCE}. This is the default for interceptors without specified priority.
+     */
+    public static final int ORDER_LAST = Ordered.LOWEST_PRECEDENCE;
+
+    private InterceptorOrder() {}
+
+}

--- a/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/autoconfigure/GrpcServerAutoConfiguration.java
+++ b/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/autoconfigure/GrpcServerAutoConfiguration.java
@@ -60,6 +60,7 @@ public class GrpcServerAutoConfiguration {
         return new GrpcServerProperties();
     }
 
+    @ConditionalOnMissingBean
     @Bean
     public GlobalServerInterceptorRegistry globalServerInterceptorRegistry() {
         return new GlobalServerInterceptorRegistry();

--- a/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/interceptor/AnnotationGlobalServerInterceptorConfigurer.java
+++ b/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/interceptor/AnnotationGlobalServerInterceptorConfigurer.java
@@ -17,11 +17,8 @@
 
 package net.devh.boot.grpc.server.interceptor;
 
-import java.util.Map;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
-import org.springframework.core.annotation.AnnotationAwareOrderComparator;
 
 import io.grpc.ServerInterceptor;
 import lombok.extern.slf4j.Slf4j;
@@ -40,12 +37,9 @@ public class AnnotationGlobalServerInterceptorConfigurer implements GlobalServer
     @Override
     public void addServerInterceptors(final GlobalServerInterceptorRegistry registry) {
         this.context.getBeansWithAnnotation(GrpcGlobalServerInterceptor.class)
-                .entrySet()
-                .stream()
-                .sorted(Map.Entry.comparingByValue(AnnotationAwareOrderComparator.INSTANCE))
-                .forEach(entry -> {
-                    ServerInterceptor interceptor = (ServerInterceptor) entry.getValue();
-                    log.debug("Registering GlobalServerInterceptor: {} ({})", entry.getKey(), interceptor);
+                .forEach((name, bean) -> {
+                    ServerInterceptor interceptor = (ServerInterceptor) bean;
+                    log.debug("Registering GlobalServerInterceptor: {} ({})", name, interceptor);
                     registry.addServerInterceptors(interceptor);
                 });
     }

--- a/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/interceptor/GlobalServerInterceptorRegistry.java
+++ b/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/interceptor/GlobalServerInterceptorRegistry.java
@@ -24,23 +24,32 @@ import javax.annotation.PostConstruct;
 
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
+import org.springframework.core.annotation.AnnotationAwareOrderComparator;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 
+import io.grpc.BindableService;
 import io.grpc.ServerInterceptor;
-import lombok.Getter;
+import io.grpc.ServerInterceptors;
 
 /**
  * The global server interceptor registry keeps references to all {@link ServerInterceptor}s that should be registered
- * globally. The interceptors will be applied in the same order they are added to this registry.
+ * globally. The interceptors will be applied in the same order they as specified by the {@link #sortInterceptors(List)}
+ * method.
+ *
+ * <p>
+ * <b>Note:</b> Custom interceptors will be appended to the global interceptors and applied using
+ * {@link ServerInterceptors#interceptForward(BindableService, ServerInterceptor...)}.
+ * </p>
  *
  * @author Michael (yidongnan@gmail.com)
  * @since 5/17/16
  */
 public class GlobalServerInterceptorRegistry implements ApplicationContextAware {
 
-    @Getter
     private final List<ServerInterceptor> serverInterceptors = Lists.newArrayList();
+    private ImmutableList<ServerInterceptor> sortedServerInterceptors;
     private ApplicationContext applicationContext;
 
     @Override
@@ -64,8 +73,33 @@ public class GlobalServerInterceptorRegistry implements ApplicationContextAware 
      * @return This instance for chaining.
      */
     public GlobalServerInterceptorRegistry addServerInterceptors(final ServerInterceptor interceptor) {
+        this.sortedServerInterceptors = null;
         this.serverInterceptors.add(interceptor);
         return this;
+    }
+
+    /**
+     * Gets the immutable and sorted list of global server interceptors.
+     *
+     * @return The list of globally registered server interceptors.
+     */
+    public ImmutableList<ServerInterceptor> getServerInterceptors() {
+        if (this.sortedServerInterceptors == null) {
+            List<ServerInterceptor> temp = Lists.newArrayList(this.serverInterceptors);
+            sortInterceptors(temp);
+            this.sortedServerInterceptors = ImmutableList.copyOf(temp);
+        }
+        return this.sortedServerInterceptors;
+    }
+
+    /**
+     * Sorts the given list of interceptors. Use this method if you want to sort custom interceptors. The default
+     * implementation will sort them by using then {@link AnnotationAwareOrderComparator}.
+     *
+     * @param interceptors The interceptors to sort.
+     */
+    public void sortInterceptors(List<? extends ServerInterceptor> interceptors) {
+        interceptors.sort(AnnotationAwareOrderComparator.INSTANCE);
     }
 
 }

--- a/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/interceptor/OrderedServerInterceptor.java
+++ b/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/interceptor/OrderedServerInterceptor.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2016-2019 Michael Zhang <yidongnan@gmail.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package net.devh.boot.grpc.server.interceptor;
+
+import static java.util.Objects.requireNonNull;
+
+import org.springframework.core.Ordered;
+
+import io.grpc.Metadata;
+import io.grpc.ServerCall;
+import io.grpc.ServerCall.Listener;
+import io.grpc.ServerCallHandler;
+import io.grpc.ServerInterceptor;
+
+/**
+ * A server interceptor wrapper that assigns an order to the underlying server interceptor.
+ *
+ * @author Daniel Theuke (daniel.theuke@heuboe.de)
+ */
+public class OrderedServerInterceptor implements ServerInterceptor, Ordered {
+
+    private final ServerInterceptor serverInterceptor;
+    private final int order;
+
+    /**
+     * Creates a new OrderedServerInterceptor with the given server interceptor and order.
+     *
+     * @param serverInterceptor The server interceptor to delegate to.
+     * @param order The order of this interceptor.
+     */
+    public OrderedServerInterceptor(ServerInterceptor serverInterceptor, int order) {
+        this.serverInterceptor = requireNonNull(serverInterceptor, "serverInterceptor");
+        this.order = order;
+    }
+
+    @Override
+    public <ReqT, RespT> Listener<ReqT> interceptCall(ServerCall<ReqT, RespT> call, Metadata headers,
+            ServerCallHandler<ReqT, RespT> next) {
+        return this.serverInterceptor.interceptCall(call, headers, next);
+    }
+
+    @Override
+    public int getOrder() {
+        return this.order;
+    }
+
+    @Override
+    public String toString() {
+        return "OrderedServerInterceptor [interceptor=" + this.serverInterceptor + ", order=" + this.order + "]";
+    }
+
+}

--- a/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/metric/MetricCollectingServerInterceptor.java
+++ b/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/metric/MetricCollectingServerInterceptor.java
@@ -26,6 +26,8 @@ import static net.devh.boot.grpc.common.metric.MetricUtils.prepareTimerFor;
 import java.util.function.Function;
 import java.util.function.UnaryOperator;
 
+import org.springframework.core.annotation.Order;
+
 import io.grpc.BindableService;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
@@ -39,6 +41,7 @@ import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
 import net.devh.boot.grpc.common.metric.AbstractMetricCollectingInterceptor;
+import net.devh.boot.grpc.common.util.InterceptorOrder;
 import net.devh.boot.grpc.server.interceptor.GrpcGlobalServerInterceptor;
 
 /**
@@ -47,6 +50,7 @@ import net.devh.boot.grpc.server.interceptor.GrpcGlobalServerInterceptor;
  * @author Daniel Theuke (daniel.theuke@heuboe.de)
  */
 @GrpcGlobalServerInterceptor
+@Order(InterceptorOrder.ORDER_TRACING_METRICS)
 public class MetricCollectingServerInterceptor extends AbstractMetricCollectingInterceptor
         implements ServerInterceptor {
 

--- a/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/security/authentication/CompositeGrpcAuthenticationReader.java
+++ b/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/security/authentication/CompositeGrpcAuthenticationReader.java
@@ -29,9 +29,8 @@ import io.grpc.Metadata;
 import io.grpc.ServerCall;
 
 /**
- * Combines multiple {@link GrpcAuthenticationReader} into a single one. The interceptors will be executed in the same
- * order the are passed to the constructor. The authentication is aborted if a grpc authentication reader throws an
- * exception.
+ * Combines multiple {@link GrpcAuthenticationReader} into a single one. The readers will be executed in the same order
+ * the are passed to the constructor. The authentication is aborted if a grpc authentication reader throws an exception.
  *
  * @author Daniel Theuke (daniel.theuke@heuboe.de)
  */

--- a/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/security/interceptors/AuthenticatingServerInterceptor.java
+++ b/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/security/interceptors/AuthenticatingServerInterceptor.java
@@ -20,6 +20,7 @@ package net.devh.boot.grpc.server.security.interceptors;
 import static java.util.Objects.requireNonNull;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.annotation.Order;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.authentication.AbstractAuthenticationToken;
 import org.springframework.security.authentication.AnonymousAuthenticationToken;
@@ -37,6 +38,7 @@ import io.grpc.ServerCall.Listener;
 import io.grpc.ServerCallHandler;
 import io.grpc.ServerInterceptor;
 import lombok.extern.slf4j.Slf4j;
+import net.devh.boot.grpc.common.util.InterceptorOrder;
 import net.devh.boot.grpc.server.interceptor.GrpcGlobalServerInterceptor;
 import net.devh.boot.grpc.server.security.authentication.GrpcAuthenticationReader;
 
@@ -53,6 +55,7 @@ import net.devh.boot.grpc.server.security.authentication.GrpcAuthenticationReade
  */
 @Slf4j
 @GrpcGlobalServerInterceptor
+@Order(InterceptorOrder.ORDER_SECURITY_AUTHENTICATION)
 public class AuthenticatingServerInterceptor implements ServerInterceptor {
 
     /**

--- a/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/security/interceptors/AuthorizationCheckingServerInterceptor.java
+++ b/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/security/interceptors/AuthorizationCheckingServerInterceptor.java
@@ -19,6 +19,7 @@ package net.devh.boot.grpc.server.security.interceptors;
 
 import static java.util.Objects.requireNonNull;
 
+import org.springframework.core.annotation.Order;
 import org.springframework.security.access.AccessDecisionManager;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.access.SecurityMetadataSource;
@@ -33,6 +34,7 @@ import io.grpc.ServerCall.Listener;
 import io.grpc.ServerCallHandler;
 import io.grpc.ServerInterceptor;
 import lombok.extern.slf4j.Slf4j;
+import net.devh.boot.grpc.common.util.InterceptorOrder;
 import net.devh.boot.grpc.server.interceptor.GrpcGlobalServerInterceptor;
 import net.devh.boot.grpc.server.security.check.GrpcSecurityMetadataSource;
 
@@ -52,6 +54,7 @@ import net.devh.boot.grpc.server.security.check.GrpcSecurityMetadataSource;
  */
 @Slf4j
 @GrpcGlobalServerInterceptor
+@Order(InterceptorOrder.ORDER_SECURITY_AUTHORISATION)
 public class AuthorizationCheckingServerInterceptor extends AbstractSecurityInterceptor implements ServerInterceptor {
 
     private final GrpcSecurityMetadataSource securityMetadataSource;

--- a/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/security/interceptors/ExceptionTranslatingServerInterceptor.java
+++ b/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/security/interceptors/ExceptionTranslatingServerInterceptor.java
@@ -17,6 +17,7 @@
 
 package net.devh.boot.grpc.server.security.interceptors;
 
+import org.springframework.core.annotation.Order;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.core.AuthenticationException;
 
@@ -27,6 +28,7 @@ import io.grpc.ServerCall.Listener;
 import io.grpc.ServerCallHandler;
 import io.grpc.ServerInterceptor;
 import io.grpc.Status;
+import net.devh.boot.grpc.common.util.InterceptorOrder;
 import net.devh.boot.grpc.server.interceptor.GrpcGlobalServerInterceptor;
 
 /**
@@ -36,9 +38,16 @@ import net.devh.boot.grpc.server.interceptor.GrpcGlobalServerInterceptor;
  * @author Daniel Theuke (daniel.theuke@heuboe.de)
  */
 @GrpcGlobalServerInterceptor
+@Order(InterceptorOrder.ORDER_SECURITY_EXCEPTION_HANDLING)
 public class ExceptionTranslatingServerInterceptor implements ServerInterceptor {
 
+    /**
+     * A constant that contains the response message for unauthenticated calls.
+     */
     public static final String UNAUTHENTICATED_DESCRIPTION = "Authentication failed";
+    /**
+     * A constant that contains the response message for calls with insufficient permissions.
+     */
     public static final String ACCESS_DENIED_DESCRIPTION = "Access denied";
 
     @Override

--- a/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/service/GrpcService.java
+++ b/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/service/GrpcService.java
@@ -27,11 +27,17 @@ import org.springframework.stereotype.Service;
 
 import io.grpc.BindableService;
 import io.grpc.ServerInterceptor;
+import io.grpc.ServerInterceptors;
 
 /**
  * Annotation that marks gRPC services that should be registered with a gRPC server. If spring-boot's auto configuration
  * is used, then the server will be created automatically. This annotation should only be added to implementations of
  * {@link BindableService} (GrpcService-ImplBase).
+ *
+ * <p>
+ * <b>Note:</b> These annotation allows the specification of custom interceptors. These will be appended to the global
+ * interceptors and applied using {@link ServerInterceptors#interceptForward(BindableService, ServerInterceptor...)}.
+ * </p>
  *
  * @author Michael (yidongnan@gmail.com)
  * @since 5/17/16
@@ -47,8 +53,7 @@ public @interface GrpcService {
      * type exists, it will be used; otherwise a new instance of that class will be created via no-args constructor.
      *
      * <p>
-     * <b>Note:</b> These interceptors will be applied after the global interceptors. But the interceptors that were
-     * applied last, will be called first.
+     * <b>Note:</b> Please read the javadocs regarding the ordering of interceptors.
      * </p>
      *
      * @return A list of ServerInterceptor classes that should be used.
@@ -59,12 +64,20 @@ public @interface GrpcService {
      * A list of {@link ServerInterceptor} beans that should be applied to only this service.
      *
      * <p>
-     * <b>Note:</b> These interceptors will be applied after the global interceptors and the interceptor classes. But
-     * the interceptors that were applied last, will be called first.
+     * <b>Note:</b> Please read the javadocs regarding the ordering of interceptors.
      * </p>
      *
      * @return A list of ServerInterceptor beans that should be used.
      */
     String[] interceptorNames() default {};
+
+    /**
+     * Whether the custom interceptors should be mixed with the global interceptors and sorted afterwards. Use this
+     * option if you want to add a custom interceptor between global interceptors.
+     *
+     * @return True, if the custom interceptors should be merged with the global ones and sorted afterwards. False
+     *         otherwise.
+     */
+    boolean sortInterceptors() default false;
 
 }

--- a/tests/src/test/java/net/devh/boot/grpc/test/interceptor/DefaultServerInterceptorTest.java
+++ b/tests/src/test/java/net/devh/boot/grpc/test/interceptor/DefaultServerInterceptorTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2016-2019 Michael Zhang <yidongnan@gmail.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package net.devh.boot.grpc.test.interceptor;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ApplicationContext;
+import org.springframework.core.annotation.AnnotationAwareOrderComparator;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+import io.grpc.ServerInterceptor;
+import net.devh.boot.grpc.server.interceptor.GlobalServerInterceptorRegistry;
+import net.devh.boot.grpc.server.metric.MetricCollectingServerInterceptor;
+import net.devh.boot.grpc.server.security.interceptors.AuthenticatingServerInterceptor;
+import net.devh.boot.grpc.server.security.interceptors.AuthorizationCheckingServerInterceptor;
+import net.devh.boot.grpc.server.security.interceptors.ExceptionTranslatingServerInterceptor;
+import net.devh.boot.grpc.test.config.ManualSecurityConfiguration;
+import net.devh.boot.grpc.test.config.ServiceConfiguration;
+import net.devh.boot.grpc.test.config.WithBasicAuthSecurityConfiguration;
+
+@SpringBootTest
+@SpringJUnitConfig(classes = {ServiceConfiguration.class, WithBasicAuthSecurityConfiguration.class,
+        ManualSecurityConfiguration.class})
+@EnableAutoConfiguration
+@DirtiesContext
+public class DefaultServerInterceptorTest {
+
+    @Autowired
+    private ApplicationContext applicationContext;
+
+    @Autowired
+    private GlobalServerInterceptorRegistry registry;
+
+    @Test
+    void testOrderingOfTheDefaultInterceptors() {
+        List<ServerInterceptor> expected = new ArrayList<>();
+        expected.add(this.applicationContext.getBean(MetricCollectingServerInterceptor.class));
+        expected.add(this.applicationContext.getBean(ExceptionTranslatingServerInterceptor.class));
+        expected.add(this.applicationContext.getBean(AuthenticatingServerInterceptor.class));
+        expected.add(this.applicationContext.getBean(AuthorizationCheckingServerInterceptor.class));
+
+        List<ServerInterceptor> actual = new ArrayList<>(this.registry.getServerInterceptors());
+        assertEquals(expected, actual);
+
+        Collections.shuffle(actual);
+        AnnotationAwareOrderComparator.sort(actual);
+        assertEquals(expected, actual);
+    }
+
+}


### PR DESCRIPTION
Assigns priorities to the default interceptors and move the sorting of the interceptors to a central place, to make overwriting the logic easier.

Fixes #226 
Adds the last bits for #214

I couldn't find a way to make it less disrupting. 😢 

**Known limitations:**
* `@Order` on `@Bean` methods in `@Configuration` classes won't be picked up by Spring. I haven't found a solution for that yet: https://stackoverflow.com/questions/56331925/sort-spring-beans-by-method-level-order-annotation