### PR TITLE
gRPC request validation (server-side)

### DIFF
--- a/grpc-common-spring-boot/src/main/java/net/devh/boot/grpc/common/util/InterceptorOrder.java
+++ b/grpc-common-spring-boot/src/main/java/net/devh/boot/grpc/common/util/InterceptorOrder.java
@@ -55,6 +55,10 @@ public final class InterceptorOrder {
      */
     public static final int ORDER_SECURITY_AUTHORISATION = 5200;
     /**
+     * The order value for validating incoming server requests interceptors.
+     */
+    public static final int ORDER_SERVER_REQUEST_VALIDATION = 15000;
+    /**
      * The order value for interceptors that should be executed last. This is equivalent to
      * {@link Ordered#LOWEST_PRECEDENCE}. This is the default for interceptors without specified priority.
      */

--- a/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/validation/GrpcConstraint.java
+++ b/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/validation/GrpcConstraint.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2016-2021 Michael Zhang <yidongnan@gmail.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package net.devh.boot.grpc.server.validation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.springframework.stereotype.Component;
+
+/**
+ * Marker annotation to scan for validation classes, which have to implement {@link GrpcConstraintValidator}. Scanning
+ * is done in {@link GrpcValidationResolver}.
+ *
+ * @author Andjelko Perisic (andjelko.perisic@gmail.com)
+ * @see GrpcConstraintValidator
+ * @see GrpcValidationResolver
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Component
+public @interface GrpcConstraint {
+
+}

--- a/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/validation/GrpcConstraintIsPresent.java
+++ b/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/validation/GrpcConstraintIsPresent.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2016-2021 Michael Zhang <yidongnan@gmail.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package net.devh.boot.grpc.server.validation;
+
+import java.util.Objects;
+
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+import org.springframework.context.annotation.ConditionContext;
+import org.springframework.context.annotation.ConfigurationCondition;
+import org.springframework.core.type.AnnotatedTypeMetadata;
+
+/**
+ * Condition checking if annotation {@link GrpcConstraint @GrpcConstraint} is present. Used to indicate that classes can
+ * be picked up for validation purpose with {@link GrpcValidationResolver}.
+ *
+ * @author Andjelko Perisic (andjelko.perisic@gmail.com)
+ * @see GrpcConstraint
+ * @see GrpcValidationResolver
+ */
+class GrpcConstraintIsPresent implements ConfigurationCondition {
+
+    @Override
+    public ConfigurationPhase getConfigurationPhase() {
+        return ConfigurationPhase.REGISTER_BEAN;
+    }
+
+    @Override
+    public boolean matches(ConditionContext context, AnnotatedTypeMetadata metadata) {
+
+        ConfigurableListableBeanFactory safeBeanFactory =
+                Objects.requireNonNull(context.getBeanFactory(), "ConfigurableListableBeanFactory is null");
+        return !safeBeanFactory.getBeansWithAnnotation(GrpcConstraint.class).isEmpty();
+    }
+}

--- a/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/validation/GrpcConstraintValidator.java
+++ b/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/validation/GrpcConstraintValidator.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2016-2021 Michael Zhang <yidongnan@gmail.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package net.devh.boot.grpc.server.validation;
+
+import com.google.protobuf.MessageLiteOrBuilder;
+
+import net.devh.boot.grpc.server.service.GrpcService;
+
+/**
+ * Implement this interface to perform a request validation for incoming gRPC messages. Subsequently requests received
+ * in {@link GrpcService @GrpcService} are validated.<br>
+ * <b>Hint: </b> Also annotate class with {@link GrpcConstraint @GrpcConstraint} to be picked up.
+ *
+ * @author Andjelko Perisic (andjelko.perisic@gmail.com)
+ * @see GrpcValidationResolver
+ * @see GrpcConstraint
+ */
+public interface GrpcConstraintValidator<E extends MessageLiteOrBuilder> {
+
+    /**
+     * Method invoked to check wheter validation succeds. In case an exeception occurs a
+     * {@link io.grpc.Status.Code#INTERNAL} is sent back to the client with the thrown exception message.
+     *
+     * @param request gRPC request
+     * @return {@code true} if validation successfull, {@code false otherwise}
+     */
+    boolean isValid(E request);
+
+}

--- a/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/validation/GrpcValidationConfig.java
+++ b/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/validation/GrpcValidationConfig.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2016-2021 Michael Zhang <yidongnan@gmail.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package net.devh.boot.grpc.server.validation;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Conditional;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
+
+import net.devh.boot.grpc.common.util.InterceptorOrder;
+import net.devh.boot.grpc.server.interceptor.GrpcGlobalServerInterceptor;
+
+/**
+ * In Order to have valid requests this autoconfiguration is looking for marker annotation
+ * {@link GrpcConstraint @GrpcConstraint}. In case of success, all necessary beans are being instantiated.
+ *
+ * @author Andjelko Perisic (andjelko.perisic@gmail.com)
+ * @see GrpcConstraint
+ * @see GrpcValidationResolver
+ * @see RequestValidationInterceptor
+ */
+@Configuration
+@Conditional(GrpcConstraintIsPresent.class)
+class GrpcValidationConfig {
+
+    @Bean
+    GrpcValidationResolver grpcValidationResolver() {
+        return new GrpcValidationResolver();
+    }
+
+    @GrpcGlobalServerInterceptor
+    @Order(InterceptorOrder.ORDER_SERVER_REQUEST_VALIDATION)
+    RequestValidationInterceptor requestValidationInterceptor(final GrpcValidationResolver grpcValidationResolver) {
+        return new RequestValidationInterceptor(grpcValidationResolver);
+    }
+
+}

--- a/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/validation/GrpcValidationResolver.java
+++ b/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/validation/GrpcValidationResolver.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2016-2021 Michael Zhang <yidongnan@gmail.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package net.devh.boot.grpc.server.validation;
+
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.stream.Collectors;
+
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
+
+import com.google.protobuf.MessageLiteOrBuilder;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Resolving all classes implementing {@link GrpcConstraintValidator} and marked with annotation
+ * {@link GrpcConstraint @GrpcConstraint}. Resolved classes are validation classes for gRPC requests to be validated.
+ * <p>
+ * The Validation is done via {@link RequestValidationInterceptor}. There can be more than one validation class for the
+ * same request type, all of them are being resolved and used for validation.
+ *
+ * @author Andjelko Perisic (andjelko.perisic@gmail.com)
+ * @see GrpcConstraintValidator
+ * @see RequestValidationInterceptor
+ */
+@Slf4j
+class GrpcValidationResolver implements InitializingBean, ApplicationContextAware {
+
+    private Map<String, GrpcConstraintValidator<MessageLiteOrBuilder>> validatorMap;
+    private ApplicationContext applicationContext;
+
+    @Override
+    public void setApplicationContext(ApplicationContext applicationContext) {
+        this.applicationContext = applicationContext;
+    }
+
+    @Override
+    public void afterPropertiesSet() throws Exception {
+
+        validatorMap = applicationContext.getBeansWithAnnotation(GrpcConstraint.class)
+                .entrySet()
+                .stream()
+                .collect(Collectors.toMap(Entry::getKey, this::convertSafely));
+        log.debug("Found {} gRPC validators", validatorMap.size());
+    }
+
+
+    private GrpcConstraintValidator<MessageLiteOrBuilder> convertSafely(Map.Entry<String, Object> entry) {
+
+        Object annotatedValidator = entry.getValue();
+        if (annotatedValidator instanceof GrpcConstraintValidator) {
+            @SuppressWarnings("unchecked")
+            GrpcConstraintValidator<MessageLiteOrBuilder> safeConstraintInstance =
+                    (GrpcConstraintValidator<MessageLiteOrBuilder>) annotatedValidator;
+            return safeConstraintInstance;
+        }
+
+        throw new IllegalStateException(
+                String.format("@GrpcConstraint annotated class [%s] has to implement GrpcConstraintValidator.class",
+                        annotatedValidator.getClass()));
+    }
+
+    /**
+     * Retrieve all {@link GrpcConstraintValidator} which are the same class or at least a superclass of given input
+     * parameter.
+     *
+     * @param request gRPC request
+     * @param <E> type of the gRPC request message
+     * @return validators to be used in conjunction with the request
+     */
+    <E> List<GrpcConstraintValidator<MessageLiteOrBuilder>> findValidators(E request) {
+        return validatorMap.values()
+                .stream()
+                .filter(cs -> checkForGenericTypeArgument(cs, request))
+                .collect(Collectors.toList());
+    }
+
+    private <E> boolean checkForGenericTypeArgument(
+            GrpcConstraintValidator<MessageLiteOrBuilder> grpcConstraintValidator, E request) {
+
+        List<Type> genericTypes = Arrays.asList(grpcConstraintValidator.getClass().getGenericInterfaces());
+
+        return genericTypes.stream()
+                .map(t -> (ParameterizedType) t)
+                .flatMap(pt -> Arrays.stream(pt.getActualTypeArguments()))
+                .map(t -> (Class<?>) t)
+                .anyMatch(c -> c.isAssignableFrom(request.getClass()));
+    }
+
+}

--- a/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/validation/RequestValidationInterceptor.java
+++ b/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/validation/RequestValidationInterceptor.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2016-2021 Michael Zhang <yidongnan@gmail.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package net.devh.boot.grpc.server.validation;
+
+import io.grpc.Metadata;
+import io.grpc.ServerCall;
+import io.grpc.ServerCall.Listener;
+import io.grpc.ServerCallHandler;
+import io.grpc.ServerInterceptor;
+
+/**
+ * Interceptor to validate incoming gRPC requests. Validations are obtained from {@link GrpcValidationResolver} and
+ * processed with {@link RequestValidationListener}.
+ *
+ * @author Andjelko Perisic (andjelko.perisic@gmail.com)
+ * @see RequestValidationListener
+ * @see GrpcValidationResolver
+ */
+class RequestValidationInterceptor implements ServerInterceptor {
+
+    private final GrpcValidationResolver grpcValidationResolver;
+
+    RequestValidationInterceptor(final GrpcValidationResolver grpcValidationResolver) {
+        this.grpcValidationResolver = grpcValidationResolver;
+    }
+
+    @Override
+    public <ReqT, RespT> Listener<ReqT> interceptCall(
+            ServerCall<ReqT, RespT> call,
+            Metadata headers,
+            ServerCallHandler<ReqT, RespT> next) {
+
+        Listener<ReqT> delegate = next.startCall(call, headers);
+        return new RequestValidationListener<>(delegate, call, headers, grpcValidationResolver);
+    }
+
+}

--- a/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/validation/RequestValidationListener.java
+++ b/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/validation/RequestValidationListener.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2016-2021 Michael Zhang <yidongnan@gmail.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package net.devh.boot.grpc.server.validation;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import com.google.protobuf.MessageLiteOrBuilder;
+
+import io.grpc.ForwardingServerCallListener.SimpleForwardingServerCallListener;
+import io.grpc.Metadata;
+import io.grpc.ServerCall;
+import io.grpc.ServerCall.Listener;
+import io.grpc.Status;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Responsible for a proper server-side validation of incoming gRPC requests. There is no restriction in how many
+ * validations of a request type can exist. Every one of them is being applied and validated.<br>
+ * When a validation fails, a {@link Status.Code#INVALID_ARGUMENT} is returned with
+ * {@link ServerCall#close(Status, Metadata)}. In case an exception is raised inside
+ * {@link GrpcConstraintValidator#isValid(MessageLiteOrBuilder)} the {@code Status} is {@link Status.Code#INTERNAL} with
+ * a message from raised exception.
+ *
+ * @author Andjelko Perisic (andjelko.perisic@gmail.com)
+ * @see GrpcValidationResolver
+ */
+@Slf4j
+class RequestValidationListener<ReqT, RespT> extends SimpleForwardingServerCallListener<ReqT> {
+
+    private final ServerCall<ReqT, RespT> serverCall;
+    private final Metadata headers;
+    private final GrpcValidationResolver grpcValidationResolver;
+
+    protected RequestValidationListener(
+            Listener<ReqT> delegate,
+            ServerCall<ReqT, RespT> serverCall,
+            Metadata headers,
+            GrpcValidationResolver grpcValidationResolver) {
+        super(delegate);
+        this.serverCall = serverCall;
+        this.headers = headers;
+        this.grpcValidationResolver = grpcValidationResolver;
+    }
+
+    @Override
+    public void onMessage(ReqT message) {
+
+        List<GrpcConstraintValidator<MessageLiteOrBuilder>> validatorList =
+                grpcValidationResolver.findValidators(message);
+        MessageLiteOrBuilder convertedMessage = (MessageLiteOrBuilder) message;
+        boolean requestIsNotValid = validatorList.stream().anyMatch(v -> isNotValid(v, convertedMessage));
+
+        if (requestIsNotValid) {
+            handleInvalidRequest(validatorList);
+        } else {
+            super.onMessage(message);
+        }
+    }
+
+    private boolean isNotValid(
+            GrpcConstraintValidator<MessageLiteOrBuilder> validator,
+            MessageLiteOrBuilder convertedMessage) {
+
+        try {
+            return !validator.isValid(convertedMessage);
+        } catch (Throwable t) {
+            log.error("Error during validation: " + t);
+            Status status = Status.INTERNAL.withDescription(t.getMessage());
+            serverCall.close(status, headers);
+            return true;
+        }
+    }
+
+    private void handleInvalidRequest(List<GrpcConstraintValidator<MessageLiteOrBuilder>> validatorList) {
+
+        String validators = validatorList.stream()
+                .map(v -> v.getClass().getSimpleName())
+                .collect(Collectors.joining(", "));
+
+        String errorMsg = String.format("Validation error at least in one of [%s]", validators);
+        Status status = Status.INVALID_ARGUMENT.withDescription(errorMsg);
+        serverCall.close(status, headers);
+    }
+
+}


### PR DESCRIPTION
I came across some repeating pattern, a request validation. Clients send a gRPC request and with this functionality just implement `GrpcConstraintValidator` with validation-logic and annotate with `@GrpcConstraint` and the validation is being processed. 
By the time the request enters implemented service via `@GrpcService`, the request was validated successful. Removes boilerplate-code and preserves the real business-logic inside `@GrpcService`.

**Following a simple use case:**

_Proto-file_ - Consider your proto-file, here just a simple one to illustrate use-case
```proto
syntax = "proto3";
option java_multiple_files = true;
package com.github.anjeyy.proto.document;

import "google/protobuf/empty.proto";

message DocumentRequest{
  string docId = 1;
}

message DocumentResponse{
  string docId = 1;
  string title = 2;
  string person = 3;
  int32 filesize = 4;
}

service DocumentService{
  rpc getDocumentById(DocumentRequest) returns (DocumentResponse);
}
```

Now all you need to do, create Validator classes
_DocumentRequestValidator_
```java
@GrpcConstraint
public class DocumentRequestValidator implements GrpcConstraintValidator<DocumentRequest> {

    @Override
    public boolean isValid(DocumentRequest request) {
        return StringUtils.isNotBlank(request.getDocId());
    }
}
```
There can also be multiple Validator of the same Request-Message
```java
@GrpcConstraint
public class SecondDocumentRequestValidator implements GrpcConstraintValidator<DocumentRequest> {

    @Override
    public boolean isValid(DocumentRequest request) {
        try{
            UUID.fromString(request.getDocId());
            return true;
        } catch (IllegalArgumentException exception){
            return false;
        }
}
```

**Side-Note:** If an uncatched exception is thrown inside a Validator the return type to the client is `Status.INTERNAL..`, otherwise it's `Status.INVALID_ARGUMENT..` for failed validations.

---


Currently the implementation works well - the response to the client is exactly how it is inteded to be.
![image](https://user-images.githubusercontent.com/66070554/105613145-0c380000-5dc1-11eb-84f4-1c49dae02a78.png)

However, i came across a (cosmetic?) problem and i do not now how to resolve it elegantly, may be you guys have some suggestions. Situation: The validation fails (either with returning false from `GrpcConstraintValidator.isValid(....)` or a exception is trown inside the validation), in both cases the `serverCall.close(...)` is called and the console prints following thing

```java
2021-01-23 21:26:45.810 ERROR [my-grpc-server,,,] 9804 --- [ault-executor-0] io.grpc.internal.SerializingExecutor     : Exception while executing runnable io.grpc.internal.ServerImpl$JumpToApplicationThreadServerStreamListener$1HalfClosed@73f71ba0

java.lang.IllegalStateException: call already closed
	at com.google.common.base.Preconditions.checkState(Preconditions.java:511) ~[guava-29.0-android.jar:na]
	at io.grpc.internal.ServerCallImpl.closeInternal(ServerCallImpl.java:209) ~[grpc-core-1.31.1.jar:1.31.1]
	at io.grpc.internal.ServerCallImpl.close(ServerCallImpl.java:202) ~[grpc-core-1.31.1.jar:1.31.1]
	at io.grpc.PartialForwardingServerCall.close(PartialForwardingServerCall.java:48) ~[grpc-api-1.31.1.jar:1.31.1]
	at io.grpc.ForwardingServerCall.close(ForwardingServerCall.java:22) ~[grpc-api-1.31.1.jar:1.31.1]
	at io.grpc.ForwardingServerCall$SimpleForwardingServerCall.close(ForwardingServerCall.java:39) ~[grpc-api-1.31.1.jar:1.31.1]
	at net.devh.boot.grpc.server.metric.MetricCollectingServerCall.close(MetricCollectingServerCall.java:64) ~[grpc-server-spring-boot-autoconfigure-2.10.1.RELEASE.jar:2.10.1.RELEASE]
	at brave.grpc.TracingServerInterceptor$TracingServerCall.close(TracingServerInterceptor.java:120) ~[brave-instrumentation-grpc-5.12.4.jar:na]
	at io.grpc.stub.ServerCalls$UnaryServerCallHandler$UnaryServerCallListener.onHalfClose(ServerCalls.java:174) ~[grpc-stub-1.31.1.jar:1.31.1]
	at io.grpc.PartialForwardingServerCallListener.onHalfClose(PartialForwardingServerCallListener.java:35) ~[grpc-api-1.31.1.jar:1.31.1]
	at io.grpc.ForwardingServerCallListener.onHalfClose(ForwardingServerCallListener.java:23) ~[grpc-api-1.31.1.jar:1.31.1]
	at io.grpc.ForwardingServerCallListener$SimpleForwardingServerCallListener.onHalfClose(ForwardingServerCallListener.java:40) ~[grpc-api-1.31.1.jar:1.31.1]
	at brave.grpc.TracingServerInterceptor$TracingServerCallListener.onHalfClose(TracingServerInterceptor.java:153) ~[brave-instrumentation-grpc-5.12.4.jar:na]
	at io.grpc.PartialForwardingServerCallListener.onHalfClose(PartialForwardingServerCallListener.java:35) ~[grpc-api-1.31.1.jar:1.31.1]
	at io.grpc.ForwardingServerCallListener.onHalfClose(ForwardingServerCallListener.java:23) ~[grpc-api-1.31.1.jar:1.31.1]
	at io.grpc.ForwardingServerCallListener$SimpleForwardingServerCallListener.onHalfClose(ForwardingServerCallListener.java:40) ~[grpc-api-1.31.1.jar:1.31.1]
	at io.grpc.PartialForwardingServerCallListener.onHalfClose(PartialForwardingServerCallListener.java:35) ~[grpc-api-1.31.1.jar:1.31.1]
	at io.grpc.ForwardingServerCallListener.onHalfClose(ForwardingServerCallListener.java:23) ~[grpc-api-1.31.1.jar:1.31.1]
	at io.grpc.ForwardingServerCallListener$SimpleForwardingServerCallListener.onHalfClose(ForwardingServerCallListener.java:40) ~[grpc-api-1.31.1.jar:1.31.1]
	at io.grpc.Contexts$ContextualizedServerCallListener.onHalfClose(Contexts.java:86) ~[grpc-api-1.31.1.jar:1.31.1]
	at io.grpc.internal.ServerCallImpl$ServerStreamListenerImpl.halfClosed(ServerCallImpl.java:331) ~[grpc-core-1.31.1.jar:1.31.1]
	at io.grpc.internal.ServerImpl$JumpToApplicationThreadServerStreamListener$1HalfClosed.runInContext(ServerImpl.java:814) ~[grpc-core-1.31.1.jar:1.31.1]
	at io.grpc.internal.ContextRunnable.run(ContextRunnable.java:37) ~[grpc-core-1.31.1.jar:1.31.1]
	at io.grpc.internal.SerializingExecutor.run(SerializingExecutor.java:123) ~[grpc-core-1.31.1.jar:1.31.1]
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128) ~[na:na]
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628) ~[na:na]
	at java.base/java.lang.Thread.run(Thread.java:834) ~[na:na]
```

My guess is there is not much we can do, since this message is from `io.grpc.internal`, but if you have any ideas, please let me know. Like i said for me this is more of a cosmetic error, sinde it can be printed more than once if the close is delegated or being called multiple times.

I'm interesseted in your feedback or in any way what improvements can be made. If you have questions, just let me know.


---

# TODO

- [x] implementation ✔️ 
- [x] javadoc ✔️ 
- [ ] unit tests ➖ _(in progress)_
- [ ] docs with example 🟡 
- [ ] review 🟡 
