### PR TITLE
Fixes spring-boot-starter-test dependency def

### DIFF
--- a/docs/en/server/testing.md
+++ b/docs/en/server/testing.md
@@ -89,8 +89,8 @@ For Maven add the following dependencies:
 </dependency>
 <!-- Spring-Test-Support (Optional) -->
 <dependency>
-    <groupId>io.grpc</groupId>
-    <artifactId>grpc-testing</artifactId>
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter-test</artifactId>
     <scope>test</scope>
 </dependency>
 ````


### PR DESCRIPTION
There's an incorrect value for a spring-boot-starter-test in the maven example file. This PR fixes this.