### PR TITLE
Fix #311. DiscoveryClientNameResolver leak and performance issue.

### DIFF
--- a/grpc-client-spring-boot-autoconfigure/build.gradle
+++ b/grpc-client-spring-boot-autoconfigure/build.gradle
@@ -25,7 +25,8 @@ dependencies {
     testImplementation(
         "io.grpc:grpc-testing",
         "org.springframework.boot:spring-boot-starter-test",
-        "org.junit.jupiter:junit-jupiter-api"
+        "org.junit.jupiter:junit-jupiter-api",
+        "org.springframework.cloud:spring-cloud-commons"
     )
     testRuntimeOnly(
         "org.junit.jupiter:junit-jupiter-engine"

--- a/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/nameresolver/DiscoveryClientNameResolver.java
+++ b/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/nameresolver/DiscoveryClientNameResolver.java
@@ -20,12 +20,9 @@ package net.devh.boot.grpc.client.nameresolver;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 
-import javax.annotation.concurrent.GuardedBy;
-
 import org.springframework.cloud.client.discovery.DiscoveryClient;
 
 import io.grpc.NameResolver;
-import lombok.extern.slf4j.Slf4j;
 
 /**
  * The DiscoveryClientNameResolver resolves the service hosts and their associated gRPC port using the channel's name
@@ -34,16 +31,13 @@ import lombok.extern.slf4j.Slf4j;
  * @author Michael (yidongnan@gmail.com)
  * @author Daniel Theuke (daniel.theuke@heuboe.de)
  */
-@Slf4j
-public class DiscoveryClientNameResolver extends NameResolver {
+final class DiscoveryClientNameResolver extends NameResolver {
+
     private final String name;
+    private final DiscoveryClientResolverFactory factory;
 
-    private DiscoveryClientResolverFactory factory;
-
-    @GuardedBy("this")
-    private Listener listener;
-    @GuardedBy("this")
-    private boolean shutdown;
+    // Following fields must be accessed from syncContext
+    private Listener2 listener;
 
     public DiscoveryClientNameResolver(final String name,
             final DiscoveryClientResolverFactory factory) {
@@ -52,38 +46,28 @@ public class DiscoveryClientNameResolver extends NameResolver {
     }
 
     @Override
-    public final String getServiceAuthority() {
+    public String getServiceAuthority() {
         return this.name;
     }
 
     @Override
-    public final synchronized void start(final Listener listener) {
+    public void start(final Listener2 listener) {
         checkState(this.listener == null, "already started");
         this.listener = checkNotNull(listener, "listener");
-        factory.registerListener(name, listener);
+        this.factory.registerListener(this.name, listener);
     }
 
     @Override
-    public final synchronized void refresh() {
-        // Heartbeats might happen before the resolver is even started
-        // We just ignore that case silently
-        // checkState(listener != null, "not started");
-        if (this.listener != null && !shutdown) {
-            factory.refresh(name);
-        }
+    public void refresh() {
+        checkState(this.listener != null, "not started");
+        this.factory.refresh(this.name, false);
     }
 
     @Override
     public void shutdown() {
-        if (this.shutdown) {
-            return;
-        }
-        this.shutdown = true;
-
         if (this.listener != null) {
-            factory.unregisterListener(name, listener);
+            this.factory.unregisterListener(this.name, this.listener);
         }
-
         this.listener = null;
     }
 

--- a/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/nameresolver/DiscoveryClientResolverFactory.java
+++ b/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/nameresolver/DiscoveryClientResolverFactory.java
@@ -19,21 +19,35 @@ package net.devh.boot.grpc.client.nameresolver;
 
 import static java.util.Objects.requireNonNull;
 
+import java.net.InetSocketAddress;
 import java.net.URI;
-import java.util.ArrayList;
-import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.*;
 
 import javax.annotation.Nullable;
 import javax.annotation.PreDestroy;
 
+import org.springframework.cloud.client.ServiceInstance;
 import org.springframework.cloud.client.discovery.DiscoveryClient;
 import org.springframework.cloud.client.discovery.event.HeartbeatEvent;
 import org.springframework.cloud.client.discovery.event.HeartbeatMonitor;
 import org.springframework.context.event.EventListener;
+import org.springframework.util.CollectionUtils;
 
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
+
+import io.grpc.Attributes;
+import io.grpc.EquivalentAddressGroup;
 import io.grpc.NameResolver;
+import io.grpc.NameResolver.Listener;
 import io.grpc.NameResolverProvider;
-import io.grpc.internal.GrpcUtil;
+import io.grpc.Status;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * A name resolver factory that will create a {@link DiscoveryClientNameResolver} based on the target uri.
@@ -42,17 +56,22 @@ import io.grpc.internal.GrpcUtil;
  * @since 5/17/16
  */
 // Do not add this to the NameResolverProvider service loader list
+@Slf4j
 public class DiscoveryClientResolverFactory extends NameResolverProvider {
+    private static final List<ServiceInstance> KEEP_PREVIOUS = null;
 
     /**
      * The constant containing the scheme that will be used by this factory.
      */
     public static final String DISCOVERY_SCHEME = "discovery";
 
-    private final Collection<DiscoveryClientNameResolver> discoveryClientNameResolvers = new ArrayList<>();
     private final HeartbeatMonitor monitor = new HeartbeatMonitor();
 
     private final DiscoveryClient client;
+    private final ExecutorService executor = Executors.newCachedThreadPool();
+    private final Map<String, Set<Listener>> listenerMap = new HashMap<>();
+    private final Map<String, List<ServiceInstance>> serviceInstanceMap = new HashMap<>();
+    private final Map<String, Future<List<ServiceInstance>>> discoverClientTasks = new HashMap<>();
 
     /**
      * Creates a new discovery client based name resolver factory.
@@ -73,11 +92,7 @@ public class DiscoveryClientResolverFactory extends NameResolverProvider {
                         + "expected: '" + DISCOVERY_SCHEME + ":[//]/<service-name>'; "
                         + "but was '" + targetUri.toString() + "'");
             }
-            final DiscoveryClientNameResolver discoveryClientNameResolver =
-                    new DiscoveryClientNameResolver(serviceName.substring(1), this.client, args,
-                            GrpcUtil.SHARED_CHANNEL_EXECUTOR);
-            this.discoveryClientNameResolvers.add(discoveryClientNameResolver);
-            return discoveryClientNameResolver;
+            return new DiscoveryClientNameResolver(serviceName.substring(1), this);
         }
         return null;
     }
@@ -97,6 +112,239 @@ public class DiscoveryClientResolverFactory extends NameResolverProvider {
         return 6; // More important than DNS
     }
 
+    public final synchronized void registerListener(String name, Listener listener) {
+        Preconditions.checkState(listener != null, "invalid listener");
+
+        listenerMap.computeIfAbsent(name, n -> Sets.newHashSet()).add(listener);
+
+        List<ServiceInstance> instances = serviceInstanceMap.get(name);
+
+        // notify listener with cached instance first for latency, in most case it improves a lot.
+        if (instances != null) {
+            List<EquivalentAddressGroup> targets = convert(name, instances);
+
+            // no instance has GRPC port, clean cached instances to force notifying all listeners.
+            if (targets.isEmpty()) {
+                serviceInstanceMap.remove(name);
+            } else {
+                listener.onAddresses(targets, Attributes.EMPTY);
+            }
+        }
+
+        refresh(name);
+    }
+
+    public final synchronized void unregisterListener(String name, Listener listener) {
+        Set<Listener> listeners = listenerMap.get(name);
+
+        if (listeners != null) {
+            listeners.remove(listener);
+        }
+    }
+
+    private synchronized void refresh() {
+        for (String name : listenerMap.keySet()) {
+            refresh(name);
+        }
+    }
+
+    private boolean resolving(Future<List<ServiceInstance>> future) {
+        return future != null && !future.isDone();
+    }
+
+    private List<ServiceInstance> getResolveResult(Future<List<ServiceInstance>> future) {
+        try {
+            if (future != null && future.isDone()) {
+                return future.get();
+            }
+        } catch (ExecutionException | InterruptedException ignored) {
+        }
+
+        return KEEP_PREVIOUS;
+    }
+
+    private boolean forceRefresh(String name) {
+        return serviceInstanceMap.get(name) == null;
+    }
+
+    public final synchronized void refresh(String name) {
+        Future<List<ServiceInstance>> future = discoverClientTasks.get(name);
+
+        // no resolver is running with this service name.
+        if (CollectionUtils.isEmpty(listenerMap.get(name))) {
+            return;
+        }
+
+        // exit when resolving but not a force refresh
+        if (resolving(future) && !forceRefresh(name)) {
+            return;
+        }
+
+        // update cached instances when not a force refresh.
+        if (!forceRefresh(name)) {
+            List<ServiceInstance> instances = getResolveResult(future);
+
+            if (instances != KEEP_PREVIOUS) {
+                serviceInstanceMap.put(name, instances);
+            }
+        }
+
+        discoverClientTasks.put(name,
+                executor.submit(new Resolve(name, Sets.newHashSet(listenerMap.get(name)),
+                        Lists.newArrayList(
+                                serviceInstanceMap.computeIfAbsent(name, n -> Lists.newArrayList())))));
+    }
+
+    private final class Resolve implements Callable<List<ServiceInstance>> {
+
+        private final String name;
+        private final Set<Listener> savedListenerList;
+        private final List<ServiceInstance> savedInstanceList;
+
+        /**
+         * Creates a new Resolve that stores a snapshot of the relevant states of the resolver.
+         *
+         * @param listenerList The listener to send the results to.
+         * @param instanceList The current server instance list.
+         */
+        Resolve(final String name, final Set<Listener> listenerList, final List<ServiceInstance> instanceList) {
+            this.name = requireNonNull(name, "name");
+            this.savedListenerList = requireNonNull(listenerList, "listenerList");
+            this.savedInstanceList = requireNonNull(instanceList, "instanceList");
+        }
+
+        @Override
+        public List<ServiceInstance> call() {
+            try {
+                return resolveInternal();
+            } catch (final Exception e) {
+                notifyStatus(Status.UNAVAILABLE.withCause(e)
+                        .withDescription("Failed to update server list for " + name));
+            }
+
+            return KEEP_PREVIOUS;
+        }
+
+        private void notifyAddresses(List<EquivalentAddressGroup> targets, Attributes attributes) {
+            for (Listener listener : savedListenerList) {
+                try {
+                    listener.onAddresses(targets, attributes);
+                } catch (Exception ignored) {
+                }
+            }
+        }
+
+        private void notifyStatus(Status status) {
+            for (Listener listener : savedListenerList) {
+                try {
+                    listener.onError(status);
+                } catch (Exception ignored) {
+                }
+            }
+        }
+
+        /**
+         * Do the actual update checks and resolving logic.
+         *
+         * @return The new service instance list that is used to connect to the gRPC server or null if the old ones
+         *         should be used.
+         */
+        private List<ServiceInstance> resolveInternal() {
+            final List<ServiceInstance> newInstanceList =
+                    DiscoveryClientResolverFactory.this.client.getInstances(name);
+            log.debug("Got {} candidate servers for {}", newInstanceList.size(), name);
+            if (CollectionUtils.isEmpty(newInstanceList)) {
+                log.error("No servers found for {}", name);
+                notifyStatus(Status.UNAVAILABLE.withDescription("No servers found for " + name));
+                return Lists.newArrayList();
+            }
+            if (!needsToUpdateConnections(newInstanceList)) {
+                log.debug("Nothing has changed... skipping update for {}", name);
+                return KEEP_PREVIOUS;
+            }
+            log.debug("Ready to update server list for {}", name);
+            final List<EquivalentAddressGroup> targets = convert(name, newInstanceList);
+            if (targets.isEmpty()) {
+                log.error("None of the servers for {} specified a gRPC port", name);
+                notifyStatus(Status.UNAVAILABLE
+                        .withDescription("None of the servers for " + name + " specified a gRPC port"));
+                return Lists.newArrayList();
+            } else {
+                notifyAddresses(targets, Attributes.EMPTY);
+                log.info("Done updating server list for {}", name);
+                return newInstanceList;
+            }
+        }
+
+        /**
+         * Checks whether this instance should update its connections.
+         *
+         * @param newInstanceList The new instances that should be compared to the stored ones.
+         * @return True, if the given instance list contains different entries than the stored ones.
+         */
+        private boolean needsToUpdateConnections(final List<ServiceInstance> newInstanceList) {
+            if (this.savedInstanceList.size() != newInstanceList.size()) {
+                return true;
+            }
+            for (final ServiceInstance instance : this.savedInstanceList) {
+                final int port = getGRPCPort(instance);
+                boolean isSame = false;
+                for (final ServiceInstance newInstance : newInstanceList) {
+                    final int newPort = getGRPCPort(newInstance);
+                    if (newInstance.getHost().equals(instance.getHost())
+                            && port == newPort) {
+                        isSame = true;
+                        break;
+                    }
+                }
+                if (!isSame) {
+                    return true;
+                }
+            }
+            return false;
+        }
+    }
+
+    /**
+     * Extracts the gRPC server port from the given service instance.
+     *
+     * @param instance The instance to extract the port from.
+     * @return The gRPC server port.
+     * @throws IllegalArgumentException If the specified port definition couldn't be parsed.
+     */
+    private int getGRPCPort(final ServiceInstance instance) {
+        final Map<String, String> metadata = instance.getMetadata();
+        if (metadata == null) {
+            return instance.getPort();
+        }
+        final String portString = metadata.get("gRPC.port");
+        if (portString == null) {
+            return instance.getPort();
+        }
+        try {
+            return Integer.parseInt(portString);
+        } catch (final NumberFormatException e) {
+            throw new IllegalArgumentException("Failed to parse gRPC port information from: " + instance, e);
+        }
+    }
+
+    private List<EquivalentAddressGroup> convert(String name, List<ServiceInstance> newInstanceList) {
+        final List<EquivalentAddressGroup> targets = Lists.newArrayList();
+
+        for (final ServiceInstance instance : newInstanceList) {
+            try {
+                final int port = getGRPCPort(instance);
+                log.debug("Found gRPC server {}:{} for {}", instance.getHost(), port, name);
+                targets.add(new EquivalentAddressGroup(
+                        new InetSocketAddress(instance.getHost(), port), Attributes.EMPTY));
+            } catch (IllegalArgumentException e) {
+                log.error(e.getMessage(), e);
+            }
+        }
+
+        return targets;
+    }
+
     /**
      * Triggers a refresh of the registered name resolvers.
      *
@@ -105,9 +353,7 @@ public class DiscoveryClientResolverFactory extends NameResolverProvider {
     @EventListener(HeartbeatEvent.class)
     public void heartbeat(final HeartbeatEvent event) {
         if (this.monitor.update(event.getValue())) {
-            for (final DiscoveryClientNameResolver discoveryClientNameResolver : this.discoveryClientNameResolvers) {
-                discoveryClientNameResolver.refresh();
-            }
+            refresh();
         }
     }
 
@@ -116,7 +362,21 @@ public class DiscoveryClientResolverFactory extends NameResolverProvider {
      */
     @PreDestroy
     public void destroy() {
-        this.discoveryClientNameResolvers.clear();
+        // interrupt
+        for (Future<?> task : discoverClientTasks.values()) {
+            task.cancel(true);
+        }
+
+        // wait for complete
+        for (Future<?> task : discoverClientTasks.values()) {
+            try {
+                task.get();
+            } catch (InterruptedException | ExecutionException ignored) {
+            }
+        }
+
+        // safe to clean all
+        listenerMap.clear();
     }
 
     @Override

--- a/grpc-client-spring-boot-autoconfigure/src/test/java/net/devh/boot/grpc/client/nameresolver/DiscoveryClientResolverFactoryTest.java
+++ b/grpc-client-spring-boot-autoconfigure/src/test/java/net/devh/boot/grpc/client/nameresolver/DiscoveryClientResolverFactoryTest.java
@@ -1,0 +1,674 @@
+/*
+ * Copyright (c) 2016-2019 Michael Zhang <yidongnan@gmail.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package net.devh.boot.grpc.client.nameresolver;
+
+import static java.util.Arrays.asList;
+import static net.devh.boot.grpc.client.nameresolver.DiscoveryClientResolverFactory.DISCOVERY_SCHEME;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.DynamicTest.dynamicTest;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.lang.Thread.UncaughtExceptionHandler;
+import java.net.SocketAddress;
+import java.net.URI;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+
+import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.TestFactory;
+import org.springframework.cloud.client.DefaultServiceInstance;
+import org.springframework.cloud.client.ServiceInstance;
+import org.springframework.cloud.client.discovery.DiscoveryClient;
+
+import io.grpc.EquivalentAddressGroup;
+import io.grpc.NameResolver;
+import io.grpc.NameResolver.Listener2;
+import io.grpc.NameResolver.ResolutionResult;
+import io.grpc.NameResolver.ServiceConfigParser;
+import io.grpc.ProxyDetector;
+import io.grpc.Status;
+import io.grpc.SynchronizationContext;
+
+/**
+ * Tests {@link DiscoveryClientResolverFactory}.
+ */
+class DiscoveryClientResolverFactoryTest {
+
+    private static final String SERVICE_NAME = "TEST";
+
+    private static final URI SERVICE_URI = URI.create(DISCOVERY_SCHEME + ":///" + SERVICE_NAME);
+
+    private static final NameResolver.Args NRA = NameResolver.Args.newBuilder()
+            .setDefaultPort(80)
+            .setProxyDetector(mock(ProxyDetector.class))
+            .setServiceConfigParser(mock(ServiceConfigParser.class))
+            .setSynchronizationContext(new SynchronizationContext(mock(UncaughtExceptionHandler.class)))
+            .build();
+
+    private static final ServiceInstance I1 = new DefaultServiceInstance("I1", SERVICE_NAME, "127.0.0.1", 80, false);
+    private static final ServiceInstance I2 = new DefaultServiceInstance("I2", SERVICE_NAME, "127.0.0.2", 80, false);
+    private static final ServiceInstance I3 = new DefaultServiceInstance("I3", SERVICE_NAME, "127.0.0.3", 80, false);
+    private static final ServiceInstance I4 = new DefaultServiceInstance("I4", SERVICE_NAME, "127.0.0.4", 80, false);
+    private static final List<ServiceInstance> I__ = asList();
+    private static final List<ServiceInstance> I12 = asList(I1, I2);
+    private static final List<ServiceInstance> I34 = asList(I3, I4);
+
+    /**
+     * Tests for the {@link DiscoveryClientNameResolver}s returned from
+     * {@link DiscoveryClientResolverFactory#newNameResolver(URI, Args)}.
+     *
+     * @return The tests.
+     */
+    @TestFactory
+    List<DynamicTest> testFactory() {
+        return asList(
+                // Simple test
+                dynamicTest("simple", () -> {
+                    // Setup
+                    final DiscoveryClient client = mock(DiscoveryClient.class);
+                    when(client.getInstances(SERVICE_NAME)).thenReturn(I12);
+                    final DiscoveryClientResolverFactory factory = new DiscoveryClientResolverFactory(client);
+
+                    // Prepare
+                    final TestListener listener = new TestListener();
+                    final int ref = listener.getUpdateCount();
+
+                    // New
+                    final NameResolver nameResolver = factory.newNameResolver(SERVICE_URI, NRA);
+
+                    // Resolve
+                    nameResolver.start(listener);
+
+                    // Verify
+                    assertTrue(listener.await(1000, ref));
+                    assertTargetsEqual(listener, I12);
+                    verify(client, times(1)).getInstances(anyString());
+
+                    // Cleanup
+                    nameResolver.shutdown();
+                    factory.destroy();
+                }),
+                // Slight delay in initialization
+                dynamicTest("simple-delayed", () -> {
+                    // Setup
+                    final DiscoveryClient client = mock(DiscoveryClient.class);
+                    final CountDownLatch latch = new CountDownLatch(1);
+                    when(client.getInstances(SERVICE_NAME)).thenAnswer(inv -> {
+                        latch.await();
+                        return I12;
+                    });
+                    final DiscoveryClientResolverFactory factory = new DiscoveryClientResolverFactory(client);
+
+                    // Prepare
+                    final TestListener listener = new TestListener();
+                    final int ref = listener.getUpdateCount();
+
+                    // New
+                    final NameResolver nameResolver = factory.newNameResolver(SERVICE_URI, NRA);
+
+                    // Resolve
+                    nameResolver.start(listener);
+
+                    assertFalse(listener.await(1000, ref));
+
+                    latch.countDown();
+
+                    // Verify
+                    assertTrue(listener.await(1000, ref));
+                    assertTargetsEqual(listener, I12);
+                    verify(client, times(1)).getInstances(anyString());
+
+                    // Cleanup
+                    nameResolver.shutdown();
+                    factory.destroy();
+                }),
+                // Slight delay in initialization
+                dynamicTest("simple-error", () -> {
+                    // Setup
+                    final DiscoveryClient client = mock(DiscoveryClient.class);
+                    when(client.getInstances(SERVICE_NAME)).thenReturn(I__);
+                    final DiscoveryClientResolverFactory factory = new DiscoveryClientResolverFactory(client);
+
+                    // Prepare
+                    final TestListener listener = new TestListener();
+                    final int ref = listener.getUpdateCount();
+
+                    // New
+                    final NameResolver nameResolver = factory.newNameResolver(SERVICE_URI, NRA);
+
+                    // Resolve
+                    nameResolver.start(listener);
+
+                    // Verify
+                    assertTrue(listener.await(1000, ref));
+                    assertError(listener);
+                    verify(client, times(1)).getInstances(anyString());
+
+                    // Cleanup
+                    nameResolver.shutdown();
+                    factory.destroy();
+                }),
+                // NameResolver starting simultaneously
+                dynamicTest("new+new", () -> {
+                    // Setup
+                    final DiscoveryClient client = mock(DiscoveryClient.class);
+                    final CountDownLatch latch = new CountDownLatch(1);
+                    when(client.getInstances(SERVICE_NAME)).thenAnswer(inv -> {
+                        latch.await();
+                        return I12;
+                    });
+                    final DiscoveryClientResolverFactory factory = new DiscoveryClientResolverFactory(client);
+
+                    // Prepare
+                    final TestListener listener = new TestListener();
+                    final int ref = listener.getUpdateCount();
+
+                    final TestListener listener2 = new TestListener();
+                    final int ref2 = listener.getUpdateCount();
+
+                    // New
+                    final NameResolver nameResolver = factory.newNameResolver(SERVICE_URI, NRA);
+                    final NameResolver nameResolver2 = factory.newNameResolver(SERVICE_URI, NRA);
+
+                    // Resolve
+                    nameResolver.start(listener);
+                    nameResolver2.start(listener2);
+                    latch.countDown();
+
+                    // Verify
+                    assertTrue(listener.await(1000, ref));
+                    assertTrue(listener2.await(0, ref2));
+                    assertTargetsEqual(listener, I12);
+                    assertTargetsEqual(listener2, I12);
+                    verify(client, times(1)).getInstances(anyString());
+
+                    // Cleanup
+                    nameResolver.shutdown();
+                    nameResolver2.shutdown();
+                    factory.destroy();
+                }),
+                // NameResolver currently resolving and then new one started
+                dynamicTest("resolving+new", () -> {
+                    // Setup
+                    final DiscoveryClient client = mock(DiscoveryClient.class);
+                    final CountDownLatch latch = new CountDownLatch(1);
+                    when(client.getInstances(SERVICE_NAME)).thenAnswer(inv -> {
+                        latch.await();
+                        return I12;
+                    });
+                    final DiscoveryClientResolverFactory factory = new DiscoveryClientResolverFactory(client);
+
+                    // Prepare + New + Resolve (1)
+                    final TestListener listener = new TestListener();
+                    final int ref = listener.getUpdateCount();
+
+                    final NameResolver nameResolver = factory.newNameResolver(SERVICE_URI, NRA);
+                    nameResolver.start(listener);
+
+                    // Prepare + New + Resolve (2)
+                    final TestListener listener2 = new TestListener();
+                    final int ref2 = listener.getUpdateCount();
+
+                    final NameResolver nameResolver2 = factory.newNameResolver(SERVICE_URI, NRA);
+                    nameResolver2.start(listener2);
+
+                    latch.countDown();
+
+                    // Verify
+                    assertTrue(listener.await(1000, ref));
+                    assertTrue(listener2.await(1000, ref2));
+                    assertTargetsEqual(listener, I12);
+                    assertTargetsEqual(listener2, I12);
+                    verify(client, times(1)).getInstances(anyString());
+
+                    // Cleanup
+                    nameResolver.shutdown();
+                    nameResolver2.shutdown();
+                    factory.destroy();
+                }),
+                // NameResolver already resolved and then new one started
+                dynamicTest("resolved+new", () -> {
+                    // Setup
+                    final DiscoveryClient client = mock(DiscoveryClient.class);
+                    when(client.getInstances(SERVICE_NAME)).thenReturn(I12);
+                    final DiscoveryClientResolverFactory factory = new DiscoveryClientResolverFactory(client);
+
+                    // Prepare + New + Resolve (1)
+                    final TestListener listener = new TestListener();
+                    final int ref = listener.getUpdateCount();
+
+                    final NameResolver nameResolver = factory.newNameResolver(SERVICE_URI, NRA);
+                    nameResolver.start(listener);
+
+                    // Wait for the first run to complete
+                    assertTrue(listener.await(1000, ref));
+
+                    // Prepare + New + Resolve (2)
+                    final TestListener listener2 = new TestListener();
+
+                    final NameResolver nameResolver2 = factory.newNameResolver(SERVICE_URI, NRA);
+                    nameResolver2.start(listener2);
+
+                    // Verify
+                    // Cannot await the update since the previous run contains the same data
+                    // Thus we need to wait a bit for the second run to finish
+                    Thread.sleep(100);
+                    assertTargetsEqual(listener, I12);
+                    assertTargetsEqual(listener2, I12);
+                    verify(client, times(2)).getInstances(anyString());
+
+                    // Cleanup
+                    nameResolver.shutdown();
+                    nameResolver2.shutdown();
+                    factory.destroy();
+                }),
+                // NameResolver already shutdown and then new one started
+                dynamicTest("shutdown+new", () -> {
+                    // Setup
+                    final DiscoveryClient client = mock(DiscoveryClient.class);
+                    when(client.getInstances(SERVICE_NAME)).thenReturn(I12);
+                    final DiscoveryClientResolverFactory factory = new DiscoveryClientResolverFactory(client);
+
+                    // Prepare + New + Resolve (1)
+                    final TestListener listener = new TestListener();
+                    final int ref = listener.getUpdateCount();
+
+                    final NameResolver nameResolver = factory.newNameResolver(SERVICE_URI, NRA);
+                    nameResolver.start(listener);
+
+                    // Wait for the first run to complete
+                    assertTrue(listener.await(1000, ref));
+                    assertTargetsEqual(listener, I12);
+                    nameResolver.shutdown();
+
+                    when(client.getInstances(SERVICE_NAME)).thenReturn(I34);
+
+                    // Prepare + New + Resolve (2)
+                    final TestListener listener2 = new TestListener();
+
+                    final NameResolver nameResolver2 = factory.newNameResolver(SERVICE_URI, NRA);
+                    nameResolver2.start(listener2);
+                    final int ref2 = listener2.getUpdateCount();
+
+                    // Verify
+                    assertTrue(listener2.await(1000, ref2));
+                    assertTargetsEqual(listener, I12);
+                    assertTargetsEqual(listener2, I34);
+                    verify(client, times(2)).getInstances(anyString());
+
+                    // Cleanup
+                    nameResolver2.shutdown();
+                    factory.destroy();
+                }),
+                // NameResolver already resolved and the new one causes an error
+                dynamicTest("resolved+error", () -> {
+                    // Setup
+                    final DiscoveryClient client = mock(DiscoveryClient.class);
+                    when(client.getInstances(SERVICE_NAME)).thenReturn(I12);
+                    final DiscoveryClientResolverFactory factory = new DiscoveryClientResolverFactory(client);
+
+                    // Prepare + New + Resolve (1)
+                    final TestListener listener = new TestListener();
+                    final int ref = listener.getUpdateCount();
+
+                    final NameResolver nameResolver = factory.newNameResolver(SERVICE_URI, NRA);
+                    nameResolver.start(listener);
+
+                    // Wait for the first run to complete
+                    assertTrue(listener.await(1000, ref));
+                    assertTargetsEqual(listener, I12);
+
+                    when(client.getInstances(SERVICE_NAME)).thenReturn(I__);
+
+                    // Prepare + New + Resolve (2)
+                    final TestListener listener2 = new TestListener();
+                    final int ref2 = listener.getUpdateCount();
+
+                    final NameResolver nameResolver2 = factory.newNameResolver(SERVICE_URI, NRA);
+                    nameResolver2.start(listener2);
+
+                    // Verify
+                    assertTrue(listener2.await(1000, ref2));
+                    assertError(listener);
+                    assertError(listener2);
+                    verify(client, times(2)).getInstances(anyString());
+
+                    // Cleanup
+                    nameResolver.shutdown();
+                    nameResolver2.shutdown();
+                    factory.destroy();
+                }),
+                // NameResolver already resolved and the resolving one causes an error
+                dynamicTest("re-resolving+error", () -> {
+                    // Setup
+                    final DiscoveryClient client = mock(DiscoveryClient.class);
+                    when(client.getInstances(SERVICE_NAME)).thenReturn(I12);
+                    final DiscoveryClientResolverFactory factory = new DiscoveryClientResolverFactory(client);
+
+                    // Prepare + New + Resolve (1)
+                    final TestListener listener = new TestListener();
+                    final int ref = listener.getUpdateCount();
+
+                    final NameResolver nameResolver = factory.newNameResolver(SERVICE_URI, NRA);
+                    nameResolver.start(listener);
+
+                    // Wait for the first run to complete
+                    assertTrue(listener.await(1000, ref));
+                    assertTargetsEqual(listener, I12);
+
+                    final CountDownLatch latch = new CountDownLatch(1);
+                    when(client.getInstances(SERVICE_NAME)).thenAnswer(inv -> {
+                        latch.await();
+                        return I__;
+                    });
+                    factory.refresh(SERVICE_NAME, false);
+
+                    // Prepare + New + Resolve (2)
+                    final TestListener listener2 = new TestListener();
+                    final int ref2 = listener.getUpdateCount();
+
+                    final NameResolver nameResolver2 = factory.newNameResolver(SERVICE_URI, NRA);
+                    nameResolver2.start(listener2);
+                    assertTargetsEqual(listener2, I12); // result from cache
+
+                    latch.countDown();
+                    // Verify
+                    assertTrue(listener2.await(1000, ref2));
+                    assertError(listener);
+                    assertError(listener2);
+                    verify(client, times(2)).getInstances(anyString());
+
+                    // Cleanup
+                    nameResolver.shutdown();
+                    nameResolver2.shutdown();
+                    factory.destroy();
+                }),
+                // NameResolver already errored and then new one is started
+                dynamicTest("error+new", () -> {
+                    // Setup
+                    final DiscoveryClient client = mock(DiscoveryClient.class);
+                    when(client.getInstances(SERVICE_NAME)).thenReturn(I__);
+                    final DiscoveryClientResolverFactory factory = new DiscoveryClientResolverFactory(client);
+
+                    // Prepare + New + Resolve (1)
+                    final TestListener listener = new TestListener();
+                    final int ref = listener.getUpdateCount();
+
+                    final NameResolver nameResolver = factory.newNameResolver(SERVICE_URI, NRA);
+                    nameResolver.start(listener);
+
+                    // Wait for the first run to complete
+                    assertTrue(listener.await(1000, ref));
+                    assertError(listener);
+
+                    final CountDownLatch latch = new CountDownLatch(1);
+                    when(client.getInstances(SERVICE_NAME)).thenAnswer(inv -> {
+                        latch.await();
+                        return I12;
+                    });
+
+                    // Prepare + New + Resolve (2)
+                    final TestListener listener2 = new TestListener();
+                    final int ref2 = listener2.getUpdateCount();
+
+                    final NameResolver nameResolver2 = factory.newNameResolver(SERVICE_URI, NRA);
+                    nameResolver2.start(listener2);
+                    assertError(listener2);
+
+                    latch.countDown();
+
+                    // Verify
+                    assertTrue(listener.await(1000, ref));
+                    assertTrue(listener2.await(1000, ref2));
+                    assertTargetsEqual(listener, I12);
+                    assertTargetsEqual(listener2, I12);
+                    verify(client, times(2)).getInstances(anyString());
+
+                    // Cleanup
+                    nameResolver.shutdown();
+                    nameResolver2.shutdown();
+                    factory.destroy();
+                }),
+                // NameResolver already errored and a refresh is started before the new one is created
+                dynamicTest("error+resolving", () -> {
+                    // Setup
+                    final DiscoveryClient client = mock(DiscoveryClient.class);
+                    when(client.getInstances(SERVICE_NAME)).thenReturn(I__);
+                    final DiscoveryClientResolverFactory factory = new DiscoveryClientResolverFactory(client);
+
+                    // Prepare + New + Resolve (1)
+                    final TestListener listener = new TestListener();
+                    final int ref = listener.getUpdateCount();
+
+                    final NameResolver nameResolver = factory.newNameResolver(SERVICE_URI, NRA);
+                    nameResolver.start(listener);
+
+                    // Wait for the first run to complete
+                    assertTrue(listener.await(1000, ref));
+                    assertError(listener);
+
+                    final CountDownLatch latch = new CountDownLatch(1);
+                    when(client.getInstances(SERVICE_NAME)).thenAnswer(inv -> {
+                        latch.await();
+                        return I12;
+                    });
+                    factory.refresh(SERVICE_NAME, false);
+
+                    // Prepare + New + Resolve (2)
+                    final TestListener listener2 = new TestListener();
+                    final int ref2 = listener2.getUpdateCount();
+
+                    final NameResolver nameResolver2 = factory.newNameResolver(SERVICE_URI, NRA);
+                    nameResolver2.start(listener2);
+                    assertError(listener2);
+
+                    latch.countDown();
+
+                    // Verify
+                    assertTrue(listener.await(1000, ref));
+                    assertTrue(listener2.await(1000, ref2));
+                    assertTargetsEqual(listener, I12);
+                    assertTargetsEqual(listener2, I12);
+                    verify(client, times(2)).getInstances(anyString());
+
+                    // Cleanup
+                    nameResolver.shutdown();
+                    nameResolver2.shutdown();
+                    factory.destroy();
+                }),
+                // NameResolver already outdated and then new one is started
+                dynamicTest("outdated+new", () -> {
+                    // Setup
+                    final DiscoveryClient client = mock(DiscoveryClient.class);
+                    when(client.getInstances(SERVICE_NAME)).thenReturn(I12);
+                    final DiscoveryClientResolverFactory factory = new DiscoveryClientResolverFactory(client);
+
+                    // Prepare + New + Resolve (1)
+                    final TestListener listener = new TestListener();
+                    int ref = listener.getUpdateCount();
+
+                    final NameResolver nameResolver = factory.newNameResolver(SERVICE_URI, NRA);
+                    nameResolver.start(listener);
+
+                    // Wait for the first run to complete
+                    assertTrue(listener.await(1000, ref));
+                    assertTargetsEqual(listener, I12);
+                    ref = listener.getUpdateCount();
+
+                    final CountDownLatch latch = new CountDownLatch(1);
+                    when(client.getInstances(SERVICE_NAME)).thenAnswer(inv -> {
+                        latch.await();
+                        return I34;
+                    });
+
+                    // Prepare + New + Resolve (2)
+                    final TestListener listener2 = new TestListener();
+                    final int ref2 = listener2.getUpdateCount();
+
+                    final NameResolver nameResolver2 = factory.newNameResolver(SERVICE_URI, NRA);
+                    nameResolver2.start(listener2);
+                    assertTargetsEqual(listener2, I12); // resolve from cache
+
+                    latch.countDown();
+
+                    // Verify
+                    assertTrue(listener.await(1000, ref));
+                    assertTrue(listener2.await(1000, ref2));
+                    assertTargetsEqual(listener, I34);
+                    assertTargetsEqual(listener2, I34);
+                    verify(client, times(2)).getInstances(anyString());
+
+                    // Cleanup
+                    nameResolver.shutdown();
+                    nameResolver2.shutdown();
+                    factory.destroy();
+                }),
+                // NameResolver already outdated and a refresh is started before the new one is created
+                dynamicTest("outdated+resolving", () -> {
+                    // Setup
+                    final DiscoveryClient client = mock(DiscoveryClient.class);
+                    when(client.getInstances(SERVICE_NAME)).thenReturn(I12);
+                    final DiscoveryClientResolverFactory factory = new DiscoveryClientResolverFactory(client);
+
+                    // Prepare + New + Resolve (1)
+                    final TestListener listener = new TestListener();
+                    int ref = listener.getUpdateCount();
+
+                    final NameResolver nameResolver = factory.newNameResolver(SERVICE_URI, NRA);
+                    nameResolver.start(listener);
+
+                    // Wait for the first run to complete
+                    assertTrue(listener.await(1000, ref));
+                    assertTargetsEqual(listener, I12);
+                    ref = listener.getUpdateCount();
+
+                    final CountDownLatch latch = new CountDownLatch(1);
+                    when(client.getInstances(SERVICE_NAME)).thenAnswer(inv -> {
+                        latch.await();
+                        return I34;
+                    });
+                    factory.refresh(SERVICE_NAME, false);
+
+                    // Prepare + New + Resolve (2)
+                    final TestListener listener2 = new TestListener();
+                    final int ref2 = listener2.getUpdateCount();
+
+                    final NameResolver nameResolver2 = factory.newNameResolver(SERVICE_URI, NRA);
+                    nameResolver2.start(listener2);
+                    assertTargetsEqual(listener2, I12); // resolve from cache
+
+                    latch.countDown();
+
+                    // Verify
+                    assertTrue(listener.await(1000, ref));
+                    assertTrue(listener2.await(1000, ref2));
+                    assertTargetsEqual(listener, I34);
+                    assertTargetsEqual(listener2, I34);
+                    verify(client, times(2)).getInstances(anyString());
+
+                    // Cleanup
+                    nameResolver.shutdown();
+                    nameResolver2.shutdown();
+                    factory.destroy();
+                }));
+    }
+
+    void assertTargetsEqual(final TestListener listener, final List<ServiceInstance> sis) {
+        final ResolutionResult result = listener.getResult();
+        assertNotNull(result, "listener not successful");
+        assertTargetsEqual(result.getAddresses(), sis);
+    }
+
+    void assertTargetsEqual(final List<EquivalentAddressGroup> eags, final List<ServiceInstance> sis) {
+        assertTrue(eags.size() == sis.size());
+        for (int i = 0; i < eags.size(); i++) {
+            final EquivalentAddressGroup eag = eags.get(i);
+            final ServiceInstance si = sis.get(i);
+            assertTargetEquals(eag, si);
+        }
+    }
+
+    void assertTargetEquals(final EquivalentAddressGroup eag, final ServiceInstance si) {
+        final List<SocketAddress> addresses = eag.getAddresses();
+        assertTrue(addresses.size() == 1);
+        final SocketAddress socketAddress = addresses.get(0);
+        assertTrue(socketAddress.toString().equals('/' + si.getHost() + ':' + si.getPort()));
+    }
+
+    void assertError(final TestListener listener) {
+        assertEquals(listener.getError().getCode(), Status.Code.UNAVAILABLE);
+    }
+
+    private static class TestListener extends Listener2 {
+
+        private ResolutionResult result = null;
+        private Status error = Status.UNAVAILABLE.withDescription("Not initialized");
+        private int updateCount;
+
+        @Override
+        public synchronized void onResult(final ResolutionResult resolutionResult) {
+            if (resolutionResult.getAddresses().isEmpty()) {
+                onError(Status.UNAVAILABLE.withDescription("Empty addresses"));
+            } else {
+                this.result = resolutionResult;
+                this.error = null;
+                this.updateCount++;
+                notifyAll();
+            }
+        }
+
+        @Override
+        public synchronized void onError(final Status error) {
+            this.result = null;
+            this.error = error;
+            this.updateCount++;
+            notifyAll();
+        }
+
+        public synchronized boolean await(final long duration, final int ref) throws InterruptedException {
+            long now = System.currentTimeMillis();
+            final long limit = now + duration;
+            while (limit > now && ref == this.updateCount) {
+                wait(limit - now);
+                now = System.currentTimeMillis();
+            }
+            return ref != this.updateCount;
+        }
+
+        public ResolutionResult getResult() {
+            return this.result;
+        }
+
+        public Status getError() {
+            return this.error;
+        }
+
+        public int getUpdateCount() {
+            return this.updateCount;
+        }
+
+    }
+
+}

--- a/grpc-client-spring-boot-autoconfigure/src/test/resources/logback-test.xml
+++ b/grpc-client-spring-boot-autoconfigure/src/test/resources/logback-test.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE xml>
+<configuration packagingData="true">
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%highlight(%d{HH:mm:ss.SSS} [%10thread] %-5level %logger{36} - %msg%n)</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="net.devh.boot.grpc.client" level="debug" />
+    <logger name="net.devh.boot.grpc.common" level="debug" />
+    <root level="info">
+        <appender-ref ref="STDOUT" />
+    </root>
+
+</configuration>


### PR DESCRIPTION
1) Move the work of updating service instance list to `DiscoveryClientResolverFactory` to reduce the workload of Eureka.
2) set listener of `DiscoveryClientNameResolver` to null to avoid leak of `Channel`.
3) Add method of register/unregister listener to `DiscoveryClientResolverFactory`


@ST-DDT 

Fixes #311 