### PR TITLE
Add support for @GrpcService annotations in @Configuration

### DIFF
--- a/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/service/GrpcService.java
+++ b/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/service/GrpcService.java
@@ -23,6 +23,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+import org.springframework.context.annotation.Bean;
 import org.springframework.stereotype.Service;
 
 import io.grpc.BindableService;
@@ -40,12 +41,12 @@ import io.grpc.ServerInterceptors;
  * </p>
  *
  * @author Michael (yidongnan@gmail.com)
- * @since 5/17/16
  */
-@Target(ElementType.TYPE)
+@Target({ElementType.TYPE, ElementType.METHOD})
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
 @Service
+@Bean
 public @interface GrpcService {
 
     /**

--- a/tests/src/test/java/net/devh/boot/grpc/test/config/BeanAnnotatedServiceConfig.java
+++ b/tests/src/test/java/net/devh/boot/grpc/test/config/BeanAnnotatedServiceConfig.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2016-2020 Michael Zhang <yidongnan@gmail.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package net.devh.boot.grpc.test.config;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.google.protobuf.Empty;
+
+import io.grpc.stub.StreamObserver;
+import net.devh.boot.grpc.server.service.GrpcService;
+import net.devh.boot.grpc.test.proto.SomeType;
+import net.devh.boot.grpc.test.proto.TestServiceGrpc.TestServiceImplBase;
+
+@Configuration
+public class BeanAnnotatedServiceConfig {
+
+    @Bean
+    AtomicBoolean invocationCheck() {
+        return new AtomicBoolean(false);
+    }
+
+    @GrpcService
+    TestServiceImplBase testServiceImplBase(final AtomicBoolean invocationCheck) {
+        return new TestServiceImplBase() {
+
+            @Override
+            public void normal(final Empty request, final StreamObserver<SomeType> responseObserver) {
+                invocationCheck.set(true);
+                final SomeType version = SomeType.newBuilder().setVersion("1.2.3").build();
+                responseObserver.onNext(version);
+                responseObserver.onCompleted();
+            }
+
+        };
+    }
+
+}

--- a/tests/src/test/java/net/devh/boot/grpc/test/setup/AbstractSimpleServerClientTest.java
+++ b/tests/src/test/java/net/devh/boot/grpc/test/setup/AbstractSimpleServerClientTest.java
@@ -61,7 +61,7 @@ public abstract class AbstractSimpleServerClientTest {
     protected TestServiceFutureStub testServiceFutureStub;
 
     @PostConstruct
-    public void init() {
+    protected void init() {
         // Test injection
         assertNotNull(this.channel, "channel");
         assertNotNull(this.testServiceBlockingStub, "testServiceBlockingStub");
@@ -77,7 +77,7 @@ public abstract class AbstractSimpleServerClientTest {
      */
     @Test
     @DirtiesContext
-    public void testSuccessfulCall() throws InterruptedException, ExecutionException {
+    void testSuccessfulCall() throws InterruptedException, ExecutionException {
         log.info("--- Starting tests with successful call ---");
         assertEquals("1.2.3",
                 TestServiceGrpc.newBlockingStub(this.channel).normal(Empty.getDefaultInstance()).getVersion());
@@ -95,7 +95,7 @@ public abstract class AbstractSimpleServerClientTest {
      */
     @Test
     @DirtiesContext
-    public void testFailingCall() {
+    void testFailingCall() {
         log.info("--- Starting tests with failing call ---");
         assertThrowsStatus(UNIMPLEMENTED,
                 () -> TestServiceGrpc.newBlockingStub(this.channel).unimplemented(Empty.getDefaultInstance()));

--- a/tests/src/test/java/net/devh/boot/grpc/test/setup/BeanAnnotatedServiceTest.java
+++ b/tests/src/test/java/net/devh/boot/grpc/test/setup/BeanAnnotatedServiceTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2016-2020 Michael Zhang <yidongnan@gmail.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package net.devh.boot.grpc.test.setup;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+import lombok.extern.slf4j.Slf4j;
+import net.devh.boot.grpc.server.service.GrpcService;
+import net.devh.boot.grpc.test.config.BaseAutoConfiguration;
+import net.devh.boot.grpc.test.config.BeanAnnotatedServiceConfig;
+import net.devh.boot.grpc.test.config.InProcessConfiguration;
+
+/**
+ * A test checking that the server picks up a {@link GrpcService} annotated bean from a {@link Configuration}.
+ *
+ * @author Daniel Theuke (daniel.theuke@heuboe.de)
+ */
+@Slf4j
+@SpringBootTest
+@SpringJUnitConfig(classes = {
+        InProcessConfiguration.class,
+        BeanAnnotatedServiceConfig.class,
+        BaseAutoConfiguration.class})
+@DirtiesContext
+class BeanAnnotatedServiceTest extends AbstractSimpleServerClientTest {
+
+    public BeanAnnotatedServiceTest() {
+        log.info("--- BeanAnnotatedServiceTest ---");
+    }
+
+    @Autowired
+    AtomicBoolean invoked;
+
+    @Override
+    @Test
+    void testSuccessfulCall() throws InterruptedException, ExecutionException {
+        assertFalse(this.invoked.get());
+        super.testSuccessfulCall();
+        assertTrue(this.invoked.get());
+    }
+
+}


### PR DESCRIPTION
Fixes #406

Example:

````java
@Configuration
public class BeanAnnotatedServiceConfig {

    @GrpcService
    SomeServiceImpl someServiceImpl() {
        return new SomeServiceImpl();
    }

}
````