### PR TITLE
Use ServerCall.Listener#onComplete for metric collection instead of ServerCall#close

### DIFF
--- a/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/metric/MetricCollectingClientCallListener.java
+++ b/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/metric/MetricCollectingClientCallListener.java
@@ -17,16 +17,13 @@
 
 package net.devh.boot.grpc.client.metric;
 
-import java.util.function.Function;
+import java.util.function.Consumer;
 
 import io.grpc.ClientCall;
 import io.grpc.ForwardingClientCallListener.SimpleForwardingClientCallListener;
 import io.grpc.Metadata;
 import io.grpc.Status;
-import io.grpc.Status.Code;
 import io.micrometer.core.instrument.Counter;
-import io.micrometer.core.instrument.MeterRegistry;
-import io.micrometer.core.instrument.Timer;
 
 /**
  * A simple forwarding client call listener that collects metrics for micrometer.
@@ -36,32 +33,29 @@ import io.micrometer.core.instrument.Timer;
  */
 class MetricCollectingClientCallListener<A> extends SimpleForwardingClientCallListener<A> {
 
-    private final Timer.Sample timerSample;
     private final Counter responseCounter;
-    private final Function<Code, Timer> timerFunction;
+    private final Consumer<Status.Code> processingDurationTiming;
 
     /**
      * Creates a new delegating ClientCallListener that will wrap the given client call listener to collect metrics.
      *
      * @param delegate The original call to wrap.
-     * @param registry The registry to save the metrics to.
      * @param responseCounter The counter for incoming responses.
-     * @param timerFunction A function that will return a timer for a given status code.
+     * @param processingDurationTiming The consumer used to time the processing duration along with a response status.
      */
     public MetricCollectingClientCallListener(
             final ClientCall.Listener<A> delegate,
-            final MeterRegistry registry,
             final Counter responseCounter,
-            final Function<Code, Timer> timerFunction) {
+            final Consumer<Status.Code> processingDurationTiming) {
+
         super(delegate);
         this.responseCounter = responseCounter;
-        this.timerFunction = timerFunction;
-        this.timerSample = Timer.start(registry);
+        this.processingDurationTiming = processingDurationTiming;
     }
 
     @Override
     public void onClose(final Status status, final Metadata metadata) {
-        this.timerSample.stop(this.timerFunction.apply(status.getCode()));
+        this.processingDurationTiming.accept(status.getCode());
         super.onClose(status, metadata);
     }
 

--- a/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/metric/MetricCollectingClientInterceptor.java
+++ b/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/metric/MetricCollectingClientInterceptor.java
@@ -23,6 +23,7 @@ import static net.devh.boot.grpc.common.metric.MetricConstants.METRIC_NAME_CLIEN
 import static net.devh.boot.grpc.common.metric.MetricUtils.prepareCounterFor;
 import static net.devh.boot.grpc.common.metric.MetricUtils.prepareTimerFor;
 
+import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.UnaryOperator;
 
@@ -104,15 +105,19 @@ public class MetricCollectingClientInterceptor extends AbstractMetricCollectingI
     }
 
     @Override
-    public <Q, A> ClientCall<Q, A> interceptCall(final MethodDescriptor<Q, A> methodDescriptor,
-            final CallOptions callOptions, final Channel channel) {
+    public <Q, A> ClientCall<Q, A> interceptCall(
+            final MethodDescriptor<Q, A> methodDescriptor,
+            final CallOptions callOptions,
+            final Channel channel) {
+
         final MetricSet metrics = metricsFor(methodDescriptor);
+        final Consumer<Code> processingDurationTiming = metrics.newProcessingDurationTiming(this.registry);
+
         return new MetricCollectingClientCall<>(
                 channel.newCall(methodDescriptor, callOptions),
-                this.registry,
                 metrics.getRequestCounter(),
                 metrics.getResponseCounter(),
-                metrics.getTimerFunction());
+                processingDurationTiming);
     }
 
 }

--- a/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/metric/MetricCollectingServerCall.java
+++ b/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/metric/MetricCollectingServerCall.java
@@ -17,16 +17,12 @@
 
 package net.devh.boot.grpc.server.metric;
 
-import java.util.function.Function;
-
 import io.grpc.ForwardingServerCall.SimpleForwardingServerCall;
 import io.grpc.Metadata;
 import io.grpc.ServerCall;
 import io.grpc.Status;
 import io.grpc.Status.Code;
 import io.micrometer.core.instrument.Counter;
-import io.micrometer.core.instrument.MeterRegistry;
-import io.micrometer.core.instrument.Timer;
 
 /**
  * A simple forwarding server call that collects metrics for micrometer.
@@ -38,29 +34,29 @@ import io.micrometer.core.instrument.Timer;
 class MetricCollectingServerCall<Q, A> extends SimpleForwardingServerCall<Q, A> {
 
     private final Counter responseCounter;
-    private final Function<Code, Timer> timerFunction;
-    private final Timer.Sample timerSample;
+    private Code responseCode = Code.UNKNOWN;
 
     /**
      * Creates a new delegating ServerCall that will wrap the given server call to collect metrics.
      *
      * @param delegate The original call to wrap.
-     * @param registry The registry to save the metrics to.
      * @param responseCounter The counter for incoming responses.
-     * @param timerFunction A function that will return a timer for a given status code.
      */
