### PR TITLE
Update dependencies, plugins, gradle and move to 2.10.0-SNAPSHOT

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,26 +9,26 @@ buildscript {
         }
     }
     ext {
-        projectVersion = '2.9.0.RELEASE'
+        projectVersion = '2.10.0-SNAPSHOT'
 
         // https://github.com/grpc/grpc-java/releases
-        grpcVersion = '1.30.0'
+        grpcVersion = '1.31.0'
         // https://github.com/protocolbuffers/protobuf/releases
-        protobufVersion = '3.12.2'
-        protobufGradlePluginVersion = '0.8.11'
+        protobufVersion = '3.12.4'
+        protobufGradlePluginVersion = '0.8.12'
 
         // https://github.com/spring-projects/spring-boot/releases
-        springBootVersion = '2.3.1.RELEASE'
+        springBootVersion = '2.3.2.RELEASE'
         // https://github.com/spring-cloud/spring-cloud-release/releases
-        springCloudVersion = 'Hoxton.SR5'
+        springCloudVersion = 'Hoxton.SR7'
         // https://github.com/alibaba/spring-cloud-alibaba/releases
         springCloudAlibabaNacosVersion = '2.2.1.RELEASE'
         // https://github.com/spring-projects/spring-security-oauth/releases/tag/2.5.0.RELEASE
         springSecurityOAuthVersion = '2.5.0.RELEASE'
 
-        lombokPluginVersion = '3.2.0'
-        versioningPluginVersion = '2.10.0'
-        versionsPluginVersion = '0.27.0'
+        lombokPluginVersion = '4.0.0'
+        versioningPluginVersion = '2.14.0'
+        versionsPluginVersion = '0.29.0'
     }
 }
 
@@ -36,13 +36,13 @@ plugins {
     id 'java'
     id 'java-library'
     // future improvement would be to use the version declared above in the ext block instead of repeating it here
-    id 'org.springframework.boot' version '2.3.1.RELEASE' apply false
+    id 'org.springframework.boot' version '2.3.2.RELEASE' apply false
     id 'io.spring.dependency-management' version '1.0.9.RELEASE'
-    id 'net.nemerosa.versioning' version '2.13.1'
+    id 'net.nemerosa.versioning' version '2.14.0'
     id 'com.google.protobuf' version '0.8.12'
     id 'io.franzbecker.gradle-lombok' version '4.0.0' apply false
-    id 'com.github.ben-manes.versions' version '0.28.0' // gradle dependencyUpdates (Takes quite some time)
-    id 'com.diffplug.gradle.spotless' version '4.3.0'
+    id 'com.github.ben-manes.versions' version '0.29.0' // gradle dependencyUpdates (Takes quite some time)
+    id 'com.diffplug.spotless' version '5.1.0'
 }
 
 // If you attempt to build without the `--scan` parameter in `gradle 6.0+` it will cause a build error that it can't find
@@ -58,7 +58,7 @@ if (hasProperty('buildScan')) {
 wrapper {
     // Update using:
     // ./gradlew wrapper --gradle-version=6.5 --distribution-type=bin
-    gradleVersion = '6.5'
+    gradleVersion = '6.5.1'
 }
 
 def buildTimeAndDate = OffsetDateTime.now()
@@ -74,7 +74,7 @@ allprojects {
     apply plugin: 'idea'
     apply plugin: 'eclipse'
     apply plugin: 'io.spring.dependency-management'
-    apply plugin: 'com.diffplug.gradle.spotless'
+    apply plugin: 'com.diffplug.spotless'
     apply plugin: 'io.franzbecker.gradle-lombok'
 
     compileJava {
@@ -230,7 +230,7 @@ allprojects { project ->
                     'https://static.javadoc.io/org.springframework.cloud/spring-cloud-commons/' + springCloudCommonsVersion + '/',
                     // 'https://static.javadoc.io/io.zipkin.brave/brave/' + braveInstrumentationGrpc + '/', // Requires javadoc 11
                     // 'https://static.javadoc.io/io.zipkin.brave/brave-instrumentation-grpc/' + braveInstrumentationGrpc + '/', // Requires javadoc 11
-                    'https://google.github.io/guava/releases/26.0-android/api/docs/'
+                    'https://google.github.io/guava/releases/29.0-android/api/docs/'
             ]
         }
     }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
I totally missed that we forgot to bump the this project's version number after the release. Not sure whether that has any side effects.

- [grpc-java v1.31.0](https://github.com/grpc/grpc-java/releases/tag/v1.31.0)
- [protobuf v3.12.4](https://github.com/protocolbuffers/protobuf/releases/tag/v3.12.4)
- [spring-boot v2.3.2](https://github.com/spring-projects/spring-boot/releases/tag/v2.3.2.RELEASE)
- [spring-cloud Hoxton.SR7](https://github.com/spring-cloud/spring-cloud-release/releases/tag/vHoxton.SR7)