### PR TITLE
Split AuthenticatingServerInterceptor into an interface

### DIFF
--- a/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/autoconfigure/GrpcServerSecurityAutoConfiguration.java
+++ b/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/autoconfigure/GrpcServerSecurityAutoConfiguration.java
@@ -32,6 +32,7 @@ import net.devh.boot.grpc.server.security.authentication.GrpcAuthenticationReade
 import net.devh.boot.grpc.server.security.check.GrpcSecurityMetadataSource;
 import net.devh.boot.grpc.server.security.interceptors.AuthenticatingServerInterceptor;
 import net.devh.boot.grpc.server.security.interceptors.AuthorizationCheckingServerInterceptor;
+import net.devh.boot.grpc.server.security.interceptors.DefaultAuthenticatingServerInterceptor;
 import net.devh.boot.grpc.server.security.interceptors.ExceptionTranslatingServerInterceptor;
 
 /**
@@ -87,7 +88,7 @@ public class GrpcServerSecurityAutoConfiguration {
     public AuthenticatingServerInterceptor authenticatingServerInterceptor(
             final AuthenticationManager authenticationManager,
             final GrpcAuthenticationReader authenticationReader) {
-        return new AuthenticatingServerInterceptor(authenticationManager, authenticationReader);
+        return new DefaultAuthenticatingServerInterceptor(authenticationManager, authenticationReader);
     }
 
     /**

--- a/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/autoconfigure/GrpcServerSecurityAutoConfiguration.java
+++ b/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/autoconfigure/GrpcServerSecurityAutoConfiguration.java
@@ -84,8 +84,8 @@ public class GrpcServerSecurityAutoConfiguration {
      * @return The authenticatingServerInterceptor bean.
      */
     @Bean
