### PR TITLE
Update DiscoveryClientNameResolver implementation

### DIFF
--- a/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/nameresolver/DiscoveryClientNameResolver.java
+++ b/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/nameresolver/DiscoveryClientNameResolver.java
@@ -189,7 +189,7 @@ public class DiscoveryClientNameResolver extends NameResolver {
             }
             log.info("Ready to update server list for {}", DiscoveryClientNameResolver.this.name);
             final List<EquivalentAddressGroup> targets = Lists.newArrayList();
-            for (final ServiceInstance instance : this.savedInstanceList) {
+            for (final ServiceInstance instance : newInstanceList) {
                 final Integer port = getGRPCPort(instance);
                 if (port != null) {
                     log.info("Found gRPC server {} {}:{}", DiscoveryClientNameResolver.this.name, instance.getHost(),

--- a/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/nameresolver/DiscoveryClientNameResolver.java
+++ b/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/nameresolver/DiscoveryClientNameResolver.java
@@ -17,12 +17,15 @@
 
 package net.devh.boot.grpc.client.nameresolver;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkState;
+import static java.util.Objects.requireNonNull;
+
 import java.net.InetSocketAddress;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.Executor;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.ScheduledFuture;
 
 import javax.annotation.concurrent.GuardedBy;
 
@@ -30,11 +33,9 @@ import org.springframework.cloud.client.ServiceInstance;
 import org.springframework.cloud.client.discovery.DiscoveryClient;
 import org.springframework.util.CollectionUtils;
 
-import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 
 import io.grpc.Attributes;
-import io.grpc.Channel;
 import io.grpc.EquivalentAddressGroup;
 import io.grpc.NameResolver;
 import io.grpc.Status;
@@ -42,173 +43,221 @@ import io.grpc.internal.SharedResourceHolder;
 import lombok.extern.slf4j.Slf4j;
 
 /**
- * The DiscoveryClientNameResolver configures the hosts and the associated ports for {@link Channel}s to use based on a
- * {@link DiscoveryClient}.
+ * The DiscoveryClientNameResolver resolves the service hosts and their associated gRPC port using the channel's name
+ * and spring's cloud {@link DiscoveryClient}. The ports are extracted from the {@code gRPC.port} metadata.
  *
  * @author Michael (yidongnan@gmail.com)
- * @since 5/17/16
+ * @author Daniel Theuke (daniel.theuke@heuboe.de)
  */
 @Slf4j
 public class DiscoveryClientNameResolver extends NameResolver {
 
     private final String name;
     private final DiscoveryClient client;
-    private final SharedResourceHolder.Resource<ScheduledExecutorService> timerServiceResource;
     private final SharedResourceHolder.Resource<Executor> executorResource;
-    @GuardedBy("this")
-    private boolean shutdown;
-    @GuardedBy("this")
-    private ScheduledExecutorService timerService;
-    @GuardedBy("this")
-    private Executor executor;
-    @GuardedBy("this")
-    private ScheduledFuture<?> resolutionTask;
-    @GuardedBy("this")
-    private boolean resolving;
+    // private final SynchronizationContext syncContext;
+
     @GuardedBy("this")
     private Listener listener;
     @GuardedBy("this")
-    private List<ServiceInstance> serviceInstanceList;
+    private Executor executor;
+    @GuardedBy("this")
+    private boolean resolving;
+    @GuardedBy("this")
+    private boolean shutdown;
+    @GuardedBy("this")
+    private List<ServiceInstance> instanceList = Lists.newArrayList();
 
+    // TODO: Update this to grpc-java 1.21 in v2.6.0
+    // Replace synchronized with syncContext
     public DiscoveryClientNameResolver(final String name, final DiscoveryClient client,
-            final SharedResourceHolder.Resource<ScheduledExecutorService> timerServiceResource,
+            // final Args args,
             final SharedResourceHolder.Resource<Executor> executorResource) {
         this.name = name;
         this.client = client;
-        this.timerServiceResource = timerServiceResource;
         this.executorResource = executorResource;
-        this.serviceInstanceList = Lists.newArrayList();
+        // this.syncContext =
+        // requireNonNull(args.getSynchronizationContext(), "syncContext");
     }
 
     @Override
     public final String getServiceAuthority() {
-        return name;
+        return this.name;
     }
 
     @Override
-    public final synchronized void start(Listener listener) {
-        Preconditions.checkState(this.listener == null, "already started");
-        timerService = SharedResourceHolder.get(timerServiceResource);
-        executor = SharedResourceHolder.get(executorResource);
-        this.listener = Preconditions.checkNotNull(listener, "listener");
+    public final synchronized void start(final Listener listener) {
+        checkState(this.listener == null, "already started");
+        this.executor = SharedResourceHolder.get(this.executorResource);
+        this.listener = checkNotNull(listener, "listener");
         resolve();
     }
 
     @Override
     public final synchronized void refresh() {
-        if (listener != null) {
+        // Heartbeats might happen before the resolver is even started
+        // We just ignore that case silently
+        // checkState(listener != null, "not started");
+        if (this.listener != null) {
             resolve();
         }
     }
 
-    private final Runnable resolutionRunnable = new Runnable() {
+    @GuardedBy("this")
+    private void resolve() {
+        if (this.resolving || this.shutdown) {
+            return;
+        }
+        this.resolving = true;
+        this.executor.execute(new Resolve(this.listener, this.instanceList));
+    }
+
+    @Override
+    public void shutdown() {
+        if (this.shutdown) {
+            return;
+        }
+        this.shutdown = true;
+        if (this.executor != null) {
+            this.executor = SharedResourceHolder.release(this.executorResource, this.executor);
+        }
+        this.instanceList = Lists.newArrayList();
+    }
+
+    @Override
+    public String toString() {
+        return "DiscoveryClientNameResolver [name=" + this.name + ", discoveryClient=" + this.client + "]";
+    }
+
+    /**
+     * The logic for updating the gRPC server list using a discovery client.
+     */
+    private final class Resolve implements Runnable {
+
+        private final Listener savedListener;
+        private final List<ServiceInstance> savedInstanceList;
+
+        /**
+         * Creates a new Resolve that stores a snapshot of the relevant states of the resolver.
+         *
+         * @param listener The listener to send the results to.
+         * @param instanceList The current server instance list.
+         */
+        Resolve(final Listener listener, final List<ServiceInstance> instanceList) {
+            this.savedListener = requireNonNull(listener, "listener");
+            this.savedInstanceList = requireNonNull(instanceList, "instanceList");
+        }
+
         @Override
         public void run() {
-            Listener savedListener;
-            synchronized (DiscoveryClientNameResolver.this) {
-                // If this task is started by refresh(), there might already be a scheduled task.
-                if (resolutionTask != null) {
-                    resolutionTask.cancel(false);
-                    resolutionTask = null;
-                }
-                if (shutdown) {
-                    return;
-                }
-                savedListener = listener;
-                resolving = true;
-            }
+            List<ServiceInstance> newInstanceList = null;
             try {
-                List<ServiceInstance> newServiceInstanceList;
-                try {
-                    newServiceInstanceList = client.getInstances(name);
-                } catch (Exception e) {
-                    savedListener.onError(Status.UNAVAILABLE.withCause(e));
-                    return;
-                }
-
-                if (!CollectionUtils.isEmpty(newServiceInstanceList)) {
-                    if (isNeedToUpdateServiceInstanceList(newServiceInstanceList)) {
-                        serviceInstanceList = newServiceInstanceList;
-                    } else {
-                        return;
-                    }
-                    List<EquivalentAddressGroup> equivalentAddressGroups = Lists.newArrayList();
-                    for (ServiceInstance serviceInstance : serviceInstanceList) {
-                        Map<String, String> metadata = serviceInstance.getMetadata();
-                        if (metadata.get("gRPC.port") != null) {
-                            Integer port = Integer.valueOf(metadata.get("gRPC.port"));
-                            log.info("Found gRPC server {} {}:{}", name, serviceInstance.getHost(), port);
-                            EquivalentAddressGroup addressGroup = new EquivalentAddressGroup(
-                                    new InetSocketAddress(serviceInstance.getHost(), port), Attributes.EMPTY);
-                            equivalentAddressGroups.add(addressGroup);
-                        } else {
-                            log.error("Can not found gRPC server {}", name);
-                        }
-                    }
-                    savedListener.onAddresses(equivalentAddressGroups, Attributes.EMPTY);
-                } else {
-                    savedListener.onError(Status.UNAVAILABLE
-                            .withDescription("No servers found for " + name));
-                }
+                newInstanceList = resolveInternal();
+            } catch (final Exception e) {
+                this.savedListener.onError(Status.UNAVAILABLE.withCause(e)
+                        .withDescription("Failed to update server list for " + DiscoveryClientNameResolver.this.name));
+                newInstanceList = Lists.newArrayList();
             } finally {
+                // syncContext.execute(() -> { work });
                 synchronized (DiscoveryClientNameResolver.this) {
-                    resolving = false;
+                    DiscoveryClientNameResolver.this.resolving = false;
+                    if (newInstanceList != null && !DiscoveryClientNameResolver.this.shutdown) {
+                        DiscoveryClientNameResolver.this.instanceList = newInstanceList;
+                    }
                 }
             }
         }
-    };
 
-    private boolean isNeedToUpdateServiceInstanceList(List<ServiceInstance> newServiceInstanceList) {
-        if (serviceInstanceList.size() == newServiceInstanceList.size()) {
-            for (ServiceInstance serviceInstance : serviceInstanceList) {
+        /**
+         * Do the actual update checks and resolving logic.
+         *
+         * @return The new service instance list that is used to connect to the gRPC server or null if the old ones
+         *         should be used.
+         */
+        private List<ServiceInstance> resolveInternal() {
+            final List<ServiceInstance> newInstanceList =
+                    DiscoveryClientNameResolver.this.client.getInstances(DiscoveryClientNameResolver.this.name);
+            if (CollectionUtils.isEmpty(newInstanceList)) {
+                this.savedListener.onError(Status.UNAVAILABLE
+                        .withDescription("No servers found for " + DiscoveryClientNameResolver.this.name));
+                return Lists.newArrayList();
+            }
+            if (!needsToUpdateConnections(newInstanceList)) {
+                log.debug("Nothing has changed... skipping update for {}", DiscoveryClientNameResolver.this.name);
+                return null;
+            }
+            log.info("Ready to update server list for {}", DiscoveryClientNameResolver.this.name);
+            final List<EquivalentAddressGroup> targets = Lists.newArrayList();
+            for (final ServiceInstance instance : this.savedInstanceList) {
+                final Integer port = getGRPCPort(instance);
+                if (port != null) {
+                    log.info("Found gRPC server {} {}:{}", DiscoveryClientNameResolver.this.name, instance.getHost(),
+                            port);
+                    final EquivalentAddressGroup target = new EquivalentAddressGroup(
+                            new InetSocketAddress(instance.getHost(), port), Attributes.EMPTY);
+                    targets.add(target);
+                } else {
+                    log.error("Cannot find gRPC server port for {} in {} - Skipping",
+                            DiscoveryClientNameResolver.this.name, instance);
+                }
+            }
+            this.savedListener.onAddresses(targets, Attributes.EMPTY);
+            log.info("Done updating server list for {}", DiscoveryClientNameResolver.this.name);
+            return newInstanceList;
+        }
+
+        /**
+         * Extracts the gRPC server port from the given service instance.
+         *
+         * @param instance The instance to extract the port from.
+         * @return The gRPC server port or null if not specified.
+         * @throws IllegalArgumentException If the specified port definition couldn't be parsed.
+         */
+        private Integer getGRPCPort(final ServiceInstance instance) {
+            final Map<String, String> metadata = instance.getMetadata();
+            if (metadata == null) {
+                return null;
+            }
+            final String portString = metadata.get("gRPC.port");
+            if (portString == null) {
+                return null;
+            }
+            try {
+                return Integer.parseInt(portString);
+            } catch (final NumberFormatException e) {
+                // TODO: How to handle this case?
+                throw new IllegalArgumentException("Failed to parse gRPC port information from: " + instance, e);
+            }
+        }
+
+        /**
+         * Checks whether this instance should update its connections.
+         *
+         * @param newInstanceList The new instances that should be compared to the stored ones.
+         * @return True, if the given instance list contains different entries than the stored ones.
+         */
+        private boolean needsToUpdateConnections(final List<ServiceInstance> newInstanceList) {
+            if (this.savedInstanceList.size() != newInstanceList.size()) {
+                return true;
+            }
+            for (final ServiceInstance instance : this.savedInstanceList) {
+                final Integer port = getGRPCPort(instance);
                 boolean isSame = false;
-                for (ServiceInstance newServiceInstance : newServiceInstanceList) {
-                    if (newServiceInstance.getHost().equals(serviceInstance.getHost())
-                            && newServiceInstance.getPort() == serviceInstance.getPort()) {
+                for (final ServiceInstance newInstance : newInstanceList) {
+                    final Integer newPort = getGRPCPort(newInstance);
+                    if (newInstance.getHost().equals(instance.getHost())
+                            && Objects.equals(port, newPort)) {
                         isSame = true;
                         break;
                     }
                 }
                 if (!isSame) {
-                    log.info("Ready to update {} server info group list", name);
                     return true;
                 }
             }
-        } else {
-            log.info("Ready to update {} server info group list", name);
-            return true;
+            return false;
         }
-        return false;
-    }
 
-    @GuardedBy("this")
-    private void resolve() {
-        if (resolving || shutdown) {
-            return;
-        }
-        executor.execute(resolutionRunnable);
-    }
-
-    @Override
-    public void shutdown() {
-        if (shutdown) {
-            return;
-        }
-        shutdown = true;
-        if (resolutionTask != null) {
-            resolutionTask.cancel(false);
-        }
-        if (timerService != null) {
-            timerService = SharedResourceHolder.release(timerServiceResource, timerService);
-        }
-        if (executor != null) {
-            executor = SharedResourceHolder.release(executorResource, executor);
-        }
-    }
-
-    @Override
-    public String toString() {
-        return "DiscoveryClientNameResolver [name=" + name + ", discoveryClient=" + client + "]";
     }
 
 }

--- a/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/nameresolver/DiscoveryClientNameResolver.java
+++ b/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/nameresolver/DiscoveryClientNameResolver.java
@@ -41,6 +41,7 @@ import io.grpc.NameResolver;
 import io.grpc.Status;
 import io.grpc.internal.SharedResourceHolder;
 import lombok.extern.slf4j.Slf4j;
+import net.devh.boot.grpc.common.util.GrpcUtils;
 
 /**
  * The DiscoveryClientNameResolver resolves the service hosts and their associated gRPC port using the channel's name
@@ -218,7 +219,7 @@ public class DiscoveryClientNameResolver extends NameResolver {
             if (metadata == null) {
                 return null;
             }
-            final String portString = metadata.get("gRPC.port");
+            final String portString = metadata.get(GrpcUtils.CLOUD_DISCOVERY_METADATA_PORT);
             if (portString == null) {
                 return null;
             }

--- a/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/nameresolver/DiscoveryClientResolverFactory.java
+++ b/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/nameresolver/DiscoveryClientResolverFactory.java
@@ -81,7 +81,7 @@ public class DiscoveryClientResolverFactory extends NameResolver.Factory {
             }
             final DiscoveryClientNameResolver discoveryClientNameResolver =
                     new DiscoveryClientNameResolver(serviceName.substring(1), this.client,
-                            GrpcUtil.TIMER_SERVICE, GrpcUtil.SHARED_CHANNEL_EXECUTOR);
+                            GrpcUtil.SHARED_CHANNEL_EXECUTOR);
             this.discoveryClientNameResolvers.add(discoveryClientNameResolver);
             return discoveryClientNameResolver;
         }

--- a/grpc-common-spring-boot/src/main/java/net/devh/boot/grpc/common/util/GrpcUtils.java
+++ b/grpc-common-spring-boot/src/main/java/net/devh/boot/grpc/common/util/GrpcUtils.java
@@ -27,6 +27,11 @@ import io.grpc.MethodDescriptor;
 public final class GrpcUtils {
 
     /**
+     * The cloud discovery metadata key used to identify the grpc port.
+     */
+    public static final String CLOUD_DISCOVERY_METADATA_PORT = "gRPC.port";
+
+    /**
      * Extracts the service name from the given method.
      *
      * @param method The method to get the service name from.

--- a/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/autoconfigure/GrpcMetadataEurekaConfiguration.java
+++ b/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/autoconfigure/GrpcMetadataEurekaConfiguration.java
@@ -28,6 +28,7 @@ import org.springframework.context.annotation.Configuration;
 import com.netflix.appinfo.EurekaInstanceConfig;
 import com.netflix.discovery.EurekaClient;
 
+import net.devh.boot.grpc.common.util.GrpcUtils;
 import net.devh.boot.grpc.server.config.GrpcServerProperties;
 
 /**
@@ -54,7 +55,7 @@ public class GrpcMetadataEurekaConfiguration {
         }
         final int port = this.grpcProperties.getPort();
         if (port != -1) {
-            this.instance.getMetadataMap().put("gRPC.port", Integer.toString(port));
+            this.instance.getMetadataMap().put(GrpcUtils.CLOUD_DISCOVERY_METADATA_PORT, Integer.toString(port));
         }
     }
 

--- a/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/autoconfigure/GrpcMetadataNacosConfiguration.java
+++ b/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/autoconfigure/GrpcMetadataNacosConfiguration.java
@@ -28,6 +28,7 @@ import org.springframework.context.annotation.Configuration;
 
 import com.alibaba.nacos.client.naming.NacosNamingService;
 
+import net.devh.boot.grpc.common.util.GrpcUtils;
 import net.devh.boot.grpc.server.config.GrpcServerProperties;
 
 /**
@@ -53,7 +54,7 @@ public class GrpcMetadataNacosConfiguration {
         }
         final int port = this.grpcProperties.getPort();
         if (port != -1) {
-            this.nacosRegistration.getMetadata().put("gRPC.port", Integer.toString(port));
+            this.nacosRegistration.getMetadata().put(GrpcUtils.CLOUD_DISCOVERY_METADATA_PORT, Integer.toString(port));
         }
     }
 

--- a/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/cloud/ConsulGrpcRegistrationCustomizer.java
+++ b/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/cloud/ConsulGrpcRegistrationCustomizer.java
@@ -23,6 +23,7 @@ import java.util.List;
 import org.springframework.cloud.consul.serviceregistry.ConsulRegistration;
 import org.springframework.cloud.consul.serviceregistry.ConsulRegistrationCustomizer;
 
+import net.devh.boot.grpc.common.util.GrpcUtils;
 import net.devh.boot.grpc.server.config.GrpcServerProperties;
 
 /**
@@ -53,7 +54,7 @@ public class ConsulGrpcRegistrationCustomizer implements ConsulRegistrationCusto
         }
         final int port = this.grpcServerProperties.getPort();
         if (port != -1) {
-            tags.add("gRPC.port=" + port);
+            tags.add(GrpcUtils.CLOUD_DISCOVERY_METADATA_PORT + "=" + port);
             registration.getService().setTags(tags);
         }
     }


### PR DESCRIPTION
Fixes #240

* Changed the implementation to follow the `DnsNameResolver` one that is provided by gRPC.
* Fixed the server identification incorrectly using the http port instead of the gRPC port

@alienxt Can you test whether this PR fixes the issue for you?

~~I'm not sure whether the current implementation fixes all issues with the discovery client.
Maybe we also have to compare the instance ids as to ensure that gRPC triggers a reconnect to a server that just restarted using the same port again. The automated cloud example test fails here sometimes and I'm not sure whether this is caused by the missing reconnect or just a side effect from the sudden server unavailability.
I will do some more testing, before I consider this ready to be merged.~~

The used eureka/zipkin server used in the example is too slow to always detect/publish the server unavailability / new server in time. That's why it fails sometimes.