-    public MetricCollectingServerCall(final ServerCall<Q, A> delegate, final MeterRegistry registry,
-            final Counter responseCounter,
-            final Function<Code, Timer> timerFunction) {
+    public MetricCollectingServerCall(
+            final ServerCall<Q, A> delegate,
+            final Counter responseCounter) {
+
         super(delegate);
         this.responseCounter = responseCounter;
-        this.timerFunction = timerFunction;
-        this.timerSample = Timer.start(registry);
+    }
+
+    public Code getResponseCode() {
+        return this.responseCode;
     }
 
     @Override
     public void close(final Status status, final Metadata responseHeaders) {
-        this.timerSample.stop(this.timerFunction.apply(status.getCode()));
+        this.responseCode = status.getCode();
         super.close(status, responseHeaders);
     }
 

--- a/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/metric/MetricCollectingServerCallListener.java
+++ b/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/metric/MetricCollectingServerCallListener.java
@@ -17,8 +17,12 @@
 
 package net.devh.boot.grpc.server.metric;
 
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
 import io.grpc.ForwardingServerCallListener.SimpleForwardingServerCallListener;
-import io.grpc.ServerCall;
+import io.grpc.ServerCall.Listener;
+import io.grpc.Status;
 import io.micrometer.core.instrument.Counter;
 
 /**
@@ -30,22 +34,50 @@ import io.micrometer.core.instrument.Counter;
 class MetricCollectingServerCallListener<Q> extends SimpleForwardingServerCallListener<Q> {
 
     private final Counter requestCounter;
+    private final Supplier<Status.Code> responseCodeSupplier;
+    private final Consumer<Status.Code> responseStatusTiming;
 
     /**
      * Creates a new delegating ServerCallListener that will wrap the given server call listener to collect metrics.
      *
      * @param delegate The original listener to wrap.
      * @param requestCounter The counter for incoming requests.
+     * @param responseCodeSupplier The supplier of the response code.
+     * @param responseStatusTiming The consumer used to time the processing duration along with a response status.
      */
-    public MetricCollectingServerCallListener(final ServerCall.Listener<Q> delegate, final Counter requestCounter) {
+
+    public MetricCollectingServerCallListener(
+            final Listener<Q> delegate,
+            final Counter requestCounter,
+            final Supplier<Status.Code> responseCodeSupplier,
+            final Consumer<Status.Code> responseStatusTiming) {
+
         super(delegate);
         this.requestCounter = requestCounter;
+        this.responseCodeSupplier = responseCodeSupplier;
+        this.responseStatusTiming = responseStatusTiming;
     }
 
     @Override
     public void onMessage(final Q requestMessage) {
         this.requestCounter.increment();
         super.onMessage(requestMessage);
+    }
+
+    @Override
+    public void onComplete() {
+        report(this.responseCodeSupplier.get());
+        super.onComplete();
+    }
+
+    @Override
+    public void onCancel() {
+        report(Status.Code.CANCELLED);
+        super.onCancel();
+    }
+
+    private void report(final Status.Code code) {
+        this.responseStatusTiming.accept(code);
     }
 
 }

--- a/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/metric/MetricCollectingServerInterceptor.java
+++ b/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/metric/MetricCollectingServerInterceptor.java
@@ -23,6 +23,7 @@ import static net.devh.boot.grpc.common.metric.MetricConstants.METRIC_NAME_SERVE
 import static net.devh.boot.grpc.common.metric.MetricUtils.prepareCounterFor;
 import static net.devh.boot.grpc.common.metric.MetricUtils.prepareTimerFor;
 
+import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.UnaryOperator;
 
@@ -36,6 +37,7 @@ import io.grpc.ServerCallHandler;
 import io.grpc.ServerInterceptor;
 import io.grpc.ServerServiceDefinition;
 import io.grpc.ServiceDescriptor;
+import io.grpc.Status;
 import io.grpc.Status.Code;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
@@ -131,11 +133,18 @@ public class MetricCollectingServerInterceptor extends AbstractMetricCollectingI
             final ServerCall<Q, A> call,
             final Metadata requestHeaders,
             final ServerCallHandler<Q, A> next) {
+
         final MetricSet metrics = metricsFor(call.getMethodDescriptor());
-        final ServerCall<Q, A> monitoringCall = new MetricCollectingServerCall<>(call, this.registry,
-                metrics.getResponseCounter(), metrics.getTimerFunction());
+        final Consumer<Status.Code> responseStatusTiming = metrics.newProcessingDurationTiming(this.registry);
+
+        final MetricCollectingServerCall<Q, A> monitoringCall =
+                new MetricCollectingServerCall<>(call, metrics.getResponseCounter());
+
         return new MetricCollectingServerCallListener<>(
-                next.startCall(monitoringCall, requestHeaders), metrics.getRequestCounter());
+                next.startCall(monitoringCall, requestHeaders),
+                metrics.getRequestCounter(),
+                monitoringCall::getResponseCode,
+                responseStatusTiming);
     }
 
 }

