### PR TITLE
Extend metrics (Part 1)

### DIFF
--- a/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/metric/MetricCollectingClientInterceptor.java
+++ b/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/metric/MetricCollectingClientInterceptor.java
@@ -100,7 +100,7 @@ public class MetricCollectingClientInterceptor extends AbstractMetricCollectingI
         return asTimerFunction(() -> this.timerCustomizer.apply(
                 prepareTimerFor(method,
                         METRIC_NAME_CLIENT_PROCESSING_DURATION,
-                        "The total time taken for the server to process the requests including network delay as observed by the client")));
+                        "The total time taken for the client to complete the call, including network delay")));
     }
 
     @Override

--- a/grpc-common-spring-boot/src/main/java/net/devh/boot/grpc/common/metric/MetricConstants.java
+++ b/grpc-common-spring-boot/src/main/java/net/devh/boot/grpc/common/metric/MetricConstants.java
@@ -41,6 +41,10 @@ public final class MetricConstants {
      */
     public static final String TAG_METHOD_NAME = "method";
     /**
+     * The metrics tag key that belongs to the called method type.
+     */
+    public static final String TAG_METHOD_TYPE = "methodType";
+    /**
      * The metrics tag key that belongs to the result status code.
      */
     public static final String TAG_STATUS_CODE = "statusCode";

--- a/grpc-common-spring-boot/src/main/java/net/devh/boot/grpc/common/metric/MetricConstants.java
+++ b/grpc-common-spring-boot/src/main/java/net/devh/boot/grpc/common/metric/MetricConstants.java
@@ -24,13 +24,31 @@ package net.devh.boot.grpc.common.metric;
  */
 public final class MetricConstants {
 
-    public static final String METRIC_NAME_SERVER_PROCESSING_DURATION = "grpc.server.processing.duration";
-    public static final String METRIC_NAME_SERVER_RESPONSES_SENT = "grpc.server.responses.sent";
+    /**
+     * The total number of requests received
+     */
     public static final String METRIC_NAME_SERVER_REQUESTS_RECEIVED = "grpc.server.requests.received";
+    /**
+     * The total number of responses sent
+     */
+    public static final String METRIC_NAME_SERVER_RESPONSES_SENT = "grpc.server.responses.sent";
+    /**
+     * The total time taken for the server to complete the call.
+     */
+    public static final String METRIC_NAME_SERVER_PROCESSING_DURATION = "grpc.server.processing.duration";
 
-    public static final String METRIC_NAME_CLIENT_PROCESSING_DURATION = "grpc.client.processing.duration";
-    public static final String METRIC_NAME_CLIENT_RESPONSES_RECEIVED = "grpc.client.responses.received";
+    /**
+     * The total number of requests sent
+     */
     public static final String METRIC_NAME_CLIENT_REQUESTS_SENT = "grpc.client.requests.sent";
+    /**
+     * The total number of responses received
+     */
+    public static final String METRIC_NAME_CLIENT_RESPONSES_RECEIVED = "grpc.client.responses.received";
+    /**
+     * The total time taken for the client to complete the call, including network delay
+     */
+    public static final String METRIC_NAME_CLIENT_PROCESSING_DURATION = "grpc.client.processing.duration";
 
     /**
      * The metrics tag key that belongs to the called service name.

--- a/grpc-common-spring-boot/src/main/java/net/devh/boot/grpc/common/metric/MetricConstants.java
+++ b/grpc-common-spring-boot/src/main/java/net/devh/boot/grpc/common/metric/MetricConstants.java
@@ -59,7 +59,7 @@ public final class MetricConstants {
      */
     public static final String TAG_METHOD_NAME = "method";
     /**
-     * The metrics tag key that belongs to the called method type.
+     * The metrics tag key that belongs to the type of the called method.
      */
     public static final String TAG_METHOD_TYPE = "methodType";
     /**

--- a/grpc-common-spring-boot/src/main/java/net/devh/boot/grpc/common/metric/MetricUtils.java
+++ b/grpc-common-spring-boot/src/main/java/net/devh/boot/grpc/common/metric/MetricUtils.java
@@ -18,6 +18,7 @@
 package net.devh.boot.grpc.common.metric;
 
 import static net.devh.boot.grpc.common.metric.MetricConstants.TAG_METHOD_NAME;
+import static net.devh.boot.grpc.common.metric.MetricConstants.TAG_METHOD_TYPE;
 import static net.devh.boot.grpc.common.metric.MetricConstants.TAG_SERVICE_NAME;
 import static net.devh.boot.grpc.common.util.GrpcUtils.extractMethodName;
 import static net.devh.boot.grpc.common.util.GrpcUtils.extractServiceName;
@@ -48,7 +49,8 @@ public final class MetricUtils {
                 .description(description)
                 .baseUnit("messages")
                 .tag(TAG_SERVICE_NAME, extractServiceName(method))
-                .tag(TAG_METHOD_NAME, extractMethodName(method));
+                .tag(TAG_METHOD_NAME, extractMethodName(method))
+                .tag(TAG_METHOD_TYPE, method.getType().name());
     }
 
     /**
@@ -64,7 +66,8 @@ public final class MetricUtils {
         return Timer.builder(name)
                 .description(description)
                 .tag(TAG_SERVICE_NAME, extractServiceName(method))
-                .tag(TAG_METHOD_NAME, extractMethodName(method));
+                .tag(TAG_METHOD_NAME, extractMethodName(method))
+                .tag(TAG_METHOD_TYPE, method.getType().name());
     }
 
     private MetricUtils() {}

--- a/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/metric/MetricCollectingServerInterceptor.java
+++ b/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/metric/MetricCollectingServerInterceptor.java
@@ -123,7 +123,7 @@ public class MetricCollectingServerInterceptor extends AbstractMetricCollectingI
         return asTimerFunction(() -> this.timerCustomizer.apply(
                 prepareTimerFor(method,
                         METRIC_NAME_SERVER_PROCESSING_DURATION,
-                        "The total time taken for the server to process requests as observed by the server")));
+                        "The total time taken for the server to complete the call")));
     }
 
     @Override


### PR DESCRIPTION
Partially adds #263

The rest will be added in `2.6.0`.

This improves the description of the metrics and adds the `methodType` to the tags to allow metric visualization tools to include the type.