### PR TITLE
[BREAKING] Simplify interceptor registration

### DIFF
--- a/docs/en/client/configuration.md
+++ b/docs/en/client/configuration.md
@@ -128,8 +128,8 @@ public GrpcChannelConfigurer keepAliveClientConfigurer() {
 
 There are three ways to add a `ClientInterceptor` to your channel.
 
-- Define the `ClientInterceptor` as a global interceptor using either the `@GrpcGlobalClientInterceptor` annotation or
-  the `GlobalClientInterceptorRegistry`
+- Define the `ClientInterceptor` as a global interceptor using either the `@GrpcGlobalClientInterceptor` annotation,
+  or a `GlobalClientInterceptorConfigurer`
 - Explicitly list them in the `@GrpcClient#interceptors` or `@GrpcClient#interceptorNames` field
 - Use a `StubTransformer` and call `stub.withInterceptors(ClientInterceptor... interceptors)`
 

--- a/docs/en/server/configuration.md
+++ b/docs/en/server/configuration.md
@@ -10,6 +10,7 @@ This section describes how you can configure your grpc-spring-boot-starter appli
   - [Changing the Server Port](#changing-the-server-port)
   - [Enabling the InProcessServer](#enabling-the-inprocessserver)
 - [Configuration via Beans](#configuration-via-beans)
+  - [ServerInterceptor](#serverinterceptor)
   - [GrpcServerConfigurer](#grpcserverconfigurer)
 
 ## Additional topics <!-- omit in toc -->
@@ -85,6 +86,15 @@ extension points that exist in this library.
 First of all most of the beans can be replaced by custom ones, that you can configure in every way you want.
 If you don't wish to go that far, you can use classes such as `GrpcServerConfigurer` to configure the server and other
 components without losing the features provided by this library.
+
+### ServerInterceptor
+
+There are three ways to add a `ServerInterceptor` to your server.
+
+- Define the `ServerInterceptor` as a global interceptor using either the `@GrpcGlobalServerInterceptor` annotation,
+  or a `GlobalServerInterceptorConfigurer`
+- Explicitly list them in the `@GrpcService#interceptors` or `@GrpcService#interceptorNames` field
+- Use a `GrpcServerConfigurer` and call `serverBuilder.intercept(ServerInterceptor interceptor)`
 
 ### GrpcServerConfigurer
 

--- a/examples/cloud-grpc-client/src/main/java/net/devh/boot/grpc/examples/cloud/client/GlobalClientInterceptorConfiguration.java
+++ b/examples/cloud-grpc-client/src/main/java/net/devh/boot/grpc/examples/cloud/client/GlobalClientInterceptorConfiguration.java
@@ -22,15 +22,15 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
 
-import net.devh.boot.grpc.client.interceptor.GlobalClientInterceptorConfigurer;
+import io.grpc.ClientInterceptor;
 
 @Order(Ordered.LOWEST_PRECEDENCE)
 @Configuration(proxyBeanMethods = false)
 public class GlobalClientInterceptorConfiguration {
 
     @Bean
-    public GlobalClientInterceptorConfigurer globalInterceptorConfigurerAdapter() {
-        return registry -> registry.addClientInterceptors(new LogGrpcInterceptor());
+    ClientInterceptor logClientInterceptor() {
+        return new LogGrpcInterceptor();
     }
 
 }

--- a/examples/cloud-grpc-client/src/main/java/net/devh/boot/grpc/examples/cloud/client/GlobalClientInterceptorConfiguration.java
+++ b/examples/cloud-grpc-client/src/main/java/net/devh/boot/grpc/examples/cloud/client/GlobalClientInterceptorConfiguration.java
@@ -17,18 +17,18 @@
 
 package net.devh.boot.grpc.examples.cloud.client;
 
-import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
 
 import io.grpc.ClientInterceptor;
+import net.devh.boot.grpc.client.interceptor.GrpcGlobalClientInterceptor;
 
 @Order(Ordered.LOWEST_PRECEDENCE)
 @Configuration(proxyBeanMethods = false)
 public class GlobalClientInterceptorConfiguration {
 
-    @Bean
+    @GrpcGlobalClientInterceptor
     ClientInterceptor logClientInterceptor() {
         return new LogGrpcInterceptor();
     }

--- a/examples/cloud-grpc-server/src/main/java/net/devh/boot/grpc/examples/cloud/server/GlobalInterceptorConfiguration.java
+++ b/examples/cloud-grpc-server/src/main/java/net/devh/boot/grpc/examples/cloud/server/GlobalInterceptorConfiguration.java
@@ -17,17 +17,17 @@
 
 package net.devh.boot.grpc.examples.cloud.server;
 
-import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-import net.devh.boot.grpc.server.interceptor.GlobalServerInterceptorConfigurer;
+import io.grpc.ServerInterceptor;
+import net.devh.boot.grpc.server.interceptor.GrpcGlobalServerInterceptor;
 
 @Configuration(proxyBeanMethods = false)
 public class GlobalInterceptorConfiguration {
 
-    @Bean
-    public GlobalServerInterceptorConfigurer globalInterceptorConfigurerAdapter() {
-        return registry -> registry.addServerInterceptors(new LogGrpcInterceptor());
+    @GrpcGlobalServerInterceptor
+    ServerInterceptor logServerInterceptor() {
+        return new LogGrpcInterceptor();
     }
 
 }

--- a/examples/local-grpc-client/src/main/java/net/devh/boot/grpc/examples/local/client/GlobalClientInterceptorConfiguration.java
+++ b/examples/local-grpc-client/src/main/java/net/devh/boot/grpc/examples/local/client/GlobalClientInterceptorConfiguration.java
@@ -17,18 +17,18 @@
 
 package net.devh.boot.grpc.examples.local.client;
 
-import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
 
 import io.grpc.ClientInterceptor;
+import net.devh.boot.grpc.client.interceptor.GrpcGlobalClientInterceptor;
 
 @Order(Ordered.LOWEST_PRECEDENCE)
 @Configuration(proxyBeanMethods = false)
 public class GlobalClientInterceptorConfiguration {
 
-    @Bean
+    @GrpcGlobalClientInterceptor
     ClientInterceptor logClientInterceptor() {
         return new LogGrpcInterceptor();
     }

--- a/examples/local-grpc-client/src/main/java/net/devh/boot/grpc/examples/local/client/GlobalClientInterceptorConfiguration.java
+++ b/examples/local-grpc-client/src/main/java/net/devh/boot/grpc/examples/local/client/GlobalClientInterceptorConfiguration.java
@@ -22,15 +22,15 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
 
-import net.devh.boot.grpc.client.interceptor.GlobalClientInterceptorConfigurer;
+import io.grpc.ClientInterceptor;
 
 @Order(Ordered.LOWEST_PRECEDENCE)
 @Configuration(proxyBeanMethods = false)
 public class GlobalClientInterceptorConfiguration {
 
     @Bean
-    public GlobalClientInterceptorConfigurer globalInterceptorConfigurerAdapter() {
-        return registry -> registry.addClientInterceptors(new LogGrpcInterceptor());
+    ClientInterceptor logClientInterceptor() {
+        return new LogGrpcInterceptor();
     }
 
 }

--- a/examples/local-grpc-server/src/main/java/net/devh/boot/grpc/examples/local/server/GlobalInterceptorConfiguration.java
+++ b/examples/local-grpc-server/src/main/java/net/devh/boot/grpc/examples/local/server/GlobalInterceptorConfiguration.java
@@ -17,23 +17,17 @@
 
 package net.devh.boot.grpc.examples.local.server;
 
-import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-import net.devh.boot.grpc.server.interceptor.GlobalServerInterceptorConfigurer;
-import net.devh.boot.grpc.server.interceptor.GlobalServerInterceptorRegistry;
+import io.grpc.ServerInterceptor;
+import net.devh.boot.grpc.server.interceptor.GrpcGlobalServerInterceptor;
 
 @Configuration(proxyBeanMethods = false)
 public class GlobalInterceptorConfiguration {
 
-    @Bean
-    public GlobalServerInterceptorConfigurer globalInterceptorConfigurerAdapter() {
-        return new GlobalServerInterceptorConfigurer() {
-            @Override
-            public void addServerInterceptors(GlobalServerInterceptorRegistry registry) {
-                registry.addServerInterceptors(new LogGrpcInterceptor());
-            }
-        };
+    @GrpcGlobalServerInterceptor
+    ServerInterceptor logServerInterceptor() {
+        return new LogGrpcInterceptor();
     }
 
 }

--- a/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/autoconfigure/GrpcClientAutoConfiguration.java
+++ b/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/autoconfigure/GrpcClientAutoConfiguration.java
@@ -92,13 +92,15 @@ public class GrpcClientAutoConfiguration {
 
     @ConditionalOnMissingBean
     @Bean
-    GlobalClientInterceptorRegistry globalClientInterceptorRegistry() {
-        return new GlobalClientInterceptorRegistry();
+    GlobalClientInterceptorRegistry globalClientInterceptorRegistry(final ApplicationContext applicationContext) {
+        return new GlobalClientInterceptorRegistry(applicationContext);
     }
 
     @Bean
-    AnnotationGlobalClientInterceptorConfigurer annotationGlobalClientInterceptorConfigurer() {
-        return new AnnotationGlobalClientInterceptorConfigurer();
+    @Lazy
+    AnnotationGlobalClientInterceptorConfigurer annotationGlobalClientInterceptorConfigurer(
+            final ApplicationContext applicationContext) {
+        return new AnnotationGlobalClientInterceptorConfigurer(applicationContext);
     }
 
     /**

--- a/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/autoconfigure/GrpcClientTraceAutoConfiguration.java
+++ b/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/autoconfigure/GrpcClientTraceAutoConfiguration.java
@@ -20,11 +20,11 @@ package net.devh.boot.grpc.client.autoconfigure;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 import brave.grpc.GrpcTracing;
-import net.devh.boot.grpc.client.interceptor.GlobalClientInterceptorConfigurer;
+import io.grpc.ClientInterceptor;
+import net.devh.boot.grpc.client.interceptor.GrpcGlobalClientInterceptor;
 import net.devh.boot.grpc.client.interceptor.OrderedClientInterceptor;
 import net.devh.boot.grpc.common.autoconfigure.GrpcCommonTraceAutoConfiguration;
 import net.devh.boot.grpc.common.util.InterceptorOrder;
@@ -44,14 +44,13 @@ public class GrpcClientTraceAutoConfiguration {
      * Configures a global client interceptor that applies brave's tracing logic to the requests.
      *
      * @param grpcTracing The grpc tracing bean.
-     * @return The globalTraceClientInterceptorConfigurer bean.
+     * @return The tracing client interceptor bean.
      */
-    @Bean
-    public GlobalClientInterceptorConfigurer globalTraceClientInterceptorConfigurer(final GrpcTracing grpcTracing) {
-        return registry -> registry.addClientInterceptors(
-                new OrderedClientInterceptor(
-                        grpcTracing.newClientInterceptor(),
-                        InterceptorOrder.ORDER_TRACING_METRICS + 1));
+    @GrpcGlobalClientInterceptor
+    ClientInterceptor globalTraceClientInterceptorConfigurer(final GrpcTracing grpcTracing) {
+        return new OrderedClientInterceptor(
+                grpcTracing.newClientInterceptor(),
+                InterceptorOrder.ORDER_TRACING_METRICS + 1);
     }
 
 }

--- a/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/interceptor/GlobalClientInterceptorConfigurer.java
+++ b/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/interceptor/GlobalClientInterceptorConfigurer.java
@@ -17,10 +17,12 @@
 
 package net.devh.boot.grpc.client.interceptor;
 
+import java.util.List;
+
 import io.grpc.ClientInterceptor;
 
 /**
- * This configurer can be used to register new global {@link ClientInterceptor}s.
+ * A bean that can be used to configure global {@link ClientInterceptor}s.
  *
  * @author Daniel Theuke (daniel.theuke@heuboe.de)
  */
@@ -28,10 +30,11 @@ import io.grpc.ClientInterceptor;
 public interface GlobalClientInterceptorConfigurer {
 
     /**
-     * Adds the {@link ClientInterceptor}s that should be registered globally to the given registry.
+     * Configures the given list of client interceptors, possibly adding new elements, removing unwanted elements, or
+     * reordering the existing ones.
      *
-     * @param registry The registry the interceptors should be added to.
+     * @param interceptors A mutable list of client interceptors to configure.
      */
-    void addClientInterceptors(GlobalClientInterceptorRegistry registry);
+    void configureClientInterceptors(List<ClientInterceptor> interceptors);
 
 }

--- a/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/interceptor/GlobalClientInterceptorRegistry.java
+++ b/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/interceptor/GlobalClientInterceptorRegistry.java
@@ -17,78 +17,73 @@
 
 package net.devh.boot.grpc.client.interceptor;
 
-import java.util.List;
-import java.util.Map;
+import static java.util.Objects.requireNonNull;
 
-import javax.annotation.PostConstruct;
+import java.util.ArrayList;
+import java.util.List;
 
 import org.springframework.context.ApplicationContext;
-import org.springframework.context.ApplicationContextAware;
 import org.springframework.core.annotation.AnnotationAwareOrderComparator;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Lists;
 
+import io.grpc.Channel;
 import io.grpc.ClientInterceptor;
 import io.grpc.ClientInterceptors;
 
 /**
  * The global client interceptor registry keeps references to all {@link ClientInterceptor}s that should be registered
- * globally. The interceptors will be applied in the same order they as specified by the {@link #sortInterceptors(List)}
- * method.
+ * to all client channels. The interceptors will be applied in the same order they as specified by the
+ * {@link #sortInterceptors(List)} method.
  *
  * <p>
  * <b>Note:</b> Custom interceptors will be appended to the global interceptors and applied using
- * {@link ClientInterceptors#interceptForward(io.grpc.Channel, ClientInterceptor...)}.
+ * {@link ClientInterceptors#interceptForward(Channel, ClientInterceptor...)}.
  * </p>
  *
  * @author Michael (yidongnan@gmail.com)
- * @since 5/17/16
  */
-public class GlobalClientInterceptorRegistry implements ApplicationContextAware {
+public class GlobalClientInterceptorRegistry {
 
-    private final List<ClientInterceptor> clientInterceptors = Lists.newArrayList();
+    private final ApplicationContext applicationContext;
+
     private ImmutableList<ClientInterceptor> sortedClientInterceptors;
-    private ApplicationContext applicationContext;
-
-    @Override
-    public void setApplicationContext(final ApplicationContext applicationContext) {
-        this.applicationContext = applicationContext;
-    }
-
-    @PostConstruct
-    public void init() {
-        final Map<String, GlobalClientInterceptorConfigurer> map =
-                this.applicationContext.getBeansOfType(GlobalClientInterceptorConfigurer.class);
-        for (final GlobalClientInterceptorConfigurer globalClientInterceptorConfigurer : map.values()) {
-            globalClientInterceptorConfigurer.addClientInterceptors(this);
-        }
-    }
 
     /**
-     * Adds the given {@link ClientInterceptor} to the list of globally registered interceptors.
+     * Creates a new GlobalClientInterceptorRegistry.
      *
-     * @param interceptor The interceptor to add.
-     * @return This instance for chaining.
+     * @param applicationContext The application context to fetch the {@link GlobalClientInterceptorConfigurer} beans
+     *        from.
      */
-    public GlobalClientInterceptorRegistry addClientInterceptors(final ClientInterceptor interceptor) {
-        this.sortedClientInterceptors = null;
-        this.clientInterceptors.add(interceptor);
-        return this;
+    public GlobalClientInterceptorRegistry(final ApplicationContext applicationContext) {
+        this.applicationContext = requireNonNull(applicationContext, "applicationContext");
     }
 
     /**
-     * Gets the immutable and sorted list of global server interceptors.
+     * Gets the immutable list of global server interceptors.
      *
      * @return The list of globally registered server interceptors.
      */
     public ImmutableList<ClientInterceptor> getClientInterceptors() {
         if (this.sortedClientInterceptors == null) {
-            List<ClientInterceptor> temp = Lists.newArrayList(this.clientInterceptors);
-            sortInterceptors(temp);
-            this.sortedClientInterceptors = ImmutableList.copyOf(temp);
+            this.sortedClientInterceptors = ImmutableList.copyOf(initClientInterceptors());
         }
         return this.sortedClientInterceptors;
+    }
+
+    /**
+     * Initializes the list of client interceptors.
+     *
+     * @return The list of global client interceptors.
+     */
+    protected List<ClientInterceptor> initClientInterceptors() {
+        final List<ClientInterceptor> interceptors = new ArrayList<>();
+        for (final GlobalClientInterceptorConfigurer configurer : this.applicationContext
+                .getBeansOfType(GlobalClientInterceptorConfigurer.class).values()) {
+            configurer.configureClientInterceptors(interceptors);
+        }
+        sortInterceptors(interceptors);
+        return interceptors;
     }
 
     /**
@@ -97,7 +92,7 @@ public class GlobalClientInterceptorRegistry implements ApplicationContextAware 
      *
      * @param interceptors The interceptors to sort.
      */
-    public void sortInterceptors(List<? extends ClientInterceptor> interceptors) {
+    public void sortInterceptors(final List<? extends ClientInterceptor> interceptors) {
         interceptors.sort(AnnotationAwareOrderComparator.INSTANCE);
     }
 

--- a/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/interceptor/GrpcGlobalClientInterceptor.java
+++ b/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/interceptor/GrpcGlobalClientInterceptor.java
@@ -23,6 +23,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+import org.springframework.context.annotation.Bean;
 import org.springframework.stereotype.Component;
 
 import io.grpc.ClientInterceptor;
@@ -32,9 +33,10 @@ import io.grpc.ClientInterceptor;
  *
  * @author Daniel Theuke (daniel.theuke@heuboe.de)
  */
-@Target(ElementType.TYPE)
+@Target({ElementType.TYPE, ElementType.METHOD})
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
 @Component
+@Bean
 public @interface GrpcGlobalClientInterceptor {
 }

--- a/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/autoconfigure/GrpcServerAutoConfiguration.java
+++ b/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/autoconfigure/GrpcServerAutoConfiguration.java
@@ -25,6 +25,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Lazy;
@@ -83,19 +84,22 @@ public class GrpcServerAutoConfiguration {
     @ConditionalOnMissingBean
     @Bean
     @Lazy
-    public SelfNameResolverFactory selfNameResolverFactory(GrpcServerProperties properties) {
+    public SelfNameResolverFactory selfNameResolverFactory(final GrpcServerProperties properties) {
         return new SelfNameResolverFactory(properties);
     }
 
     @ConditionalOnMissingBean
     @Bean
-    public GlobalServerInterceptorRegistry globalServerInterceptorRegistry() {
-        return new GlobalServerInterceptorRegistry();
+    GlobalServerInterceptorRegistry globalServerInterceptorRegistry(
+            final ApplicationContext applicationContext) {
+        return new GlobalServerInterceptorRegistry(applicationContext);
     }
 
     @Bean
-    public AnnotationGlobalServerInterceptorConfigurer annotationGlobalServerInterceptorConfigurer() {
-        return new AnnotationGlobalServerInterceptorConfigurer();
+    @Lazy
+    AnnotationGlobalServerInterceptorConfigurer annotationGlobalServerInterceptorConfigurer(
+            final ApplicationContext applicationContext) {
+        return new AnnotationGlobalServerInterceptorConfigurer(applicationContext);
     }
 
     @ConditionalOnMissingBean

--- a/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/autoconfigure/GrpcServerTraceAutoConfiguration.java
+++ b/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/autoconfigure/GrpcServerTraceAutoConfiguration.java
@@ -20,13 +20,13 @@ package net.devh.boot.grpc.server.autoconfigure;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 import brave.grpc.GrpcTracing;
+import io.grpc.ServerInterceptor;
 import net.devh.boot.grpc.common.autoconfigure.GrpcCommonTraceAutoConfiguration;
 import net.devh.boot.grpc.common.util.InterceptorOrder;
-import net.devh.boot.grpc.server.interceptor.GlobalServerInterceptorConfigurer;
+import net.devh.boot.grpc.server.interceptor.GrpcGlobalServerInterceptor;
 import net.devh.boot.grpc.server.interceptor.OrderedServerInterceptor;
 
 /**
@@ -44,14 +44,13 @@ public class GrpcServerTraceAutoConfiguration {
      * Configures a global server interceptor that applies brave's tracing logic to the requests.
      *
      * @param grpcTracing The grpc tracing bean.
-     * @return The globalTraceServerInterceptorConfigurer bean.
+     * @return The tracing server interceptor bean.
      */
-    @Bean
-    public GlobalServerInterceptorConfigurer globalTraceServerInterceptorConfigurer(final GrpcTracing grpcTracing) {
-        return registry -> registry.addServerInterceptors(
-                new OrderedServerInterceptor(
-                        grpcTracing.newServerInterceptor(),
-                        InterceptorOrder.ORDER_TRACING_METRICS + 1));
+    @GrpcGlobalServerInterceptor
+    public ServerInterceptor globalTraceServerInterceptorConfigurer(final GrpcTracing grpcTracing) {
+        return new OrderedServerInterceptor(
+                grpcTracing.newServerInterceptor(),
+                InterceptorOrder.ORDER_TRACING_METRICS + 1);
     }
 
 }

--- a/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/interceptor/GlobalServerInterceptorConfigurer.java
+++ b/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/interceptor/GlobalServerInterceptorConfigurer.java
@@ -17,10 +17,12 @@
 
 package net.devh.boot.grpc.server.interceptor;
 
+import java.util.List;
+
 import io.grpc.ServerInterceptor;
 
 /**
- * This configurer can be used to register new global {@link ServerInterceptor}s.
+ * A bean that can be used to configure global {@link ServerInterceptor}s.
  *
  * @author Daniel Theuke (daniel.theuke@heuboe.de)
  */
@@ -28,10 +30,11 @@ import io.grpc.ServerInterceptor;
 public interface GlobalServerInterceptorConfigurer {
 
     /**
-     * Adds the {@link ServerInterceptor}s that should be registered globally to the given registry.
+     * Configures the given list of server interceptors, possibly adding new elements, removing unwanted elements, or
+     * reordering the existing ones.
      *
-     * @param registry The registry the interceptors should be added to.
+     * @param interceptors A mutable list of server interceptors to configure.
      */
-    void addServerInterceptors(GlobalServerInterceptorRegistry registry);
+    void configureServerInterceptors(List<ServerInterceptor> interceptors);
 
 }

--- a/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/interceptor/GlobalServerInterceptorRegistry.java
+++ b/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/interceptor/GlobalServerInterceptorRegistry.java
@@ -17,17 +17,15 @@
 
 package net.devh.boot.grpc.server.interceptor;
 
-import java.util.List;
-import java.util.Map;
+import static java.util.Objects.requireNonNull;
 
-import javax.annotation.PostConstruct;
+import java.util.ArrayList;
+import java.util.List;
 
 import org.springframework.context.ApplicationContext;
-import org.springframework.context.ApplicationContextAware;
 import org.springframework.core.annotation.AnnotationAwareOrderComparator;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Lists;
 
 import io.grpc.BindableService;
 import io.grpc.ServerInterceptor;
@@ -35,8 +33,8 @@ import io.grpc.ServerInterceptors;
 
 /**
  * The global server interceptor registry keeps references to all {@link ServerInterceptor}s that should be registered
- * globally. The interceptors will be applied in the same order they as specified by the {@link #sortInterceptors(List)}
- * method.
+ * to all server channels. The interceptors will be applied in the same order they as specified by the
+ * {@link #sortInterceptors(List)} method.
  *
  * <p>
  * <b>Note:</b> Custom interceptors will be appended to the global interceptors and applied using
@@ -44,52 +42,48 @@ import io.grpc.ServerInterceptors;
  * </p>
  *
  * @author Michael (yidongnan@gmail.com)
- * @since 5/17/16
  */
-public class GlobalServerInterceptorRegistry implements ApplicationContextAware {
+public class GlobalServerInterceptorRegistry {
 
-    private final List<ServerInterceptor> serverInterceptors = Lists.newArrayList();
+    private final ApplicationContext applicationContext;
+
     private ImmutableList<ServerInterceptor> sortedServerInterceptors;
-    private ApplicationContext applicationContext;
-
-    @Override
-    public void setApplicationContext(final ApplicationContext applicationContext) {
-        this.applicationContext = applicationContext;
-    }
-
-    @PostConstruct
-    public void init() {
-        final Map<String, GlobalServerInterceptorConfigurer> map =
-                this.applicationContext.getBeansOfType(GlobalServerInterceptorConfigurer.class);
-        for (final GlobalServerInterceptorConfigurer globalServerInterceptorConfigurerAdapter : map.values()) {
-            globalServerInterceptorConfigurerAdapter.addServerInterceptors(this);
-        }
-    }
 
     /**
-     * Adds the given {@link ServerInterceptor} to the list of globally registered interceptors.
+     * Creates a new GlobalServerInterceptorRegistry.
      *
-     * @param interceptor The interceptor to add.
-     * @return This instance for chaining.
+     * @param applicationContext The application context to fetch the {@link GlobalServerInterceptorConfigurer} beans
+     *        from.
      */
-    public GlobalServerInterceptorRegistry addServerInterceptors(final ServerInterceptor interceptor) {
-        this.sortedServerInterceptors = null;
-        this.serverInterceptors.add(interceptor);
-        return this;
+    public GlobalServerInterceptorRegistry(final ApplicationContext applicationContext) {
+        this.applicationContext = requireNonNull(applicationContext, "applicationContext");
     }
 
     /**
-     * Gets the immutable and sorted list of global server interceptors.
+     * Gets the immutable list of global server interceptors.
      *
      * @return The list of globally registered server interceptors.
      */
     public ImmutableList<ServerInterceptor> getServerInterceptors() {
         if (this.sortedServerInterceptors == null) {
-            List<ServerInterceptor> temp = Lists.newArrayList(this.serverInterceptors);
-            sortInterceptors(temp);
-            this.sortedServerInterceptors = ImmutableList.copyOf(temp);
+            this.sortedServerInterceptors = ImmutableList.copyOf(initServerInterceptors());
         }
         return this.sortedServerInterceptors;
+    }
+
+    /**
+     * Initializes the list of server interceptors.
+     *
+     * @return The list of global server interceptors.
+     */
+    protected List<ServerInterceptor> initServerInterceptors() {
+        final List<ServerInterceptor> interceptors = new ArrayList<>();
+        for (final GlobalServerInterceptorConfigurer configurer : this.applicationContext
+                .getBeansOfType(GlobalServerInterceptorConfigurer.class).values()) {
+            configurer.configureServerInterceptors(interceptors);
+        }
+        sortInterceptors(interceptors);
+        return interceptors;
     }
 
     /**
@@ -98,7 +92,7 @@ public class GlobalServerInterceptorRegistry implements ApplicationContextAware 
      *
      * @param interceptors The interceptors to sort.
      */
-    public void sortInterceptors(List<? extends ServerInterceptor> interceptors) {
+    public void sortInterceptors(final List<? extends ServerInterceptor> interceptors) {
         interceptors.sort(AnnotationAwareOrderComparator.INSTANCE);
     }
 

--- a/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/interceptor/GrpcGlobalServerInterceptor.java
+++ b/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/interceptor/GrpcGlobalServerInterceptor.java
@@ -23,6 +23,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+import org.springframework.context.annotation.Bean;
 import org.springframework.stereotype.Component;
 
 import io.grpc.ServerInterceptor;
@@ -32,9 +33,10 @@ import io.grpc.ServerInterceptor;
  *
  * @author Daniel Theuke (daniel.theuke@heuboe.de)
  */
-@Target(ElementType.TYPE)
+@Target({ElementType.TYPE, ElementType.METHOD})
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
 @Component
+@Bean
 public @interface GrpcGlobalServerInterceptor {
 }

--- a/tests/src/test/java/net/devh/boot/grpc/test/codec/BeanCodecTest.java
+++ b/tests/src/test/java/net/devh/boot/grpc/test/codec/BeanCodecTest.java
@@ -30,9 +30,9 @@ import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
 import io.grpc.Codec;
-import net.devh.boot.grpc.client.interceptor.GlobalClientInterceptorConfigurer;
+import net.devh.boot.grpc.client.interceptor.GrpcGlobalClientInterceptor;
 import net.devh.boot.grpc.common.codec.GrpcCodec;
-import net.devh.boot.grpc.server.interceptor.GlobalServerInterceptorConfigurer;
+import net.devh.boot.grpc.server.interceptor.GrpcGlobalServerInterceptor;
 import net.devh.boot.grpc.test.config.BaseAutoConfiguration;
 import net.devh.boot.grpc.test.config.ServiceConfiguration;
 
@@ -40,8 +40,10 @@ import net.devh.boot.grpc.test.config.ServiceConfiguration;
         "grpc.client.GLOBAL.address=localhost:9090",
         "grpc.client.GLOBAL.negotiationType=PLAINTEXT"
 })
-@SpringJUnitConfig(
-        classes = {BeanCodecTest.CustomConfiguration.class, ServiceConfiguration.class, BaseAutoConfiguration.class})
+@SpringJUnitConfig(classes = {
+        BeanCodecTest.CustomConfiguration.class,
+        ServiceConfiguration.class,
+        BaseAutoConfiguration.class})
 @DirtiesContext
 public class BeanCodecTest extends AbstractCodecTest {
 
@@ -54,14 +56,14 @@ public class BeanCodecTest extends AbstractCodecTest {
     @Configuration
     public static class CustomConfiguration {
 
-        @Bean
-        GlobalClientInterceptorConfigurer gcic() {
-            return registry -> registry.addClientInterceptors(new CodecValidatingClientInterceptor(CODEC));
+        @GrpcGlobalClientInterceptor
+        CodecValidatingClientInterceptor gcic() {
+            return new CodecValidatingClientInterceptor(CODEC);
         }
 
-        @Bean
-        GlobalServerInterceptorConfigurer gsic() {
-            return registry -> registry.addServerInterceptors(new CodecValidatingServerInterceptor(CODEC));
+        @GrpcGlobalServerInterceptor
+        CodecValidatingServerInterceptor gsic() {
+            return new CodecValidatingServerInterceptor(CODEC);
         }
 
         @Bean

--- a/tests/src/test/java/net/devh/boot/grpc/test/codec/CustomCodecTest.java
+++ b/tests/src/test/java/net/devh/boot/grpc/test/codec/CustomCodecTest.java
@@ -31,11 +31,11 @@ import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
 import io.grpc.Codec;
-import net.devh.boot.grpc.client.interceptor.GlobalClientInterceptorConfigurer;
+import net.devh.boot.grpc.client.interceptor.GrpcGlobalClientInterceptor;
 import net.devh.boot.grpc.common.codec.CodecType;
 import net.devh.boot.grpc.common.codec.GrpcCodecDefinition;
 import net.devh.boot.grpc.common.codec.GrpcCodecDiscoverer;
-import net.devh.boot.grpc.server.interceptor.GlobalServerInterceptorConfigurer;
+import net.devh.boot.grpc.server.interceptor.GrpcGlobalServerInterceptor;
 import net.devh.boot.grpc.test.config.BaseAutoConfiguration;
 import net.devh.boot.grpc.test.config.ServiceConfiguration;
 
@@ -43,8 +43,10 @@ import net.devh.boot.grpc.test.config.ServiceConfiguration;
         "grpc.client.GLOBAL.address=localhost:9090",
         "grpc.client.GLOBAL.negotiationType=PLAINTEXT"
 })
-@SpringJUnitConfig(
-        classes = {CustomCodecTest.CustomConfiguration.class, ServiceConfiguration.class, BaseAutoConfiguration.class})
+@SpringJUnitConfig(classes = {
+        CustomCodecTest.CustomConfiguration.class,
+        ServiceConfiguration.class,
+        BaseAutoConfiguration.class})
 @DirtiesContext
 public class CustomCodecTest extends AbstractCodecTest {
 
@@ -57,14 +59,14 @@ public class CustomCodecTest extends AbstractCodecTest {
     @Configuration
     public static class CustomConfiguration {
 
-        @Bean
-        GlobalClientInterceptorConfigurer gcic() {
-            return registry -> registry.addClientInterceptors(new CodecValidatingClientInterceptor(CODEC));
+        @GrpcGlobalClientInterceptor
+        CodecValidatingClientInterceptor gcic() {
+            return new CodecValidatingClientInterceptor(CODEC);
         }
 
-        @Bean
-        GlobalServerInterceptorConfigurer gsic() {
-            return registry -> registry.addServerInterceptors(new CodecValidatingServerInterceptor(CODEC));
+        @GrpcGlobalServerInterceptor
+        CodecValidatingServerInterceptor gsic() {
+            return new CodecValidatingServerInterceptor(CODEC);
         }
 
         @Bean

--- a/tests/src/test/java/net/devh/boot/grpc/test/codec/GzipCodecTest.java
+++ b/tests/src/test/java/net/devh/boot/grpc/test/codec/GzipCodecTest.java
@@ -25,10 +25,10 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
-import net.devh.boot.grpc.client.interceptor.GlobalClientInterceptorConfigurer;
+import net.devh.boot.grpc.client.interceptor.GrpcGlobalClientInterceptor;
 import net.devh.boot.grpc.common.codec.GrpcCodecDefinition;
 import net.devh.boot.grpc.common.codec.GrpcCodecDiscoverer;
-import net.devh.boot.grpc.server.interceptor.GlobalServerInterceptorConfigurer;
+import net.devh.boot.grpc.server.interceptor.GrpcGlobalServerInterceptor;
 import net.devh.boot.grpc.test.config.BaseAutoConfiguration;
 import net.devh.boot.grpc.test.config.ServiceConfiguration;
 
@@ -42,7 +42,10 @@ import net.devh.boot.grpc.test.config.ServiceConfiguration;
         "grpc.client.GLOBAL.address=localhost:9090",
         "grpc.client.GLOBAL.negotiationType=PLAINTEXT"
 })
-@SpringJUnitConfig(classes = {ServiceConfiguration.class, BaseAutoConfiguration.class})
+@SpringJUnitConfig(classes = {
+        GzipCodecTest.CustomConfiguration.class,
+        ServiceConfiguration.class,
+        BaseAutoConfiguration.class})
 @DirtiesContext
 public class GzipCodecTest extends AbstractCodecTest {
 
@@ -55,14 +58,14 @@ public class GzipCodecTest extends AbstractCodecTest {
     @Configuration
     public static class CustomConfiguration {
 
-        @Bean
-        GlobalClientInterceptorConfigurer gcic() {
-            return registry -> registry.addClientInterceptors(new CodecValidatingClientInterceptor(CODEC));
+        @GrpcGlobalClientInterceptor
+        CodecValidatingClientInterceptor gcic() {
+            return new CodecValidatingClientInterceptor(CODEC);
         }
 
-        @Bean
-        GlobalServerInterceptorConfigurer gsic() {
-            return registry -> registry.addServerInterceptors(new CodecValidatingServerInterceptor(CODEC));
+        @GrpcGlobalServerInterceptor
+        CodecValidatingServerInterceptor gsic() {
+            return new CodecValidatingServerInterceptor(CODEC);
         }
 
         @Bean

--- a/tests/src/test/java/net/devh/boot/grpc/test/codec/IdentityCodecTest.java
+++ b/tests/src/test/java/net/devh/boot/grpc/test/codec/IdentityCodecTest.java
@@ -25,10 +25,10 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
-import net.devh.boot.grpc.client.interceptor.GlobalClientInterceptorConfigurer;
+import net.devh.boot.grpc.client.interceptor.GrpcGlobalClientInterceptor;
 import net.devh.boot.grpc.common.codec.GrpcCodecDefinition;
 import net.devh.boot.grpc.common.codec.GrpcCodecDiscoverer;
-import net.devh.boot.grpc.server.interceptor.GlobalServerInterceptorConfigurer;
+import net.devh.boot.grpc.server.interceptor.GrpcGlobalServerInterceptor;
 import net.devh.boot.grpc.test.config.BaseAutoConfiguration;
 import net.devh.boot.grpc.test.config.ServiceConfiguration;
 
@@ -42,8 +42,10 @@ import net.devh.boot.grpc.test.config.ServiceConfiguration;
         "grpc.client.GLOBAL.address=localhost:9090",
         "grpc.client.GLOBAL.negotiationType=PLAINTEXT"
 })
-@SpringJUnitConfig(classes = {ServiceConfiguration.class, BaseAutoConfiguration.class,
-        IdentityCodecTest.CustomConfiguration.class})
+@SpringJUnitConfig(classes = {
+        IdentityCodecTest.CustomConfiguration.class,
+        ServiceConfiguration.class,
+        BaseAutoConfiguration.class})
 @DirtiesContext
 public class IdentityCodecTest extends AbstractCodecTest {
 
@@ -56,14 +58,14 @@ public class IdentityCodecTest extends AbstractCodecTest {
     @Configuration
     public static class CustomConfiguration {
 
-        @Bean
-        GlobalClientInterceptorConfigurer gcic() {
-            return registry -> registry.addClientInterceptors(new CodecValidatingClientInterceptor(CODEC));
+        @GrpcGlobalClientInterceptor
+        CodecValidatingClientInterceptor gcic() {
+            return new CodecValidatingClientInterceptor(CODEC);
         }
 
-        @Bean
-        GlobalServerInterceptorConfigurer gsic() {
-            return registry -> registry.addServerInterceptors(new CodecValidatingServerInterceptor(CODEC));
+        @GrpcGlobalServerInterceptor
+        CodecValidatingServerInterceptor gsic() {
+            return new CodecValidatingServerInterceptor(CODEC);
         }
 
         @Bean

--- a/tests/src/test/java/net/devh/boot/grpc/test/interceptor/PickupClientInterceptorTest.java
+++ b/tests/src/test/java/net/devh/boot/grpc/test/interceptor/PickupClientInterceptorTest.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright (c) 2016-2020 Michael Zhang <yidongnan@gmail.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package net.devh.boot.grpc.test.interceptor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.SpringBootConfiguration;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.stereotype.Component;
+
+import io.grpc.CallOptions;
+import io.grpc.Channel;
+import io.grpc.ClientCall;
+import io.grpc.ClientInterceptor;
+import io.grpc.MethodDescriptor;
+import net.devh.boot.grpc.client.autoconfigure.GrpcClientAutoConfiguration;
+import net.devh.boot.grpc.client.interceptor.AnnotationGlobalClientInterceptorConfigurer;
+import net.devh.boot.grpc.client.interceptor.GlobalClientInterceptorConfigurer;
+import net.devh.boot.grpc.client.interceptor.GlobalClientInterceptorRegistry;
+import net.devh.boot.grpc.client.interceptor.GrpcGlobalClientInterceptor;
+
+/**
+ * Tests that {@link GrpcGlobalClientInterceptor}, {@link GlobalClientInterceptorConfigurer} and
+ * {@link GlobalClientInterceptorRegistry} work as expected.
+ */
+@SpringBootTest
+class PickupClientInterceptorTest {
+
+    @Autowired
+    AnnotationGlobalClientInterceptorConfigurer annotationGlobalClientInterceptorConfigurer;
+
+    @Autowired
+    GlobalClientInterceptorRegistry globalClientInterceptorRegistry;
+
+    @Test
+    void test() {
+        final List<ClientInterceptor> interceptors = new ArrayList<>();
+        this.annotationGlobalClientInterceptorConfigurer.configureClientInterceptors(interceptors);
+        assertThat(interceptors).containsExactlyInAnyOrder(
+                new ConfigAnnotatedClientInterceptor(),
+                new ClassAnnotatedClientInterceptor());
+
+        assertThat(this.globalClientInterceptorRegistry.getClientInterceptors()).containsExactlyInAnyOrder(
+                new ConfigAnnotatedClientInterceptor(),
+                new ClassAnnotatedClientInterceptor(),
+                new ConfigurerClientInterceptor());
+
+    }
+
+    @SpringBootConfiguration
+    @ImportAutoConfiguration(GrpcClientAutoConfiguration.class)
+    @ComponentScan(basePackageClasses = ClassAnnotatedClientInterceptor.class)
+    public static class TestConfig {
+
+        @GrpcGlobalClientInterceptor
+        ConfigAnnotatedClientInterceptor configAnnotatedClientInterceptor() {
+            return new ConfigAnnotatedClientInterceptor();
+        }
+
+        @Bean
+        GlobalClientInterceptorConfigurer globalClientInterceptorConfigurer() {
+            return interceptors -> interceptors.add(new ConfigurerClientInterceptor());
+        }
+
+    }
+
+    /**
+     * Simple No-Op ClientInterceptor for testing purposes.
+     */
+    static class NoOpClientInterceptor implements ClientInterceptor {
+
+        @Override
+        public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(
+                final MethodDescriptor<ReqT, RespT> method,
+                final CallOptions callOptions,
+                final Channel next) {
+            return next.newCall(method, callOptions);
+        }
+
+        @Override
+        public int hashCode() {
+            return getClass().hashCode();
+        }
+
+        @Override
+        // Fake equality for test simplifications
+        public boolean equals(final Object obj) {
+            return obj != null && getClass().equals(obj.getClass());
+        }
+
+    }
+
+    /**
+     * Used to check that {@link GrpcGlobalClientInterceptor} works in {@link Configuration}s.
+     */
+    static class ConfigAnnotatedClientInterceptor extends NoOpClientInterceptor {
+    }
+
+    /**
+     * Used to check that {@link GrpcGlobalClientInterceptor} works on bean classes themselves.
+     */
+    @GrpcGlobalClientInterceptor
+    static class ClassAnnotatedClientInterceptor extends NoOpClientInterceptor {
+    }
+
+    /**
+     * Used to check that {@link GlobalClientInterceptorConfigurer} work.
+     */
+    @Component
+    static class ConfigurerClientInterceptor extends NoOpClientInterceptor {
+    }
+
+    /**
+     * Used to check that {@link ClientInterceptor} aren't picked up randomly.
+     */
+    @Component
+    static class DoNotPickMeUpClientInterceptor extends NoOpClientInterceptor {
+    }
+
+}

--- a/tests/src/test/java/net/devh/boot/grpc/test/interceptor/PickupServerInterceptorTest.java
+++ b/tests/src/test/java/net/devh/boot/grpc/test/interceptor/PickupServerInterceptorTest.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright (c) 2016-2020 Michael Zhang <yidongnan@gmail.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package net.devh.boot.grpc.test.interceptor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.SpringBootConfiguration;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.stereotype.Component;
+
+import io.grpc.Metadata;
+import io.grpc.ServerCall;
+import io.grpc.ServerCall.Listener;
+import io.grpc.ServerCallHandler;
+import io.grpc.ServerInterceptor;
+import net.devh.boot.grpc.server.autoconfigure.GrpcServerAutoConfiguration;
+import net.devh.boot.grpc.server.interceptor.AnnotationGlobalServerInterceptorConfigurer;
+import net.devh.boot.grpc.server.interceptor.GlobalServerInterceptorConfigurer;
+import net.devh.boot.grpc.server.interceptor.GlobalServerInterceptorRegistry;
+import net.devh.boot.grpc.server.interceptor.GrpcGlobalServerInterceptor;
+import net.devh.boot.grpc.server.scope.GrpcRequestScope;
+
+/**
+ * Tests that {@link GrpcGlobalServerInterceptor}, {@link GlobalServerInterceptorConfigurer} and
+ * {@link GlobalServerInterceptorRegistry} work as expected.
+ */
+@SpringBootTest
+class PickupServerInterceptorTest {
+
+    @Autowired
+    AnnotationGlobalServerInterceptorConfigurer annotationGlobalServerInterceptorConfigurer;
+
+    @Autowired
+    GlobalServerInterceptorRegistry globalServerInterceptorRegistry;
+
+    @Autowired
+    GrpcRequestScope grpcRequestScope;
+
+    @Test
+    void test() {
+        final List<ServerInterceptor> interceptors = new ArrayList<>();
+        this.annotationGlobalServerInterceptorConfigurer.configureServerInterceptors(interceptors);
+        assertThat(interceptors).containsExactlyInAnyOrder(
+                new ConfigAnnotatedServerInterceptor(),
+                new ClassAnnotatedServerInterceptor(),
+                this.grpcRequestScope);
+
+        assertThat(this.globalServerInterceptorRegistry.getServerInterceptors()).containsExactlyInAnyOrder(
+                new ConfigAnnotatedServerInterceptor(),
+                new ClassAnnotatedServerInterceptor(),
+                new ConfigurerServerInterceptor(),
+                this.grpcRequestScope);
+
+    }
+
+    @SpringBootConfiguration
+    @ImportAutoConfiguration(GrpcServerAutoConfiguration.class)
+    @ComponentScan(basePackageClasses = ClassAnnotatedServerInterceptor.class)
+    public static class TestConfig {
+
+        @GrpcGlobalServerInterceptor
+        ConfigAnnotatedServerInterceptor configAnnotatedServerInterceptor() {
+            return new ConfigAnnotatedServerInterceptor();
+        }
+
+        @Bean
+        GlobalServerInterceptorConfigurer globalServerInterceptorConfigurer() {
+            return interceptors -> interceptors.add(new ConfigurerServerInterceptor());
+        }
+
+    }
+
+    /**
+     * Simple No-Op ServerInterceptor for testing purposes.
+     */
+    static class NoOpServerInterceptor implements ServerInterceptor {
+
+        @Override
+        public <ReqT, RespT> Listener<ReqT> interceptCall(
+                final ServerCall<ReqT, RespT> call,
+                final Metadata headers,
+                final ServerCallHandler<ReqT, RespT> next) {
+            return next.startCall(call, headers);
+        }
+
+        @Override
+        public int hashCode() {
+            return getClass().hashCode();
+        }
+
+        @Override
+        // Fake equality for test simplifications
+        public boolean equals(final Object obj) {
+            return obj != null && getClass().equals(obj.getClass());
+        }
+
+    }
+
+    /**
+     * Used to check that {@link GrpcGlobalServerInterceptor} works in {@link Configuration}s.
+     */
+    static class ConfigAnnotatedServerInterceptor extends NoOpServerInterceptor {
+    }
+
+    /**
+     * Used to check that {@link GrpcGlobalServerInterceptor} works on bean classes themselves.
+     */
+    @GrpcGlobalServerInterceptor
+    static class ClassAnnotatedServerInterceptor extends NoOpServerInterceptor {
+    }
+
+    /**
+     * Used to check that {@link GlobalServerInterceptorConfigurer} work.
+     */
+    @Component
+    static class ConfigurerServerInterceptor extends NoOpServerInterceptor {
+    }
+
+    /**
+     * Used to check that {@link ServerInterceptor} aren't picked up randomly.
+     */
+    @Component
+    static class DoNotPickMeUpServerInterceptor extends NoOpServerInterceptor {
+    }
+
+}


### PR DESCRIPTION
Fixes #338

- Lazy collect interceptors and global interceptor configurers
- Changed API of global interceptor registry and configurers

Now it is possible to define a global interceptor using the respective annotation in a @Configuration. It is no longer required for (auto) configs with global interceptor and their configurers to be loaded before the grpc channel/server auto config.

