### PR TITLE
fix: The registration conditions of defaultDecompressorRegistry 

### DIFF
--- a/grpc-common-spring-boot/src/main/java/net/devh/boot/grpc/common/autoconfigure/GrpcCommonCodecAutoConfiguration.java
+++ b/grpc-common-spring-boot/src/main/java/net/devh/boot/grpc/common/autoconfigure/GrpcCommonCodecAutoConfiguration.java
@@ -70,7 +70,7 @@ public class GrpcCommonCodecAutoConfiguration {
         log.debug("Found GrpcCodecDiscoverer -> Creating custom DecompressorRegistry");
         DecompressorRegistry registry = DecompressorRegistry.getDefaultInstance();
         for (final GrpcCodecDefinition definition : codecDiscoverer.findGrpcCodecs()) {
-            if (definition.getCodecType().isForCompression()) {
+            if (definition.getCodecType().isForDecompression()) {
                 final Codec codec = definition.getCodec();
                 final boolean isAdvertised = definition.isAdvertised();
                 log.debug("Registering {} decompressor: '{}' ({})",


### PR DESCRIPTION
The condition `isForCompression` is the same as CompressorRegistry.  It should be isForDecompression.

change the condition register codec definition on defaultDecompressorRegistry from `isForCompression()` to `isForDecompression()`
