### PR TITLE
feat: add metadata size config for server

### DIFF
--- a/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/config/GrpcServerProperties.java
+++ b/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/config/GrpcServerProperties.java
@@ -164,6 +164,7 @@ public class GrpcServerProperties {
      * The maximum size of metadata allowed to be received. If not set ({@code null}) then
      * {@link GrpcUtil#DEFAULT_MAX_HEADER_LIST_SIZE gRPC's default} should be used.
      * 
+     * @return The maximum metadata size allowed.
      */
     @DataSizeUnit(DataUnit.BYTES)
     private DataSize maxInboundMetadataSize = null;
@@ -321,6 +322,16 @@ public class GrpcServerProperties {
         }
     }
 
+    /**
+     * Sets the maximum metadata size allowed to be received by the server. If not set ({@code null}) then it will
+     * default to {@link GrpcUtil#DEFAULT_MAX_HEADER_LIST_SIZE gRPC's default}. If set to {@code -1} then it will use the
+     * highest possible limit (not recommended).
+     *
+     * @param maxInboundMetadataSize The new maximum size allowed for incoming metadata. {@code -1} for max possible.
+     *        Null to use the gRPC's default.
+     *
+     * @see ServerBuilder#maxInboundMetadataSize(int)
+     */
     public void setMaxInboundMetadataSize(final DataSize maxInboundMetadataSize) {
         if (maxInboundMetadataSize == null || maxInboundMetadataSize.toBytes() >= 0) {
             this.maxInboundMetadataSize = maxInboundMetadataSize;

--- a/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/config/GrpcServerProperties.java
+++ b/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/config/GrpcServerProperties.java
@@ -161,6 +161,14 @@ public class GrpcServerProperties {
     private DataSize maxInboundMessageSize = null;
 
     /**
+     * The maximum size of metadata allowed to be received. If not set ({@code null}) then
+     * {@link GrpcUtil#DEFAULT_MAX_HEADER_LIST_SIZE gRPC's default} should be used.
+     * 
+     */
+    @DataSizeUnit(DataUnit.BYTES)
+    private DataSize maxInboundMetadataSize = null;
+
+    /**
      * Whether gRPC health service is enabled or not. Defaults to {@code true}.
      *
      * @param healthServiceEnabled Whether gRPC health service is enabled.
@@ -310,6 +318,16 @@ public class GrpcServerProperties {
             this.maxInboundMessageSize = DataSize.ofBytes(Integer.MAX_VALUE);
         } else {
             throw new IllegalArgumentException("Unsupported maxInboundMessageSize: " + maxInboundMessageSize);
+        }
+    }
+
+    public void setmaxInboundMetadataSize(final DataSize maxInboundMetadataSize) {
+        if (maxInboundMetadataSize == null || maxInboundMetadataSize.toBytes() >= 0) {
+            this.maxInboundMetadataSize = maxInboundMetadataSize;
+        } else if (maxInboundMetadataSize.toBytes() == -1) {
+            this.maxInboundMetadataSize = DataSize.ofBytes(Integer.MAX_VALUE);
+        } else {
+            throw new IllegalArgumentException("Unsupported maxInboundMetadataSize: " + maxInboundMetadataSize);
         }
     }
 

--- a/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/config/GrpcServerProperties.java
+++ b/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/config/GrpcServerProperties.java
@@ -324,8 +324,8 @@ public class GrpcServerProperties {
 
     /**
      * Sets the maximum metadata size allowed to be received by the server. If not set ({@code null}) then it will
-     * default to {@link GrpcUtil#DEFAULT_MAX_HEADER_LIST_SIZE gRPC's default}. If set to {@code -1} then it will use the
-     * highest possible limit (not recommended).
+     * default to {@link GrpcUtil#DEFAULT_MAX_HEADER_LIST_SIZE gRPC's default}. If set to {@code -1} then it will use
+     * the highest possible limit (not recommended).
      *
      * @param maxInboundMetadataSize The new maximum size allowed for incoming metadata. {@code -1} for max possible.
      *        Null to use the gRPC's default.

--- a/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/config/GrpcServerProperties.java
+++ b/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/config/GrpcServerProperties.java
@@ -321,7 +321,7 @@ public class GrpcServerProperties {
         }
     }
 
-    public void setmaxInboundMetadataSize(final DataSize maxInboundMetadataSize) {
+    public void setMaxInboundMetadataSize(final DataSize maxInboundMetadataSize) {
         if (maxInboundMetadataSize == null || maxInboundMetadataSize.toBytes() >= 0) {
             this.maxInboundMetadataSize = maxInboundMetadataSize;
         } else if (maxInboundMetadataSize.toBytes() == -1) {

--- a/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/serverfactory/AbstractGrpcServerFactory.java
+++ b/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/serverfactory/AbstractGrpcServerFactory.java
@@ -151,6 +151,10 @@ public abstract class AbstractGrpcServerFactory<T extends ServerBuilder<T>> impl
         if (maxInboundMessageSize != null) {
             builder.maxInboundMessageSize((int) maxInboundMessageSize.toBytes());
         }
+        final DataSize maxInboundMetadataSize = this.properties.getMaxInboundMetadataSize();
+        if (maxInboundMetadataSize != null) {
+            builder.maxInboundMetadataSize((int) maxInboundMetadataSize.toBytes());
+        }
     }
 
     @Override

--- a/grpc-server-spring-boot-autoconfigure/src/test/java/net/devh/boot/grpc/server/config/GrpcServerPropertiesGivenUnitTest.java
+++ b/grpc-server-spring-boot-autoconfigure/src/test/java/net/devh/boot/grpc/server/config/GrpcServerPropertiesGivenUnitTest.java
@@ -34,7 +34,8 @@ import org.springframework.util.unit.DataSize;
 @ExtendWith(SpringExtension.class)
 @SpringBootTest(properties = {
         "grpc.server.keepAliveTime=42m",
-        "grpc.server.maxInboundMessageSize=5MB"
+        "grpc.server.maxInboundMessageSize=5MB",
+        "grpc.server.maxInboundMetadataSize=10KB"
 })
 class GrpcServerPropertiesGivenUnitTest {
 
@@ -45,6 +46,7 @@ class GrpcServerPropertiesGivenUnitTest {
     void test() {
         assertEquals(Duration.ofMinutes(42), this.grpcServerProperties.getKeepAliveTime());
         assertEquals(DataSize.ofMegabytes(5), this.grpcServerProperties.getMaxInboundMessageSize());
+        assertEquals(DataSize.ofKilobytes(10), this.grpcServerProperties.getMaxInboundMetadataSize());
     }
 
 }


### PR DESCRIPTION
Added a new property to control the maximum metadata size for incoming gRPC requests to the server.