-    @ConditionalOnMissingBean
-    public AuthenticatingServerInterceptor authenticatingServerInterceptor(
+    @ConditionalOnMissingBean(AuthenticatingServerInterceptor.class)
+    public DefaultAuthenticatingServerInterceptor authenticatingServerInterceptor(
             final AuthenticationManager authenticationManager,
             final GrpcAuthenticationReader authenticationReader) {
         return new DefaultAuthenticatingServerInterceptor(authenticationManager, authenticationReader);

--- a/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/security/interceptors/AbstractAuthenticatingServerCallListener.java
+++ b/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/security/interceptors/AbstractAuthenticatingServerCallListener.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright (c) 2016-2019 Michael Zhang <yidongnan@gmail.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package net.devh.boot.grpc.server.security.interceptors;
+
+import io.grpc.Context;
+import io.grpc.Contexts;
+import io.grpc.ForwardingServerCallListener.SimpleForwardingServerCallListener;
+import io.grpc.Metadata;
+import io.grpc.ServerCall;
+import io.grpc.ServerCall.Listener;
+import io.grpc.ServerCallHandler;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * A call listener that will set the authentication context before each invocation and clear it afterwards. Use and
+ * extend this class if you want to setup non-grpc authentication contexts.
+ *
+ * <p>
+ * <b>Note:</b> If you only want to setup the grpc-context and nothing else, then you can use
+ * {@link Contexts#interceptCall(Context, ServerCall, Metadata, ServerCallHandler)} instead.
+ *
+ * @param <ReqT> The type of the request.
+ */
+@Slf4j
+public abstract class AbstractAuthenticatingServerCallListener<ReqT> extends SimpleForwardingServerCallListener<ReqT> {
+
+    private final Context context;
+
+    /**
+     * Creates a new AbstractAuthenticatingServerCallListener which will attach the given security context before
+     * delegating to the given listener.
+     *
+     * @param delegate The listener to delegate to.
+     * @param context The context to attach.
+     */
+    protected AbstractAuthenticatingServerCallListener(final Listener<ReqT> delegate, final Context context) {
+        super(delegate);
+        this.context = context;
+    }
+
+    /**
+     * Gets the {@link Context} associated with the call.
+     *
+     * @return The context of the current call.
+     */
+    protected final Context context() {
+        return this.context;
+    }
+
+    /**
+     * Attaches the authentication context before the actual call.
+     *
+     * <p>
+     * This method is called after the grpc context is attached.
+     * </p>
+     */
+    protected abstract void attachAuthenticationContext();
+
+    /**
+     * Detaches the authentication context after the actual call.
+     *
+     * <p>
+     * This method is called before the grpc context is detached.
+     * </p>
+     */
+    protected abstract void detachAuthenticationContext();
+
+    @Override
+    public void onMessage(final ReqT message) {
+        final Context previous = this.context.attach();
+        try {
+            attachAuthenticationContext();
+            log.debug("onMessage - Authentication set");
+            super.onMessage(message);
+        } finally {
+            detachAuthenticationContext();
+            this.context.detach(previous);
+            log.debug("onMessage - Authentication cleared");
+        }
+    }
+
+    @Override
+    public void onHalfClose() {
+        final Context previous = this.context.attach();
+        try {
+            attachAuthenticationContext();
+            log.debug("onHalfClose - Authentication set");
+            super.onHalfClose();
+        } finally {
+            detachAuthenticationContext();
+            this.context.detach(previous);
+            log.debug("onHalfClose - Authentication cleared");
+        }
+    }
+
+    @Override
+    public void onCancel() {
+        final Context previous = this.context.attach();
+        try {
+            attachAuthenticationContext();
+            log.debug("onCancel - Authentication set");
+            super.onCancel();
+        } finally {
+            detachAuthenticationContext();
+            log.debug("onCancel - Authentication cleared");
+            this.context.detach(previous);
+        }
+    }
+
+    @Override
+    public void onComplete() {
+        final Context previous = this.context.attach();
+        try {
+            attachAuthenticationContext();
+            log.debug("onComplete - Authentication set");
+            super.onComplete();
+        } finally {
+            detachAuthenticationContext();
+            log.debug("onComplete - Authentication cleared");
+            this.context.detach(previous);
+        }
+    }
+
+    @Override
+    public void onReady() {
+        final Context previous = this.context.attach();
+        try {
+            attachAuthenticationContext();
+            log.debug("onReady - Authentication set");
+            super.onReady();
+        } finally {
+            detachAuthenticationContext();
+            log.debug("onReady - Authentication cleared");
+            this.context.detach(previous);
+        }
+    }
+
+}

--- a/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/security/interceptors/DefaultAuthenticatingServerInterceptor.java
+++ b/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/security/interceptors/DefaultAuthenticatingServerInterceptor.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright (c) 2016-2019 Michael Zhang <yidongnan@gmail.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package net.devh.boot.grpc.server.security.interceptors;
+
+import static java.util.Objects.requireNonNull;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.annotation.Order;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.authentication.AbstractAuthenticationToken;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import io.grpc.Context;
+import io.grpc.Contexts;
+import io.grpc.Metadata;
+import io.grpc.ServerCall;
+import io.grpc.ServerCall.Listener;
+import io.grpc.ServerCallHandler;
+import lombok.extern.slf4j.Slf4j;
+import net.devh.boot.grpc.common.util.InterceptorOrder;
+import net.devh.boot.grpc.server.interceptor.GrpcGlobalServerInterceptor;
+import net.devh.boot.grpc.server.security.authentication.GrpcAuthenticationReader;
+
+/**
+ * A server interceptor that tries to {@link GrpcAuthenticationReader read} the credentials from the client and
+ * {@link AuthenticationManager#authenticate(Authentication) authenticate} them. This interceptor sets the
+ * authentication to both grpc's {@link Context} and {@link SecurityContextHolder}.
+ *
+ * <p>
+ * <b>Note:</b> This interceptor works similar to
+ * {@link Contexts#interceptCall(Context, ServerCall, Metadata, ServerCallHandler)}.
+ * </p>
+ *
+ * @author Daniel Theuke (daniel.theuke@heuboe.de)
+ */
+@Slf4j
+@GrpcGlobalServerInterceptor
+@Order(InterceptorOrder.ORDER_SECURITY_AUTHENTICATION)
+public class DefaultAuthenticatingServerInterceptor implements AuthenticatingServerInterceptor {
+
+    private final AuthenticationManager authenticationManager;
+    private final GrpcAuthenticationReader grpcAuthenticationReader;
+
+    /**
+     * Creates a new DefaultAuthenticatingServerInterceptor with the given authentication manager and reader.
+     *
+     * @param authenticationManager The authentication manager used to verify the credentials.
+     * @param authenticationReader The authentication reader used to extract the credentials from the call.
+     */
+    @Autowired
+    public DefaultAuthenticatingServerInterceptor(final AuthenticationManager authenticationManager,
+            final GrpcAuthenticationReader authenticationReader) {
+        this.authenticationManager = requireNonNull(authenticationManager, "authenticationManager");
+        this.grpcAuthenticationReader = requireNonNull(authenticationReader, "authenticationReader");
+    }
+
+    @Override
+    public <ReqT, RespT> ServerCall.Listener<ReqT> interceptCall(final ServerCall<ReqT, RespT> call,
+            final Metadata headers, final ServerCallHandler<ReqT, RespT> next) {
+        Authentication authentication = this.grpcAuthenticationReader.readAuthentication(call, headers);
+        if (authentication == null) {
+            log.debug("No credentials found: Continuing unauthenticated");
+            try {
+                return next.startCall(call, headers);
+            } catch (final AccessDeniedException e) {
+                throw new BadCredentialsException("No credentials found in the request", e);
+            }
+        }
+        if (authentication.getDetails() == null && authentication instanceof AbstractAuthenticationToken) {
+            // Append call attributes to the authentication request.
+            // This gives the AuthenticationManager access to information like remote and local address.
+            // It can then decide whether it wants to use its own user details or the attributes.
+            ((AbstractAuthenticationToken) authentication).setDetails(call.getAttributes());
+        }
+        log.debug("Credentials found: Authenticating...");
+        authentication = this.authenticationManager.authenticate(authentication);
+
+        final Context context = Context.current().withValue(AUTHENTICATION_CONTEXT_KEY, authentication);
+        final Context previousContext = context.attach();
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+        log.debug("Authentication successful: Continuing as {} ({})", authentication.getName(),
+                authentication.getAuthorities());
+        try {
+            return new AuthenticatingServerCallListener<>(next.startCall(call, headers), context, authentication);
+        } catch (final AccessDeniedException e) {
+            if (authentication instanceof AnonymousAuthenticationToken) {
+                throw new BadCredentialsException("No credentials found in the request", e);
+            } else {
+                throw e;
+            }
+        } finally {
+            SecurityContextHolder.clearContext();
+            context.detach(previousContext);
+            log.debug("startCall - Authentication cleared");
+        }
+    }
+
+    /**
+     * A call listener that will set the authentication context using {@link SecurityContextHolder} before each
+     * invocation and clear it afterwards.
+     *
+     * @param <ReqT> The type of the request.
+     */
+    private static class AuthenticatingServerCallListener<ReqT> extends AbstractAuthenticatingServerCallListener<ReqT> {
+
+        private final Authentication authentication;
+
+        /**
+         * Creates a new AuthenticatingServerCallListener which will attach the given security context before delegating
+         * to the given listener.
+         *
+         * @param delegate The listener to delegate to.
+         * @param context The context to attach.
+         * @param authentication The authentication instance to attach.
+         */
+        public AuthenticatingServerCallListener(final Listener<ReqT> delegate, final Context context,
+                final Authentication authentication) {
+            super(delegate, context);
+            this.authentication = authentication;
+        }
+
+        @Override
+        protected void attachAuthenticationContext() {
+            SecurityContextHolder.getContext().setAuthentication(this.authentication);
+        }
+
+        @Override
+        protected void detachAuthenticationContext() {
+            SecurityContextHolder.clearContext();
+        }
+
+        @Override
+        public void onHalfClose() {
+            try {
+                super.onHalfClose();
+            } catch (final AccessDeniedException e) {
+                if (this.authentication instanceof AnonymousAuthenticationToken) {
+                    throw new BadCredentialsException("No credentials found in the request", e);
+                } else {
+                    throw e;
+                }
+            }
+        }
+
+    }
+
+}


### PR DESCRIPTION
This makes it easier to replace it with custom implementations.
Fixes #249 (@pluttrell)