### PR TITLE
Update dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,18 +12,18 @@ buildscript {
         projectVersion = '2.11.0-SNAPSHOT'
 
         // https://github.com/grpc/grpc-java/releases
-        grpcVersion = '1.31.1'
+        grpcVersion = '1.32.2'
         // https://github.com/protocolbuffers/protobuf/releases
-        protobufVersion = '3.12.4'
+        protobufVersion = '3.13.0'
         protobufGradlePluginVersion = '0.8.12'
 
         // https://github.com/spring-projects/spring-boot/releases
-        springBootVersion = '2.3.3.RELEASE'
+        springBootVersion = '2.3.4.RELEASE'
         // https://github.com/spring-cloud/spring-cloud-release/releases
-        springCloudVersion = 'Hoxton.SR7'
+        springCloudVersion = 'Hoxton.SR8'
         // https://github.com/alibaba/spring-cloud-alibaba/releases
-        springCloudAlibabaNacosVersion = '2.2.1.RELEASE'
-        // https://github.com/spring-projects/spring-security-oauth/releases/tag/2.5.0.RELEASE
+        springCloudAlibabaNacosVersion = '2.2.3.RELEASE'
+        // https://github.com/spring-projects/spring-security-oauth/releases
         springSecurityOAuthVersion = '2.5.0.RELEASE'
 
         lombokPluginVersion = '4.0.0'
@@ -36,13 +36,13 @@ plugins {
     id 'java'
     id 'java-library'
     // future improvement would be to use the version declared above in the ext block instead of repeating it here
-    id 'org.springframework.boot' version '2.3.3.RELEASE' apply false
+    id 'org.springframework.boot' version '2.3.4.RELEASE' apply false
     id 'io.spring.dependency-management' version '1.0.10.RELEASE'
     id 'net.nemerosa.versioning' version '2.14.0'
-    id 'com.google.protobuf' version '0.8.12'
+    id 'com.google.protobuf' version '0.8.13'
     id 'io.franzbecker.gradle-lombok' version '4.0.0' apply false
-    id 'com.github.ben-manes.versions' version '0.29.0' // gradle dependencyUpdates (Takes quite some time)
-    id 'com.diffplug.spotless' version '5.1.1'
+    id 'com.github.ben-manes.versions' version '0.33.0' // gradle dependencyUpdates
+    id 'com.diffplug.spotless' version '5.7.0'
 }
 
 // If you attempt to build without the `--scan` parameter in `gradle 6.0+` it will cause a build error that it can't find


### PR DESCRIPTION
Fixes #440

* Updated to [grpc-java v1.32.2](https://github.com/grpc/grpc-java/releases/tag/v1.32.2) (was 1.31.1; see also #441)
* Updated to [Protobuf v3.13.0](https://github.com/protocolbuffers/protobuf/releases/tag/v3.13.0) (was 1.12.4)
* Updated to [spring-boot v2.3.4.RELEASE](https://github.com/spring-projects/spring-boot/releases/tag/v2.3.4.RELEASE) (was 2.3.3; see also #440)
