### PR TITLE
Log that the CallCredentials will be applied to all stubs automatically

### DIFF
--- a/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/autoconfigure/GrpcClientSecurityAutoConfiguration.java
+++ b/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/autoconfigure/GrpcClientSecurityAutoConfiguration.java
@@ -24,6 +24,7 @@ import org.springframework.context.annotation.Configuration;
 
 import io.grpc.CallCredentials;
 import io.grpc.stub.AbstractStub;
+import lombok.extern.slf4j.Slf4j;
 import net.devh.boot.grpc.client.inject.StubTransformer;
 import net.devh.boot.grpc.client.security.CallCredentialsHelper;
 
@@ -40,6 +41,7 @@ import net.devh.boot.grpc.client.security.CallCredentialsHelper;
  *
  * @author Daniel Theuke (daniel.theuke@heuboe.de)
  */
+@Slf4j
 @Configuration(proxyBeanMethods = false)
 @AutoConfigureBefore(GrpcClientAutoConfiguration.class)
 public class GrpcClientSecurityAutoConfiguration {
@@ -60,6 +62,7 @@ public class GrpcClientSecurityAutoConfiguration {
     @ConditionalOnSingleCandidate(CallCredentials.class)
     @Bean
     StubTransformer stubCallCredentialsTransformer(final CallCredentials credentials) {
+        log.info("Found single CallCredentials in the context, automatically using it for all stubs");
         return CallCredentialsHelper.fixedCredentialsStubTransformer(credentials);
     }
 

--- a/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/security/CallCredentialsHelper.java
+++ b/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/security/CallCredentialsHelper.java
@@ -266,7 +266,7 @@ public class CallCredentialsHelper {
 
         @Override
         public String toString() {
-            return "StaticSecurityHeaderCallCredentials [extraHeaders=" + this.extraHeaders + "]";
+            return "StaticSecurityHeaderCallCredentials [extraHeaders.keys=" + this.extraHeaders.keys() + "]";
         }
 
     }


### PR DESCRIPTION
This PR is related to #386 
It makes the behavior "public" by logging it, thus reducing any potential confusion.

Also hide the `extraHeaders.values` from `StaticSecurityHeaderCallCredentials.toString()` to avoid writing credentials to the log.