### PR TITLE
Add support for Netty-Server's UnixChannelOption.SO_REUSEPORT

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ buildscript {
         }
     }
     ext {
-        projectVersion = '2.10.1.RELEASE'
+        projectVersion = '2.10.1.1.RELEASE'
 
         // https://github.com/grpc/grpc-java/releases
         grpcVersion = '1.31.1'

--- a/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/config/GrpcServerProperties.java
+++ b/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/config/GrpcServerProperties.java
@@ -186,6 +186,20 @@ public class GrpcServerProperties {
     private boolean reflectionServiceEnabled = true;
 
     /**
+     * Whether the port allowed to be reused or not. Defaults to {@code false}.
+     * @param reUsePort Whether the port allowed to be reused or not.
+     * @return True, if the port allowed to be reused. False otherwise.
+     */
+    private boolean reUsePort = false;
+
+    /**
+     * Whether the address allowed to be reused or not. Defaults to {@code false}.
+     * @param reUseAddr Whether the address allowed to be reused or not.
+     * @return True, if the address allowed to be reused. False otherwise.
+     */
+    private boolean reUseAddr = false;
+
+    /**
      * Security options for transport security. Defaults to disabled. We strongly recommend to enable this though.
      *
      * @return The security options for transport security.

--- a/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/serverfactory/GrpcServerLifecycle.java
+++ b/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/serverfactory/GrpcServerLifecycle.java
@@ -112,6 +112,12 @@ public class GrpcServerLifecycle implements SmartLifecycle {
         final Server localServer = this.server;
         if (localServer != null) {
             localServer.shutdown();
+
+            try {
+                this.server.awaitTermination();
+            } catch (final InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
             this.server = null;
             log.info("gRPC server shutdown.");
         }

--- a/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/serverfactory/ShadedNettyGrpcServerFactory.java
+++ b/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/serverfactory/ShadedNettyGrpcServerFactory.java
@@ -19,6 +19,7 @@ package net.devh.boot.grpc.server.serverfactory;
 
 import static java.util.Objects.requireNonNull;
 
+import io.grpc.netty.shaded.io.netty.channel.unix.UnixChannelOption;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.InetSocketAddress;
@@ -63,9 +64,23 @@ public class ShadedNettyGrpcServerFactory
         final String address = getAddress();
         final int port = getPort();
         if (GrpcServerProperties.ANY_IP_ADDRESS.equals(address)) {
-            return NettyServerBuilder.forPort(port);
+            NettyServerBuilder nettyServerBuilder=NettyServerBuilder.forPort(port);
+            if(this.properties.isReUsePort()){
+                nettyServerBuilder.withOption(UnixChannelOption.SO_REUSEPORT,true);
+            }
+            if(this.properties.isReUseAddr()){
+                nettyServerBuilder.withOption(UnixChannelOption.SO_REUSEADDR,true);
+            }
+            return nettyServerBuilder;
         } else {
-            return NettyServerBuilder.forAddress(new InetSocketAddress(InetAddresses.forString(address), port));
+            NettyServerBuilder nettyServerBuilder=NettyServerBuilder.forAddress(new InetSocketAddress(InetAddresses.forString(address), port));
+            if(this.properties.isReUsePort()){
+                nettyServerBuilder.withOption(UnixChannelOption.SO_REUSEPORT,true);
+            }
+            if(this.properties.isReUseAddr()){
+                nettyServerBuilder.withOption(UnixChannelOption.SO_REUSEADDR,true);
+            }
+            return nettyServerBuilder;
         }
     }
 


### PR DESCRIPTION
Two feature were added in this PR
1.Port reuse,when using ShadedNettyGrpcServerFactory,anather process can start its server in the same port. 
2.Graceful termination,when receive the signal of kill -15，the service does not stop immediately, but first completes the current task and then exits.