--- a/tests/src/test/java/net/devh/boot/grpc/test/metric/MetricCollectingClientInterceptorTest.java
+++ b/tests/src/test/java/net/devh/boot/grpc/test/metric/MetricCollectingClientInterceptorTest.java
@@ -39,7 +39,7 @@ import net.devh.boot.grpc.test.proto.TestServiceGrpc;
 class MetricCollectingClientInterceptorTest {
 
     @Test
-    public void testClientPreRegistration() {
+    void testClientPreRegistration() {
         log.info("--- Starting tests with client pre-registration ---");
         final MeterRegistry meterRegistry = new SimpleMeterRegistry();
         assertEquals(0, meterRegistry.getMeters().size());
@@ -52,7 +52,7 @@ class MetricCollectingClientInterceptorTest {
     }
 
     @Test
-    public void testClientCustomization() {
+    void testClientCustomization() {
         log.info("--- Starting tests with client customization ---");
         final MeterRegistry meterRegistry = new SimpleMeterRegistry();
         assertEquals(0, meterRegistry.getMeters().size());

--- a/tests/src/test/java/net/devh/boot/grpc/test/metric/MetricCollectingServerInterceptorTest.java
+++ b/tests/src/test/java/net/devh/boot/grpc/test/metric/MetricCollectingServerInterceptorTest.java
@@ -40,7 +40,7 @@ import net.devh.boot.grpc.test.server.TestServiceImpl;
 class MetricCollectingServerInterceptorTest {
 
     @Test
-    public void testServerPreRegistration() {
+    void testServerPreRegistration() {
         log.info("--- Starting tests with server pre-registration ---");
         final MeterRegistry meterRegistry = new SimpleMeterRegistry();
         assertEquals(0, meterRegistry.getMeters().size());
@@ -53,7 +53,7 @@ class MetricCollectingServerInterceptorTest {
     }
 
     @Test
-    public void testServerCustomization() {
+    void testServerCustomization() {
         log.info("--- Starting tests with server customization ---");
         final MeterRegistry meterRegistry = new SimpleMeterRegistry();
         assertEquals(0, meterRegistry.getMeters().size());

--- a/tests/src/test/java/net/devh/boot/grpc/test/metric/MetricFullAutoConfigurationTest.java
+++ b/tests/src/test/java/net/devh/boot/grpc/test/metric/MetricFullAutoConfigurationTest.java
@@ -43,14 +43,14 @@ import net.devh.boot.grpc.test.config.ServiceConfiguration;
 @SpringJUnitConfig(classes = ServiceConfiguration.class)
 @EnableAutoConfiguration
 @DirtiesContext
-public class MetricFullAutoConfigurationTest {
+class MetricFullAutoConfigurationTest {
 
     @Autowired
     private MeterRegistry meterRegistry;
 
     @Test
     @DirtiesContext
-    public void testAutoDiscovery() {
+    void testAutoDiscovery() {
         log.info("--- Starting tests with full auto discovery ---");
         assertEquals(METHOD_COUNT * 2, this.meterRegistry.getMeters().stream()
                 .filter(Counter.class::isInstance)

--- a/tests/src/test/java/net/devh/boot/grpc/test/server/TestServiceImpl.java
+++ b/tests/src/test/java/net/devh/boot/grpc/test/server/TestServiceImpl.java
@@ -41,7 +41,7 @@ import net.devh.boot.grpc.test.proto.TestServiceGrpc.TestServiceImplBase;
 @GrpcService
 public class TestServiceImpl extends TestServiceImplBase {
 
-    public static final int METHOD_COUNT = 6;
+    public static final int METHOD_COUNT = 7;
 
     public TestServiceImpl() {
         log.info("Created TestServiceImpl");
@@ -60,6 +60,11 @@ public class TestServiceImpl extends TestServiceImplBase {
         log.debug("unimplemented");
         // Not implemented (on purpose)
         super.unimplemented(request, responseObserver);
+    }
+
+    @Override
+    public StreamObserver<SomeType> echo(StreamObserver<SomeType> responseObserver) {
+        return responseObserver;
     }
 
     @Override

--- a/tests/src/test/proto/TestService.proto
+++ b/tests/src/test/proto/TestService.proto
@@ -14,6 +14,9 @@ service TestService {
     // Unimplemented method
     rpc unimplemented(google.protobuf.Empty) returns (SomeType) {}
 
+    // Returns the incoming requests as is.
+    rpc echo(stream SomeType) returns (stream SomeType) {}
+
     // Secured method
     rpc secure(google.protobuf.Empty) returns (SomeType) {}
 


### PR DESCRIPTION
As documented in https://github.com/grpc/grpc-java/pull/7580, the `ServerCall#close` might not necessarily be called for cancellations so we should use `Listener#onComplete` and `Listener#onCancel` instead.

Closes #438 