### PR TITLE
fix testing server code in docs

### DIFF
--- a/docs/en/server/testing.md
+++ b/docs/en/server/testing.md
@@ -149,17 +149,17 @@ public class MyServiceTest {
     }
 
     @Test
-    void testSayHellpo() {
+    void testSayHellpo() throws Exception {
         HelloRequest request = HelloRequest.newBuilder()
                 .setName("Test")
                 .build();
         StreamRecorder<HelloReply> responseObserver = StreamRecorder.create();
         myService.sayHello(request, responseObserver);
-        if (!responseObserver.awaitCompletion(5, TimeUnit.SECONDS);
+        if (!responseObserver.awaitCompletion(5, TimeUnit.SECONDS)) {
             fail("The call did not terminate in time");
         }
         assertNull(responseObserver.getError());
-        List<HelloReply> results = responseObserver.getValues().size();
+        List<HelloReply> results = responseObserver.getValues();
         assertEquals(1, results.size());
         HelloReply response = results.get(0);
         assertEquals(HelloReply.newBuilder()
@@ -190,17 +190,17 @@ public class MyServiceTest {
     private MyServiceImpl myService;
 
     @Test
-    void testSayHellpo() {
+    void testSayHellpo() throws Exception {
         HelloRequest request = HelloRequest.newBuilder()
                 .setName("Test")
                 .build();
         StreamRecorder<HelloReply> responseObserver = StreamRecorder.create();
         myService.sayHello(request, responseObserver);
-        if (!responseObserver.awaitCompletion(5, TimeUnit.SECONDS);
+        if (!responseObserver.awaitCompletion(5, TimeUnit.SECONDS)) {
             fail("The call did not terminate in time");
         }
         assertNull(responseObserver.getError());
-        List<HelloReply> results = responseObserver.getValues().size();
+        List<HelloReply> results = responseObserver.getValues();
         assertEquals(1, results.size());
         HelloReply response = results.get(0);
         assertEquals(HelloReply.newBuilder()

--- a/docs/zh-CN/server/testing.md
+++ b/docs/zh-CN/server/testing.md
@@ -130,17 +130,17 @@ public class MyServiceTest {
     }
 
     @Test
-    void testSayHellpo() {
+    void testSayHellpo() throws Exception {
         HelloRequest request = HelloRequest.newBuilder()
                 .setName("Test")
                 .build();
         StreamRecorder<HelloReply> responseObserver = StreamRecorder.create();
         myService.sayHello(request, responseObserver);
-        if (!responseObserver.awaitCompletion(5, TimeUnit.SECONDS);
+        if (!responseObserver.awaitCompletion(5, TimeUnit.SECONDS)) {
             fail("The call did not terminate in time");
         }
         assertNull(responseObserver.getError());
-        List<HelloReply> results = responseObserver.getValues().size();
+        List<HelloReply> results = responseObserver.getValues();
         assertEquals(1, results.size());
         HelloReply response = results.get(0);
         assertEquals(HelloReply.newBuilder()
@@ -169,17 +169,17 @@ public class MyServiceTest {
     private MyServiceImpl myService;
 
     @Test
-    void testSayHellpo() {
+    void testSayHellpo() throws Exception {
         HelloRequest request = HelloRequest.newBuilder()
                 .setName("Test")
                 .build();
         StreamRecorder<HelloReply> responseObserver = StreamRecorder.create();
         myService.sayHello(request, responseObserver);
-        if (!responseObserver.awaitCompletion(5, TimeUnit.SECONDS);
+        if (!responseObserver.awaitCompletion(5, TimeUnit.SECONDS)) {
             fail("The call did not terminate in time");
         }
         assertNull(responseObserver.getError());
-        List<HelloReply> results = responseObserver.getValues().size();
+        List<HelloReply> results = responseObserver.getValues();
         assertEquals(1, results.size());
         HelloReply response = results.get(0);
         assertEquals(HelloReply.newBuilder()


### PR DESCRIPTION
fixes testing server code in docs

- From this code `List<HelloReply> results = responseObserver.getValues().size();`, results is being assigned an `int` instead of a `List<HelloReply>`.
- fixed a few syntax errors