### PR TITLE
Expose channel connectivity to actuator

### DIFF
--- a/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/autoconfigure/GrpcClientHealthAutoConfiguration.java
+++ b/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/autoconfigure/GrpcClientHealthAutoConfiguration.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2016-2019 Michael Zhang <yidongnan@gmail.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package net.devh.boot.grpc.client.autoconfigure;
+
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.HealthIndicator;
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Lazy;
+
+import com.google.common.collect.ImmutableMap;
+
+import io.grpc.ConnectivityState;
+import net.devh.boot.grpc.client.channelfactory.GrpcChannelFactory;
+
+/**
+ * Auto configuration class for Spring-Boot. This allows zero config client health status updates for gRPC services.
+ *
+ * @author Daniel Theuke (daniel.theuke@heuboe.de)
+ */
+@Configuration
+@AutoConfigureAfter(GrpcClientAutoConfiguration.class)
+@ConditionalOnClass(name = "org.springframework.boot.actuate.health.HealthIndicator")
+public class GrpcClientHealthAutoConfiguration {
+
+    /**
+     * Creates a HealthIndicator based on the channels' {@link ConnectivityState}s from the underlying
+     * {@link GrpcChannelFactory}.
+     *
+     * @param factory The factory to derive the connectivity states from.
+     * @return A health indicator bean, that uses the following assumption
+     *         <code>DOWN == states.contains(TRANSIENT_FAILURE)</code>.
+     */
+    @Bean
+    @Lazy
+    public HealthIndicator grpcChannelHealthIndicator(final GrpcChannelFactory factory) {
+        return () -> {
+            final ImmutableMap<String, ConnectivityState> states = ImmutableMap.copyOf(factory.getConnectivityState());
+            final Health.Builder health;
+            if (states.containsValue(ConnectivityState.TRANSIENT_FAILURE)) {
+                health = Health.down();
+            } else {
+                health = Health.up();
+            }
+            return health.withDetails(states)
+                    .build();
+        };
+    }
+
+}

--- a/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/autoconfigure/GrpcClientMetricAutoConfiguration.java
+++ b/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/autoconfigure/GrpcClientMetricAutoConfiguration.java
@@ -18,22 +18,15 @@
 package net.devh.boot.grpc.client.autoconfigure;
 
 import org.springframework.boot.actuate.autoconfigure.metrics.CompositeMeterRegistryAutoConfiguration;
-import org.springframework.boot.actuate.health.Health;
-import org.springframework.boot.actuate.health.HealthIndicator;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Lazy;
-
-import com.google.common.collect.ImmutableMap;
 
 import io.grpc.ClientInterceptor;
-import io.grpc.ConnectivityState;
 import io.micrometer.core.instrument.MeterRegistry;
-import net.devh.boot.grpc.client.channelfactory.GrpcChannelFactory;
 import net.devh.boot.grpc.client.metric.MetricCollectingClientInterceptor;
 
 /**
@@ -57,30 +50,6 @@ public class GrpcClientMetricAutoConfiguration {
     @ConditionalOnMissingBean
     public MetricCollectingClientInterceptor metricCollectingClientInterceptor(final MeterRegistry registry) {
         return new MetricCollectingClientInterceptor(registry);
-    }
-
-    /**
-     * Creates a HealthIndicator based on the channels' {@link ConnectivityState}s from the underlying
-     * {@link GrpcChannelFactory}.
-     *
-     * @param factory The factory to derive the connectivity states from.
-     * @return A health indicator bean, that uses the following assumption
-     *         <code>DOWN == states.contains(TRANSIENT_FAILURE)</code>.
-     */
-    @Bean
-    @Lazy
-    public HealthIndicator grpcChannelHealthIndicator(final GrpcChannelFactory factory) {
-        return () -> {
-            final ImmutableMap<String, ConnectivityState> states = ImmutableMap.copyOf(factory.getConnectivityState());
-            final Health.Builder health;
-            if (states.containsValue(ConnectivityState.TRANSIENT_FAILURE)) {
-                health = Health.down();
-            } else {
-                health = Health.up();
-            }
-            return health.withDetails(states)
-                    .build();
-        };
     }
 
 }

