### PR TITLE
Support 3rd party gRPC Java compilers via StubFactory

### DIFF
--- a/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/autoconfigure/GrpcClientAutoConfiguration.java
+++ b/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/autoconfigure/GrpcClientAutoConfiguration.java
@@ -46,6 +46,9 @@ import net.devh.boot.grpc.client.inject.GrpcClientBeanPostProcessor;
 import net.devh.boot.grpc.client.interceptor.AnnotationGlobalClientInterceptorConfigurer;
 import net.devh.boot.grpc.client.interceptor.GlobalClientInterceptorRegistry;
 import net.devh.boot.grpc.client.nameresolver.NameResolverRegistration;
+import net.devh.boot.grpc.client.stubfactory.AsyncStubFactory;
+import net.devh.boot.grpc.client.stubfactory.BlockingStubFactory;
+import net.devh.boot.grpc.client.stubfactory.FutureStubFactory;
 import net.devh.boot.grpc.common.autoconfigure.GrpcCommonCodecAutoConfiguration;
 
 /**
@@ -63,6 +66,21 @@ public class GrpcClientAutoConfiguration {
     @Bean
     static GrpcClientBeanPostProcessor grpcClientBeanPostProcessor(final ApplicationContext applicationContext) {
         return new GrpcClientBeanPostProcessor(applicationContext);
+    }
+
+    @Bean
+    AsyncStubFactory asyncStubFactory() {
+        return new AsyncStubFactory();
+    }
+
+    @Bean
+    BlockingStubFactory blockingStubFactory() {
+        return new BlockingStubFactory();
+    }
+
+    @Bean
+    FutureStubFactory futureStubFactory() {
+        return new FutureStubFactory();
     }
 
     @ConditionalOnMissingBean

--- a/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/inject/GrpcClientBeanPostProcessor.java
+++ b/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/inject/GrpcClientBeanPostProcessor.java
@@ -232,7 +232,8 @@ public class GrpcClientBeanPostProcessor implements BeanPostProcessor {
      * 
      * @param stubClass
      * @param channel
-     * @throws BeanInstantiationException If the stub couldn't be created, either because the type isn't supported or because of a failure in creation.
+     * @throws BeanInstantiationException If the stub couldn't be created, either because the type isn't supported or
+     *         because of a failure in creation.
      * @return A newly created gRPC stub.
      */
     private AbstractStub<?> createStub(Class<? extends AbstractStub<?>> stubClass, Channel channel) {
@@ -245,7 +246,8 @@ public class GrpcClientBeanPostProcessor implements BeanPostProcessor {
         try {
             return factory.createStub(stubClass, channel);
         } catch (Exception exception) {
-            throw new BeanInstantiationException(stubClass, "Failed to create gRPC stub of type " + stubClass.getName(), exception);
+            throw new BeanInstantiationException(stubClass, "Failed to create gRPC stub of type " + stubClass.getName(),
+                    exception);
         }
     }
 

--- a/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/inject/GrpcClientBeanPostProcessor.java
+++ b/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/inject/GrpcClientBeanPostProcessor.java
@@ -230,8 +230,8 @@ public class GrpcClientBeanPostProcessor implements BeanPostProcessor {
     /**
      * Creates a stub instance for the specified stub type using the resolved {@link StubFactory}.
      * 
-     * @param stubClass
-     * @param channel
+     * @param stubClass The stub class that needs to be created.
+     * @param channel The gRPC channel associated with the created stub, passed as a parameter to the stub factory.
      * @throws BeanInstantiationException If the stub couldn't be created, either because the type isn't supported or
      *         because of a failure in creation.
      * @return A newly created gRPC stub.

--- a/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/stubfactory/AsyncStubFactory.java
+++ b/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/stubfactory/AsyncStubFactory.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2016-2020 Michael Zhang <yidongnan@gmail.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package net.devh.boot.grpc.client.stubfactory;
+
+import io.grpc.stub.AbstractAsyncStub;
+import io.grpc.stub.AbstractStub;
+
+public class AsyncStubFactory extends StandardJavaGrpcStubFactory {
+
+    @Override
+    public boolean isApplicable(Class<? extends AbstractStub<?>> stubType) {
+        return AbstractAsyncStub.class.isAssignableFrom(stubType);
+    }
+
+    @Override
+    protected String getFactoryMethodName() {
+        return "newStub";
+    }
+}

--- a/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/stubfactory/BlockingStubFactory.java
+++ b/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/stubfactory/BlockingStubFactory.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2016-2020 Michael Zhang <yidongnan@gmail.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package net.devh.boot.grpc.client.stubfactory;
+
+import io.grpc.stub.AbstractBlockingStub;
+import io.grpc.stub.AbstractStub;
+
+public class BlockingStubFactory extends StandardJavaGrpcStubFactory {
+
+    @Override
+    public boolean isApplicable(Class<? extends AbstractStub<?>> stubType) {
+        return AbstractBlockingStub.class.isAssignableFrom(stubType);
+    }
+
+    @Override
+    protected String getFactoryMethodName() {
+        return "newBlockingStub";
+    }
+}

--- a/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/stubfactory/FutureStubFactory.java
+++ b/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/stubfactory/FutureStubFactory.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2016-2020 Michael Zhang <yidongnan@gmail.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package net.devh.boot.grpc.client.stubfactory;
+
+import io.grpc.stub.AbstractFutureStub;
+import io.grpc.stub.AbstractStub;
+
+public class FutureStubFactory extends StandardJavaGrpcStubFactory {
+
+    @Override
+    public boolean isApplicable(Class<? extends AbstractStub<?>> stubType) {
+        return AbstractFutureStub.class.isAssignableFrom(stubType);
+    }
+
+    @Override
+    protected String getFactoryMethodName() {
+        return "newFutureStub";
+    }
+}

--- a/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/stubfactory/StandardJavaGrpcStubFactory.java
+++ b/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/stubfactory/StandardJavaGrpcStubFactory.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2016-2020 Michael Zhang <yidongnan@gmail.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package net.devh.boot.grpc.client.stubfactory;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+
+import org.springframework.beans.BeanInstantiationException;
+
+import io.grpc.Channel;
+import io.grpc.stub.AbstractStub;
+
+/**
+ * A factory for creating stubs provided by standard grpc Java library. This is an abstract super-type that can be
+ * extended to support the different provided types.
+ */
+public abstract class StandardJavaGrpcStubFactory implements StubFactory {
+
+    /**
+     * Creates a stub of the given type.
+     *
+     * @param stubType The type of the stub to create.
+     * @param channel The channel used to create the stub.
+     * @return The newly created stub.
+     *
+     * @throws BeanInstantiationException If the stub couldn't be created.
+     */
+    @Override
+    public AbstractStub<?> createStub(final Class<? extends AbstractStub<?>> stubType, final Channel channel) {
+        try {
+            // First try the public static factory method
+            final String methodName = getFactoryMethodName();
+            final Class<?> enclosingClass = stubType.getEnclosingClass();
+            final Method factoryMethod = enclosingClass.getMethod(methodName, Channel.class);
+            return stubType.cast(factoryMethod.invoke(null, channel));
+        } catch (final Exception e) {
+            try {
+                // Use the private constructor as backup
+                final Constructor<? extends AbstractStub<?>> constructor =
+                        stubType.getDeclaredConstructor(Channel.class);
+                constructor.setAccessible(true);
+                return constructor.newInstance(channel);
+            } catch (final Exception e1) {
+                e.addSuppressed(e1);
+            }
+            throw new BeanInstantiationException(stubType, "Failed to create gRPC client", e);
+        }
+    }
+
+    /**
+     * Derives the name of the factory method from the given stub type.
+     *
+     * @return The name of the factory method.
+     */
+    protected abstract String getFactoryMethodName();
+}

--- a/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/stubfactory/StandardJavaGrpcStubFactory.java
+++ b/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/stubfactory/StandardJavaGrpcStubFactory.java
@@ -17,11 +17,12 @@
 
 package net.devh.boot.grpc.client.stubfactory;
 
-import io.grpc.Channel;
-import io.grpc.stub.AbstractStub;
+import java.lang.reflect.Method;
+
 import org.springframework.beans.BeanInstantiationException;
 
-import java.lang.reflect.Method;
+import io.grpc.Channel;
+import io.grpc.stub.AbstractStub;
 
 /**
  * A factory for creating stubs provided by standard grpc Java library. This is an abstract super-type that can be

--- a/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/stubfactory/StandardJavaGrpcStubFactory.java
+++ b/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/stubfactory/StandardJavaGrpcStubFactory.java
@@ -17,13 +17,11 @@
 
 package net.devh.boot.grpc.client.stubfactory;
 
-import java.lang.reflect.Constructor;
-import java.lang.reflect.Method;
-
-import org.springframework.beans.BeanInstantiationException;
-
 import io.grpc.Channel;
 import io.grpc.stub.AbstractStub;
+import org.springframework.beans.BeanInstantiationException;
+
+import java.lang.reflect.Method;
 
 /**
  * A factory for creating stubs provided by standard grpc Java library. This is an abstract super-type that can be
@@ -31,33 +29,15 @@ import io.grpc.stub.AbstractStub;
  */
 public abstract class StandardJavaGrpcStubFactory implements StubFactory {
 
-    /**
-     * Creates a stub of the given type.
-     *
-     * @param stubType The type of the stub to create.
-     * @param channel The channel used to create the stub.
-     * @return The newly created stub.
-     *
-     * @throws BeanInstantiationException If the stub couldn't be created.
-     */
     @Override
     public AbstractStub<?> createStub(final Class<? extends AbstractStub<?>> stubType, final Channel channel) {
         try {
-            // First try the public static factory method
+            // Use the public static factory method
             final String methodName = getFactoryMethodName();
             final Class<?> enclosingClass = stubType.getEnclosingClass();
             final Method factoryMethod = enclosingClass.getMethod(methodName, Channel.class);
             return stubType.cast(factoryMethod.invoke(null, channel));
         } catch (final Exception e) {
-            try {
-                // Use the private constructor as backup
-                final Constructor<? extends AbstractStub<?>> constructor =
-                        stubType.getDeclaredConstructor(Channel.class);
-                constructor.setAccessible(true);
-                return constructor.newInstance(channel);
-            } catch (final Exception e1) {
-                e.addSuppressed(e1);
-            }
             throw new BeanInstantiationException(stubType, "Failed to create gRPC client", e);
         }
     }

--- a/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/stubfactory/StubFactory.java
+++ b/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/stubfactory/StubFactory.java
@@ -39,7 +39,7 @@ public interface StubFactory {
      *
      * @throws BeanInstantiationException If the stub couldn't be created.
      */
-    AbstractStub<?> createStub(final Class<? extends AbstractStub<?>> stubType, final Channel channel);
+    AbstractStub<?> createStub(Class<? extends AbstractStub<?>> stubType, Channel channel);
 
     /**
      * Used to resolve a factory that matches the particular stub type.

--- a/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/stubfactory/StubFactory.java
+++ b/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/stubfactory/StubFactory.java
@@ -19,10 +19,31 @@ package net.devh.boot.grpc.client.stubfactory;
 
 import io.grpc.Channel;
 import io.grpc.stub.AbstractStub;
+import org.springframework.beans.BeanInstantiationException;
 
+/**
+ * A factory for gRPC stubs. This is an extension mechanism for supporting different types of gRPC compiled stubs
+ * in addition to the standard Java compiled gRPC.
+ *
+ * Spring beans implementing this type will be picked up automatically and added to the list of supported types.
+ */
 public interface StubFactory {
 
+    /**
+     * Creates a stub of the given type.
+     *
+     * @param stubType The type of the stub to create.
+     * @param channel The channel used to create the stub.
+     * @return The newly created stub.
+     *
+     * @throws BeanInstantiationException If the stub couldn't be created.
+     */
     AbstractStub<?> createStub(final Class<? extends AbstractStub<?>> stubType, final Channel channel);
 
+    /**
+     * Used to resolve a factory that matches the particular stub type.
+     * @param stubType The type of the stub that needs to be created.
+     * @return True if this particular factory is capable of creating instances of this stub type. False otherwise.
+     */
     boolean isApplicable(Class<? extends AbstractStub<?>> stubType);
 }

--- a/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/stubfactory/StubFactory.java
+++ b/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/stubfactory/StubFactory.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2016-2020 Michael Zhang <yidongnan@gmail.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package net.devh.boot.grpc.client.stubfactory;
+
+import io.grpc.Channel;
+import io.grpc.stub.AbstractStub;
+
+public interface StubFactory {
+
+    AbstractStub<?> createStub(final Class<? extends AbstractStub<?>> stubType, final Channel channel);
+
+    boolean isApplicable(Class<? extends AbstractStub<?>> stubType);
+}

--- a/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/stubfactory/StubFactory.java
+++ b/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/stubfactory/StubFactory.java
@@ -17,13 +17,14 @@
 
 package net.devh.boot.grpc.client.stubfactory;
 
-import io.grpc.Channel;
-import io.grpc.stub.AbstractStub;
 import org.springframework.beans.BeanInstantiationException;
 
+import io.grpc.Channel;
+import io.grpc.stub.AbstractStub;
+
 /**
- * A factory for gRPC stubs. This is an extension mechanism for supporting different types of gRPC compiled stubs
- * in addition to the standard Java compiled gRPC.
+ * A factory for gRPC stubs. This is an extension mechanism for supporting different types of gRPC compiled stubs in
+ * addition to the standard Java compiled gRPC.
  *
  * Spring beans implementing this type will be picked up automatically and added to the list of supported types.
  */
@@ -42,6 +43,7 @@ public interface StubFactory {
 
     /**
      * Used to resolve a factory that matches the particular stub type.
+     * 
      * @param stubType The type of the stub that needs to be created.
      * @return True if this particular factory is capable of creating instances of this stub type. False otherwise.
      */


### PR DESCRIPTION
Adds support for 3rd party gRPC compilers like:

- [Reactive gRPC (Reactor)](https://github.com/salesforce/reactive-grpc/tree/master/reactor)
- [Reactive gRPC (RxJava)](https://github.com/salesforce/reactive-grpc/tree/master/rx-java)
- [grpc-kotlin](https://github.com/grpc/grpc-kotlin)
- [ScalaPB](https://scalapb.github.io/grpc.html)
- [akka-grpc](https://github.com/akka/akka-grpc)

Support for server-side services is simple enough by:
- Making the service a Spring bean
- Annotating it with `@GrpcService`

Creating client stubs requires specialized stub factories. This change introduces a `StubFactory` interface:
```
public interface StubFactory {

    AbstractStub<?> createStub(final Class<? extends AbstractStub<?>> stubType, final Channel channel);

    boolean isApplicable(Class<? extends AbstractStub<?>> stubType);
}
```

This allows extending Spring Boot support to 3rd party compiled gRPC stubs by adding beans implementing `StubFactory` like so:
```
@Configuration
public class ReactorGrpcConfiguration {

    @Bean
    StubFactory reactorStubFactory() {
        return new StubFactory() {

            @Override
            public AbstractStub<?> createStub(Class<? extends AbstractStub<?>> stubType, Channel channel) {
                try {
                    final Method factoryMethod = stubType.getDeclaredMethod("newReactorStub", Channel.class);
                    return (AbstractStub<?>) factoryMethod.invoke(null, channel);
                } catch (NoSuchMethodException e) {
                    throw new IllegalArgumentException("Failed to resolve constructor for " + stubType.getName(), e);
                } catch (IllegalAccessException | InvocationTargetException e) {
                    throw new IllegalArgumentException("Failed to instantiate " + stubType.getName(), e);
                }
            }

            @Override
            public boolean isApplicable(Class<? extends AbstractStub<?>> stubType) {
                try {
                    if (stubType.getName().startsWith("Reactor")) {
                        stubType.getDeclaredMethod("newReactorStub", Channel.class);
                        return true;
                    }
                } catch (NoSuchMethodException e) {
                    // not a Reactor gRPC stub
                }
                return false;
            }
        };
    }
}
```
(The code above isn't optimized and serves as an example only)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/yidongnan/grpc-spring-boot-starter/375)
<!-- Reviewable:end -->
