### PR TITLE
Added service grace off support

### DIFF
--- a/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/serverfactory/GrpcServerLifecycle.java
+++ b/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/serverfactory/GrpcServerLifecycle.java
@@ -112,6 +112,11 @@ public class GrpcServerLifecycle implements SmartLifecycle {
         final Server localServer = this.server;
         if (localServer != null) {
             localServer.shutdown();
+            try {
+                this.server.awaitTermination();
+            } catch (final InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
             this.server = null;
             log.info("gRPC server shutdown.");
         }


### PR DESCRIPTION
Add graceful shutdown support. This is a problem found in our online environment. Our online traffic is relatively large. During each rolling update, because the service is shut down too quickly, some requests are not completed, causing a large number of requests to report errors. When the main thread is closed, block and wait for all threads to be processed to solve the problem