--- a/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/channelfactory/GrpcChannelFactory.java
+++ b/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/channelfactory/GrpcChannelFactory.java
@@ -19,10 +19,12 @@ package net.devh.boot.grpc.client.channelfactory;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 import io.grpc.Channel;
 import io.grpc.ClientInterceptor;
 import io.grpc.ClientInterceptors;
+import io.grpc.ConnectivityState;
 import io.grpc.ManagedChannel;
 
 /**
@@ -66,7 +68,7 @@ public interface GrpcChannelFactory extends AutoCloseable {
      * @param interceptors A list of additional client interceptors that should be added to the channel.
      * @return The newly created channel for the given service.
      */
-    default Channel createChannel(String name, List<ClientInterceptor> interceptors) {
+    default Channel createChannel(final String name, final List<ClientInterceptor> interceptors) {
         return createChannel(name, interceptors, false);
     }
 
@@ -89,6 +91,16 @@ public interface GrpcChannelFactory extends AutoCloseable {
      * @return The newly created channel for the given service.
      */
     Channel createChannel(String name, List<ClientInterceptor> interceptors, boolean sortInterceptors);
+
+    /**
+     * Gets an unmodifiable map that contains the names of the created channel with their current
+     * {@link ConnectivityState}. This method will return an empty map, if the feature is not supported.
+     *
+     * @return A map with the channel names and their connectivity state.
+     */
+    default Map<String, ConnectivityState> getConnectivityState() {
+        return Collections.emptyMap();
+    }
 
     @Override
     void close();

--- a/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/channelfactory/InProcessOrAlternativeChannelFactory.java
+++ b/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/channelfactory/InProcessOrAlternativeChannelFactory.java
@@ -21,9 +21,13 @@ import static java.util.Objects.requireNonNull;
 
 import java.net.URI;
 import java.util.List;
+import java.util.Map;
+
+import com.google.common.collect.ImmutableMap;
 
 import io.grpc.Channel;
 import io.grpc.ClientInterceptor;
+import io.grpc.ConnectivityState;
 import net.devh.boot.grpc.client.config.GrpcChannelsProperties;
 
 /**
@@ -77,6 +81,14 @@ public class InProcessOrAlternativeChannelFactory implements GrpcChannelFactory 
                     sortInterceptors);
         }
         return this.alternativeChannelFactory.createChannel(name, interceptors, sortInterceptors);
+    }
+
+    @Override
+    public Map<String, ConnectivityState> getConnectivityState() {
+        return ImmutableMap.<String, ConnectivityState>builder()
+                .putAll(inProcessChannelFactory.getConnectivityState())
+                .putAll(alternativeChannelFactory.getConnectivityState())
+                .build();
     }
 
     @Override

--- a/grpc-client-spring-boot-autoconfigure/src/main/resources/META-INF/spring.factories
+++ b/grpc-client-spring-boot-autoconfigure/src/main/resources/META-INF/spring.factories
@@ -2,6 +2,7 @@
 org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
 net.devh.boot.grpc.client.autoconfigure.GrpcClientAutoConfiguration,\
 net.devh.boot.grpc.client.autoconfigure.GrpcClientMetricAutoConfiguration,\
+net.devh.boot.grpc.client.autoconfigure.GrpcClientHealthAutoConfiguration,\
 net.devh.boot.grpc.client.autoconfigure.GrpcClientSecurityAutoConfiguration,\
 net.devh.boot.grpc.client.autoconfigure.GrpcClientTraceAutoConfiguration,\
 net.devh.boot.grpc.client.autoconfigure.GrpcDiscoveryClientAutoConfiguration


### PR DESCRIPTION
Fixes #110

Add a client side health indicator based on the `ManagedChannel`'s `ConnectivityState`.

You can access the new health indicator via: `/actuator/health/grpcChannel`

The output looks similar to these screenshots from the global health endpoint:

> Service UP
>
> ![up](https://user-images.githubusercontent.com/1579362/64984957-22c47200-d8c4-11e9-80c7-fa2886bdd55e.png)

> Service reconnecting (but UP)
>![connecting](https://user-images.githubusercontent.com/1579362/64984965-2526cc00-d8c4-11e9-844b-27bd9e3d22ed.png)

> Service down
>
> ![down](https://user-images.githubusercontent.com/1579362/64984973-27892600-d8c4-11e9-8f38-74c0131c9fac.png)







