### PR TITLE
Detach the server factory bean lifecycle from the server lifecycle bean

### DIFF
--- a/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/serverfactory/GrpcServerFactory.java
+++ b/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/serverfactory/GrpcServerFactory.java
@@ -17,6 +17,8 @@
 
 package net.devh.boot.grpc.server.serverfactory;
 
+import org.springframework.beans.factory.DisposableBean;
+
 import io.grpc.Server;
 import net.devh.boot.grpc.server.service.GrpcServiceDefinition;
 
@@ -26,7 +28,7 @@ import net.devh.boot.grpc.server.service.GrpcServiceDefinition;
  * @author Michael (yidongnan@gmail.com)
  * @since 5/17/16
  */
-public interface GrpcServerFactory {
+public interface GrpcServerFactory extends DisposableBean {
 
     /**
      * Creates a new grpc server with the stored options. The entire lifecycle management of the server should be
@@ -65,6 +67,7 @@ public interface GrpcServerFactory {
     /**
      * Destroys this factory. This does not destroy or shutdown any server that was created using this factory.
      */
+    @Override
     void destroy();
 
 }

--- a/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/serverfactory/GrpcServerLifecycle.java
+++ b/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/serverfactory/GrpcServerLifecycle.java
@@ -59,7 +59,7 @@ public class GrpcServerLifecycle implements SmartLifecycle {
 
     @Override
     public void stop(final Runnable callback) {
-        this.stop();
+        stop();
         callback.run();
     }
 
@@ -109,7 +109,6 @@ public class GrpcServerLifecycle implements SmartLifecycle {
      * wait for the server to be completely shut down.
      */
     protected void stopAndReleaseGrpcServer() {
-        this.factory.destroy();
         final Server localServer = this.server;
         if (localServer != null) {
             localServer.shutdown();


### PR DESCRIPTION
This allows the factory to be reused.