### PR TITLE
Add support for connecting to the own server

### DIFF
--- a/docs/en/client/configuration.md
+++ b/docs/en/client/configuration.md
@@ -28,7 +28,7 @@ You can find all build-in configuration properties here:
 
 - [`GrpcChannelsProperties`](https://javadoc.io/page/net.devh/grpc-client-spring-boot-autoconfigure/latest/net/devh/boot/grpc/client/config/GrpcChannelsProperties.html)
 - [`GrpcChannelProperties`](https://javadoc.io/page/net.devh/grpc-client-spring-boot-autoconfigure/latest/net/devh/boot/grpc/client/config/GrpcChannelProperties.html)
-- [`GrpcServerProperties.Security`](https://static.javadoc.io/net.devh/grpc-client-spring-boot-autoconfigure/2.4.0.RELEASE/net/devh/boot/grpc/client/config/GrpcChannelProperties.Security.html)
+- [`GrpcServerProperties.Security`](https://static.javadoc.io/net.devh/grpc-client-spring-boot-autoconfigure/latest/net/devh/boot/grpc/client/config/GrpcChannelProperties.Security.html)
 
 If you prefer to read the sources instead, you can do so
 [here](https://github.com/yidongnan/grpc-spring-boot-starter/blob/master/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/config/GrpcChannelProperties.java#L58).
@@ -62,6 +62,11 @@ There are a number of supported schemes, that you can use to determine the targe
   automatically during `HeartbeatEvent`s. Uses the `gRPC.port` metadata to determine the port, otherwise uses the
   service port.
   Example: `discovery:///service-name`
+- `self` (Prio 0):
+  The self address or scheme is a keyword that is available, if you also use `grpc-server-spring-boot-starter` and
+  allows you to connect to the server without specifying the own address/port. This is especially useful for tests
+  where you might want to use random server ports to avoid conflicts.
+  Example: `self` or `self:self`
 - `in-process`:
   This is a special scheme that will bypass the normal channel factory and will use the `InProcessChannelFactory`
   instead. Use it to connect to the [`InProcessServer`](../server/configuration#enabling-the-inprocessserver).

--- a/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/nameresolver/DiscoveryClientResolverFactory.java
+++ b/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/nameresolver/DiscoveryClientResolverFactory.java
@@ -36,7 +36,7 @@ import io.grpc.NameResolverProvider;
 import io.grpc.internal.GrpcUtil;
 
 /**
- * A name resolver factory that will create an {@link DiscoveryClientNameResolver} based on the target uri.
+ * A name resolver factory that will create a {@link DiscoveryClientNameResolver} based on the target uri.
  *
  * @author Michael (yidongnan@gmail.com)
  * @since 5/17/16

--- a/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/nameresolver/NameResolverRegistration.java
+++ b/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/nameresolver/NameResolverRegistration.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2016-2019 Michael Zhang <yidongnan@gmail.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package net.devh.boot.grpc.client.nameresolver;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.beans.factory.DisposableBean;
+
+import com.google.common.collect.ImmutableList;
+
+import io.grpc.NameResolverProvider;
+import io.grpc.NameResolverRegistry;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * The NameResolverRegistration manages the registration and de-registration of Spring managed name resolvers.
+ *
+ * @author Daniel Theuke (daniel.theuke@heuboe.de)
+ */
+@Slf4j
+public class NameResolverRegistration implements DisposableBean {
+
+    private final List<NameResolverRegistry> registries = new ArrayList<>(1);
+    private final List<NameResolverProvider> providers;
+
+    /**
+     * Creates a new NameResolverRegistration with the given list of providers.
+     *
+     * @param providers The providers that should be managed.
+     */
+    public NameResolverRegistration(List<NameResolverProvider> providers) {
+        this.providers = providers == null ? ImmutableList.of() : ImmutableList.copyOf(providers);
+    }
+
+    /**
+     * Register all NameResolverProviders in the given registry and store a reference to it for later de-registration.
+     *
+     * @param registry The registry to add the providers to.
+     */
+    public void register(NameResolverRegistry registry) {
+        this.registries.add(registry);
+        for (NameResolverProvider provider : this.providers) {
+            try {
+                registry.register(provider);
+                log.info("{} is available -> Added to the NameResolverRegistry", provider);
+            } catch (IllegalArgumentException e) {
+                log.info("{} is not available -> Not added to the NameResolverRegistry", provider);
+            }
+        }
+    }
+
+    @Override
+    public void destroy() {
+        for (NameResolverRegistry registry : this.registries) {
+            for (NameResolverProvider provider : this.providers) {
+                registry.deregister(provider);
+                log.info("{} was removed from the NameResolverRegistry", provider);
+            }
+        }
+        this.registries.clear();
+    }
+
+}

--- a/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/autoconfigure/GrpcServerAutoConfiguration.java
+++ b/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/autoconfigure/GrpcServerAutoConfiguration.java
@@ -27,6 +27,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Lazy;
 
 import io.grpc.CompressorRegistry;
 import io.grpc.DecompressorRegistry;
@@ -36,6 +37,7 @@ import net.devh.boot.grpc.common.autoconfigure.GrpcCommonCodecAutoConfiguration;
 import net.devh.boot.grpc.server.config.GrpcServerProperties;
 import net.devh.boot.grpc.server.interceptor.AnnotationGlobalServerInterceptorConfigurer;
 import net.devh.boot.grpc.server.interceptor.GlobalServerInterceptorRegistry;
+import net.devh.boot.grpc.server.nameresolver.SelfNameResolverFactory;
 import net.devh.boot.grpc.server.scope.GrpcRequestScope;
 import net.devh.boot.grpc.server.serverfactory.GrpcServerConfigurer;
 import net.devh.boot.grpc.server.serverfactory.GrpcServerFactory;
@@ -69,6 +71,20 @@ public class GrpcServerAutoConfiguration {
     @Bean
     public GrpcServerProperties defaultGrpcServerProperties() {
         return new GrpcServerProperties();
+    }
+
+    /**
+     * Lazily creates a {@link SelfNameResolverFactory} bean, that can be used by the client to connect to the server
+     * itself.
+     *
+     * @param properties The properties to derive the address from.
+     * @return The newly created {@link SelfNameResolverFactory} bean.
+     */
+    @ConditionalOnMissingBean
+    @Bean
+    @Lazy
+    public SelfNameResolverFactory selfNameResolverFactory(GrpcServerProperties properties) {
+        return new SelfNameResolverFactory(properties);
     }
 
     @ConditionalOnMissingBean

--- a/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/nameresolver/SelfNameResolver.java
+++ b/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/nameresolver/SelfNameResolver.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright (c) 2016-2019 Michael Zhang <yidongnan@gmail.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package net.devh.boot.grpc.server.nameresolver;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkState;
+import static java.util.Objects.requireNonNull;
+
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+import java.net.SocketException;
+import java.net.UnknownHostException;
+import java.util.concurrent.Executor;
+
+import javax.annotation.concurrent.GuardedBy;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.net.InetAddresses;
+
+import io.grpc.Attributes;
+import io.grpc.EquivalentAddressGroup;
+import io.grpc.NameResolver;
+import io.grpc.Status;
+import io.grpc.SynchronizationContext;
+import io.grpc.internal.GrpcUtil;
+import io.grpc.internal.SharedResourceHolder;
+import lombok.extern.slf4j.Slf4j;
+import net.devh.boot.grpc.server.config.GrpcServerProperties;
+
+/**
+ * A {@link NameResolver} that will always respond with the server's own address.
+ */
+@Slf4j
+public class SelfNameResolver extends NameResolver {
+
+    private final GrpcServerProperties properties;
+    private final SharedResourceHolder.Resource<Executor> executorResource;
+    private final SynchronizationContext syncContext;
+
+    @GuardedBy("this")
+    private Listener listener = null;
+    @GuardedBy("this")
+    private Executor executor = null;
+    @GuardedBy("this")
+    private boolean resolving = false;
+
+    /**
+     * Creates a self name resolver with the given properties.
+     *
+     * @param properties The properties to read the server address from.
+     * @param args The arguments for the resolver.
+     */
+    public SelfNameResolver(GrpcServerProperties properties, final Args args) {
+        this(properties, args, GrpcUtil.SHARED_CHANNEL_EXECUTOR);
+    }
+
+    /**
+     * Creates a self name resolver with the given properties.
+     *
+     * @param properties The properties to read the server address from.
+     * @param args The arguments for the resolver.
+     * @param executorResource The shared executor resource for channels.
+     */
+    public SelfNameResolver(GrpcServerProperties properties, final Args args,
+            final SharedResourceHolder.Resource<Executor> executorResource) {
+        this.properties = requireNonNull(properties, "properties");
+        this.executorResource = requireNonNull(executorResource, "executorResource");
+        this.syncContext = requireNonNull(args.getSynchronizationContext(), "syncContext");
+    }
+
+    @Override
+    public String getServiceAuthority() {
+        try {
+            return InetAddress.getLocalHost().getHostName();
+        } catch (UnknownHostException e) {
+            return getOwnAddressString("localhost");
+        }
+    }
+
+    @Override
+    public final synchronized void start(final Listener listener) {
+        checkState(this.listener == null, "already started");
+        this.executor = SharedResourceHolder.get(this.executorResource);
+        this.listener = checkNotNull(listener, "listener");
+        resolve();
+    }
+
+    @Override
+    public final synchronized void refresh() {
+        checkState(this.listener != null, "not started");
+        resolve();
+    }
+
+    @GuardedBy("this")
+    private void resolve() {
+        log.debug("Scheduled self resolve");
+        if (this.resolving || this.executor == null) {
+            return;
+        }
+        this.resolving = true;
+        this.executor.execute(new Resolve(this.listener));
+    }
+
+    @Override
+    public synchronized void shutdown() {
+        this.listener = null;
+        if (this.executor != null) {
+            this.executor = SharedResourceHolder.release(this.executorResource, this.executor);
+        }
+    }
+
+    private SocketAddress getOwnAddress() throws SocketException {
+        final String address = this.properties.getAddress();
+        final int port = this.properties.getPort();
+        final SocketAddress target;
+        if (GrpcServerProperties.ANY_IP_ADDRESS.equals(address)) {
+            target = new InetSocketAddress(port);
+        } else {
+            target = new InetSocketAddress(InetAddresses.forString(address), port);
+        }
+        return target;
+    }
+
+    private String getOwnAddressString(String fallback) {
+        try {
+            return getOwnAddress().toString().substring(1);
+        } catch (SocketException e) {
+            return fallback;
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "SelfNameResolver [" + getOwnAddressString("<unavailable>") + "]";
+    }
+
+    /**
+     * The logic for assigning the own address.
+     */
+    private final class Resolve implements Runnable {
+
+        private final Listener savedListener;
+
+        /**
+         * Creates a new Resolve that stores a snapshot of the relevant states of the resolver.
+         *
+         * @param listener The listener to send the results to.
+         */
+        Resolve(final Listener listener) {
+            this.savedListener = requireNonNull(listener, "listener");
+        }
+
+        @Override
+        public void run() {
+            try {
+                this.savedListener.onAddresses(ImmutableList.of(
+                        new EquivalentAddressGroup(getOwnAddress())), Attributes.EMPTY);
+            } catch (final Exception e) {
+                this.savedListener.onError(Status.UNAVAILABLE
+                        .withDescription("Failed to resolve own address").withCause(e));
+            } finally {
+                SelfNameResolver.this.syncContext.execute(() -> SelfNameResolver.this.resolving = false);
+            }
+        }
+
+    }
+
+}

--- a/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/nameresolver/SelfNameResolverFactory.java
+++ b/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/nameresolver/SelfNameResolverFactory.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2016-2019 Michael Zhang <yidongnan@gmail.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package net.devh.boot.grpc.server.nameresolver;
+
+import java.net.URI;
+
+import io.grpc.NameResolver;
+import io.grpc.NameResolver.Args;
+import io.grpc.NameResolverProvider;
+import net.devh.boot.grpc.server.config.GrpcServerProperties;
+
+/**
+ * A name resolver factory that will create a {@link SelfNameResolverFactory} based on the target uri.
+ *
+ * @author Daniel Theuke (daniel.theuke@heuboe.de)
+ */
+// Do not add this to the NameResolverProvider service loader list
+public class SelfNameResolverFactory extends NameResolverProvider {
+
+    /**
+     * The constant containing the scheme that will be used by this factory.
+     */
+    public static final String SELF_SCHEME = "self";
+
+    private final GrpcServerProperties properties;
+
+    /**
+     * Creates a new SelfNameResolverFactory that uses the given properties.
+     *
+     * @param properties The properties used to resolve this server's address.
+     */
+    public SelfNameResolverFactory(GrpcServerProperties properties) {
+        this.properties = properties;
+    }
+
+    @Override
+    public NameResolver newNameResolver(URI targetUri, Args args) {
+        if (SELF_SCHEME.equals(targetUri.getScheme()) || targetUri.toString().equals(SELF_SCHEME)) {
+            return new SelfNameResolver(this.properties, args);
+        }
+        return null;
+    }
+
+    @Override
+    public String getDefaultScheme() {
+        return SELF_SCHEME;
+    }
+
+    @Override
+    protected boolean isAvailable() {
+        return true;
+    }
+
+    @Override
+    protected int priority() {
+        return 0; // Lowest priority
+    }
+
+}

--- a/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/nameresolver/package-info.java
+++ b/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/nameresolver/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Classes used to resolve the client name into the actual service addresses.
+ */
+
+package net.devh.boot.grpc.server.nameresolver;

--- a/tests/src/test/java/net/devh/boot/grpc/test/setup/SelfNameResolverConnectionTest.java
+++ b/tests/src/test/java/net/devh/boot/grpc/test/setup/SelfNameResolverConnectionTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2016-2019 Michael Zhang <yidongnan@gmail.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package net.devh.boot.grpc.test.setup;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+import com.google.protobuf.Empty;
+
+import net.devh.boot.grpc.client.inject.GrpcClient;
+import net.devh.boot.grpc.server.nameresolver.SelfNameResolverFactory;
+import net.devh.boot.grpc.test.config.BaseAutoConfiguration;
+import net.devh.boot.grpc.test.config.ServiceConfiguration;
+import net.devh.boot.grpc.test.proto.TestServiceGrpc.TestServiceBlockingStub;
+
+/**
+ * Tests that the {@link SelfNameResolverFactory} works as expected.
+ *
+ * @author Daniel Theuke (daniel.theuke@heuboe.de)
+ */
+@SpringBootTest(properties = {
+        "grpc.server.port=0",
+        "grpc.client.GLOBAL.negotiationType=PLAINTEXT",
+        "grpc.client.other.address=self",
+})
+@SpringJUnitConfig(classes = {ServiceConfiguration.class, BaseAutoConfiguration.class})
+@DirtiesContext
+public class SelfNameResolverConnectionTest {
+
+    private static final Empty EMPTY = Empty.getDefaultInstance();
+
+    @GrpcClient("self")
+    private TestServiceBlockingStub selfStub;
+
+    @GrpcClient("other")
+    private TestServiceBlockingStub otherStub;
+
+    /**
+     * Tests the connection via the implicit client address.
+     */
+    @Test
+    public void testSelfConnection() {
+        assertEquals("1.2.3", this.selfStub.normal(EMPTY).getVersion());
+    }
+
+    /**
+     * Tests the connection via the explicit client address.
+     */
+    @Test
+    public void testOtherConnection() {
+        assertEquals("1.2.3", this.otherStub.normal(EMPTY).getVersion());
+    }
+
+}


### PR DESCRIPTION
Fixes #174 

This PR adds the ability to the client to connect to `grpc-server-spring-boot-starter` powered servers by using the `self` name or scheme.

For tests this would look similar to this example:

````java
@SpringBootTest(properties = {
        "grpc.server.port=0", // e.g. random port
        "grpc.client.GLOBAL.negotiationType=PLAINTEXT",
})
@SpringJUnitConfig(classes = ...)
@DirtiesContext
public class MyServiceTest {

    @GrpcClient("self")
    private TestServiceBlockingStub selfStub;
````