### PR TITLE
Ability to expose gRPC health through actuator

### DIFF
--- a/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/autoconfigure/GrpcServerAutoConfiguration.java
+++ b/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/autoconfigure/GrpcServerAutoConfiguration.java
@@ -24,6 +24,7 @@ import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
@@ -36,6 +37,7 @@ import io.grpc.Server;
 import io.grpc.services.HealthStatusManager;
 import net.devh.boot.grpc.common.autoconfigure.GrpcCommonCodecAutoConfiguration;
 import net.devh.boot.grpc.server.config.GrpcServerProperties;
+import net.devh.boot.grpc.server.health.GrpcServerActuatorHealthIndicator;
 import net.devh.boot.grpc.server.interceptor.AnnotationGlobalServerInterceptorConfigurer;
 import net.devh.boot.grpc.server.interceptor.GlobalServerInterceptorRegistry;
 import net.devh.boot.grpc.server.nameresolver.SelfNameResolverFactory;
@@ -112,6 +114,16 @@ public class GrpcServerAutoConfiguration {
     @Bean
     public HealthStatusManager healthStatusManager() {
         return new HealthStatusManager();
+    }
+
+    @ConditionalOnProperty(prefix = "grpc", name = {"healthServiceEnabled", "exposeActuatorHealth"},
+            havingValue = "true", matchIfMissing = true)
+    @ConditionalOnClass(name = "org.springframework.boot.actuate.health.AbstractReactiveHealthIndicator")
+    @Bean
+    public GrpcServerActuatorHealthIndicator actuatorHealthIndicator(final GrpcServerProperties serverProperties) {
+        return new GrpcServerActuatorHealthIndicator(serverProperties.getAddress(),
+                serverProperties.getPort(),
+                serverProperties.getActuatorHealthCheckDeadlineMs());
     }
 
     @ConditionalOnBean(CompressorRegistry.class)

--- a/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/config/GrpcServerProperties.java
+++ b/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/config/GrpcServerProperties.java
@@ -178,6 +178,22 @@ public class GrpcServerProperties {
     private boolean healthServiceEnabled = true;
 
     /**
+     * Whether to expose the health service via as a healthcheck probe.
+     *
+     * @param exposeActuatorHealth Whether gRPC health is exposed as an actuator health probe.
+     * @return True, to expose as an actuator. False otherwise.
+     */
+    private boolean exposeActuatorHealth = true;
+
+    /**
+     * Deadline time to ping the health service.
+     *
+     * @param actuatorHealthCheckDeadlineMs Time to wait for the health response in ms. Defaults to 100
+     * @return the configured deadline time in ms
+     */
+    private long actuatorHealthCheckDeadlineMs = 100L;
+
+    /**
      * Whether proto reflection service is enabled or not. Defaults to {@code true}.
      *
      * @param reflectionServiceEnabled Whether gRPC reflection service is enabled.

--- a/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/health/GrpcServerActuatorHealthIndicator.java
+++ b/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/health/GrpcServerActuatorHealthIndicator.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2016-2021 Michael Zhang <yidongnan@gmail.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package net.devh.boot.grpc.server.health;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.springframework.boot.actuate.health.AbstractReactiveHealthIndicator;
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.Status;
+
+import com.google.common.util.concurrent.FutureCallback;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.MoreExecutors;
+
+import io.grpc.Channel;
+import io.grpc.Deadline;
+import io.grpc.ManagedChannelBuilder;
+import io.grpc.health.v1.HealthCheckRequest;
+import io.grpc.health.v1.HealthCheckResponse;
+import io.grpc.health.v1.HealthGrpc;
+import reactor.core.publisher.Mono;
+
+/**
+ * This class will expose the status of the server into the actuator when it has the "show-components" configuration
+ * set. To retrieve the status the health probe actually hits the server and maps the status
+ */
+public class GrpcServerActuatorHealthIndicator extends AbstractReactiveHealthIndicator {
+
+    private final static String STATUS = "status";
+    private final static String DOWN_STATUS = "DOWN";
+    private HealthGrpc.HealthFutureStub healthCheckClient;
+    private long deadlineMs = 500;
+
+    public GrpcServerActuatorHealthIndicator(String host, int port, long deadline) {
+        String internalHost = host.equals("*") ? "0.0.0.0" : host;
+        Channel channel = ManagedChannelBuilder
+                .forAddress(internalHost, port)
+                .disableRetry()
+                .build();
+        healthCheckClient = HealthGrpc.newFutureStub(channel);
+        if (deadline > 0) {
+            this.deadlineMs = deadline;
+        }
+    }
+
+    @Override
+    protected Mono<Health> doHealthCheck(Health.Builder builder) {
+        ListenableFuture<HealthCheckResponse> responseFuture = healthCheckClient
+                .withDeadline(Deadline.after(deadlineMs, TimeUnit.MILLISECONDS))
+                .check(HealthCheckRequest.newBuilder().build());
+        Mono<Health> ret = Mono.fromFuture(toCompletableFuture(responseFuture))
+                .map(response -> {
+                    HealthCheckResponse.ServingStatus status = response.getStatus();
+                    if (HealthCheckResponse.ServingStatus.SERVING.equals(status)) {
+                        builder.withDetail(STATUS, status.toString()).status(Status.UP);
+                    } else if (HealthCheckResponse.ServingStatus.NOT_SERVING.equals(status)) {
+                        builder.withDetail(STATUS, status.toString()).status(Status.OUT_OF_SERVICE);
+                    } else {
+                        builder.withDetail(STATUS, status.toString()).status(Status.UNKNOWN);
+                    }
+                    return builder.build();
+                })
+                .onErrorReturn(builder.withDetail(STATUS, DOWN_STATUS).status(Status.DOWN).build());
+        return ret;
+    }
+
+    private <V> CompletableFuture<V> toCompletableFuture(ListenableFuture<V> listenableFuture) {
+        CompletableFuture<V> ret = new CompletableFuture<V>();
+        Futures.addCallback(listenableFuture, new FutureCallback<V>() {
+            @Override
+            public void onSuccess(@Nullable V result) {
+                ret.complete(result);
+            }
+
+            @Override
+            public void onFailure(Throwable t) {
+                ret.completeExceptionally(t);
+            }
+        }, MoreExecutors.directExecutor());
+        return ret;
+    }
+}

--- a/tests/build.gradle
+++ b/tests/build.gradle
@@ -76,6 +76,7 @@ dependencies {
     }
 
     testImplementation 'org.springframework.boot:spring-boot-starter-actuator'
+    testImplementation 'io.projectreactor:reactor-core'
     testImplementation 'org.springframework.security:spring-security-config'
     testImplementation 'org.junit.jupiter:junit-jupiter-api'
 


### PR DESCRIPTION
Implements #433 

This PR implements a reactive healthcheck (made it reactive since exposing actuator via webflux is common) that exposes the status of the gRPC server.

The healthcheck is perfromed hitting the actual service since that actually proves that the server is indeed responding. It also follows a strict (yet configurable) deadline and forces a non-retry.

I did not send the event to the liveness/readiness since the whole health endpoint goes to 503 if a component is marked as out of traffic so /actuator/health can be used directly but nothing prevents the bean from also sending the event to the readiness/liveness probe.

No specific tests added in this PR or docs but pending comments I can make changes.