### PR TITLE
Update protobuf

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ buildscript {
         projectVersion = '2.6.0-SNAPSHOT'
 
         grpcVersion = '1.24.1'
-        protobufVersion = '3.9.2'
+        protobufVersion = '3.10.0'
         protobufGradlePluginVersion = '0.8.10'
 
         springBootVersion = '2.2.0.RELEASE'


### PR DESCRIPTION
[The issue](https://github.com/protocolbuffers/protobuf/issues/6794) with [protobuf v3.10.0](https://github.com/protocolbuffers/protobuf/releases/tag/v3.10.0) seems to be a false positive. So it should be fine to update to it.