### PR TITLE
Update grpc-java for CVE-2019-9515 fix

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,9 +11,9 @@ buildscript {
         maven { url "https://plugins.gradle.org/m2/" }
     }
     ext {
-        projectVersion = '2.6.0-SNAPSHOT'
+        projectVersion = '2.5.1-SNAPSHOT'
 
-        grpcVersion = '1.22.1'
+        grpcVersion = '1.22.2'
         protobufVersion = '3.8.0'
         protobufGradlePluginVersion = '0.8.8'
 


### PR DESCRIPTION
grpc-java released a fix for CVE-2019-9515 (SETTINGS flood).

> Users using the grpc-netty server with untrusted clients should upgrade.

**CVE-Type:** Resource consumption / DOS
**Severity:** to be defined

We should update our libraries and @yidongnan - if your time permits it - create a release version for it.

### Further reading
https://nvd.nist.gov/vuln/detail/CVE-2019-9515
https://kb.cert.org/vuls/id/605641/ - lists the discovered (potential) HTTP/2 vulnerabilities
https://github.com/grpc/grpc-java/releases/tag/v1.22.2