### PR TITLE
Wait for the grpc-server to gracefully shutdown

### DIFF
--- a/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/channelfactory/AbstractChannelFactory.java
+++ b/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/channelfactory/AbstractChannelFactory.java
@@ -134,7 +134,7 @@ public abstract class AbstractChannelFactory<T extends ManagedChannelBuilder<T>>
         final T builder = newChannelBuilder(name);
         configure(builder, name);
         final ManagedChannel channel = builder.build();
-        final Duration timeout = properties.getChannel(name).getImmediateConnectTimeout();
+        final Duration timeout = this.properties.getChannel(name).getImmediateConnectTimeout();
         if (!timeout.isZero()) {
             connectOnStartup(name, channel, timeout);
         }
@@ -260,7 +260,7 @@ public abstract class AbstractChannelFactory<T extends ManagedChannelBuilder<T>>
         }
     }
 
-    private void connectOnStartup(String name, ManagedChannel channel, Duration timeout) {
+    private void connectOnStartup(final String name, final ManagedChannel channel, final Duration timeout) {
         log.debug("Initiating connection to channel {}", name);
         channel.getState(true);
 
@@ -270,7 +270,7 @@ public abstract class AbstractChannelFactory<T extends ManagedChannelBuilder<T>>
         try {
             log.debug("Waiting for connection to channel {}", name);
             connected = !readyLatch.await(timeout.toMillis(), TimeUnit.MILLISECONDS);
-        } catch (InterruptedException e) {
+        } catch (final InterruptedException e) {
             Thread.currentThread().interrupt();
             connected = false;
         }
@@ -280,7 +280,7 @@ public abstract class AbstractChannelFactory<T extends ManagedChannelBuilder<T>>
         log.info("Successfully connected to channel {}", name);
     }
 
-    private void waitForReady(ManagedChannel channel, CountDownLatch readySignal) {
+    private void waitForReady(final ManagedChannel channel, final CountDownLatch readySignal) {
         final ConnectivityState state = channel.getState(false);
         log.debug("Waiting for ready state. Currently in {}", state);
         if (state == ConnectivityState.READY) {

--- a/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/channelfactory/AbstractChannelFactory.java
+++ b/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/channelfactory/AbstractChannelFactory.java
@@ -357,7 +357,8 @@ public abstract class AbstractChannelFactory<T extends ManagedChannelBuilder<T>>
         public ShutdownRecord(final String name, final ManagedChannel channel, final long gracePeriod) {
             this.name = name;
             this.channel = channel;
-            this.gracePeriod = gracePeriod;
+            // gracePeriod < 0 => Infinite
+            this.gracePeriod = gracePeriod < 0 ? Long.MAX_VALUE : gracePeriod;
         }
 
         long getGracePeriod() {

--- a/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/channelfactory/AbstractChannelFactory.java
+++ b/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/channelfactory/AbstractChannelFactory.java
@@ -345,7 +345,7 @@ public abstract class AbstractChannelFactory<T extends ManagedChannelBuilder<T>>
         final int channelCount = this.channels.size();
         this.channels.clear();
         this.channelStates.clear();
-        log.debug("GrpcCannelFactory closed (including {} channels)", channelCount);
+        log.debug("GrpcChannelFactory closed (including {} channels)", channelCount);
     }
 
     private static class ShutdownRecord {

--- a/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/config/GrpcChannelProperties.java
+++ b/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/config/GrpcChannelProperties.java
@@ -270,8 +270,8 @@ public class GrpcChannelProperties {
     private static final Duration DEFAULT_SHUTDOWN_GRACE_PERIOD = Duration.ofSeconds(30);
 
     /**
-     * Gets the time to wait for the channel to gracefully shutdown. If set to {@code -1} the server waits forever. If
-     * set to {@code 0} the server will force shutdown immediately. Defaults to {@code 30s}.
+     * Gets the time to wait for the channel to gracefully shutdown. If set to a negative value, the channel waits
+     * forever. If set to {@code 0} the channel will force shutdown immediately. Defaults to {@code 30s}.
      *
      * @return The time to wait for a graceful shutdown.
      */
@@ -280,8 +280,9 @@ public class GrpcChannelProperties {
     }
 
     /**
-     * Sets the time to wait for the channel to gracefully shutdown (completing all requests). If set to {@code -1} the
-     * channel waits forever. If set to {@code 0} the channel will force shutdown immediately. Defaults to {@code 30s}.
+     * Sets the time to wait for the channel to gracefully shutdown (completing all requests). If set to a negative
+     * value, the channel waits forever. If set to {@code 0} the channel will force shutdown immediately. Defaults to
+     * {@code 30s}.
      *
      * @param shutdownGracePeriod The time to wait for a graceful shutdown.
      */
@@ -457,6 +458,9 @@ public class GrpcChannelProperties {
         }
         if (this.keepAliveWithoutCalls == null) {
             this.keepAliveWithoutCalls = config.keepAliveWithoutCalls;
+        }
+        if (this.shutdownGracePeriod == null) {
+            this.shutdownGracePeriod = config.shutdownGracePeriod;
         }
         if (this.maxInboundMessageSize == null) {
             this.maxInboundMessageSize = config.maxInboundMessageSize;

--- a/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/config/GrpcChannelProperties.java
+++ b/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/config/GrpcChannelProperties.java
@@ -264,6 +264,32 @@ public class GrpcChannelProperties {
     }
 
     // --------------------------------------------------
+
+    @DurationUnit(ChronoUnit.SECONDS)
+    private Duration shutdownGracePeriod;
+    private static final Duration DEFAULT_SHUTDOWN_GRACE_PERIOD = Duration.ofSeconds(30);
+
+    /**
+     * Gets the time to wait for the channel to gracefully shutdown. If set to {@code -1} the server waits forever. If
+     * set to {@code 0} the server will force shutdown immediately. Defaults to {@code 30s}.
+     *
+     * @return The time to wait for a graceful shutdown.
+     */
+    public Duration getShutdownGracePeriod() {
+        return this.shutdownGracePeriod == null ? DEFAULT_SHUTDOWN_GRACE_PERIOD : this.shutdownGracePeriod;
+    }
+
+    /**
+     * Sets the time to wait for the channel to gracefully shutdown (completing all requests). If set to {@code -1} the
+     * channel waits forever. If set to {@code 0} the channel will force shutdown immediately. Defaults to {@code 30s}.
+     *
+     * @param shutdownGracePeriod The time to wait for a graceful shutdown.
+     */
+    public void setShutdownGracePeriod(final Duration shutdownGracePeriod) {
+        this.shutdownGracePeriod = shutdownGracePeriod;
+    }
+
+    // --------------------------------------------------
     // Message Transfer
     // --------------------------------------------------
 

--- a/grpc-client-spring-boot-autoconfigure/src/test/java/net/devh/boot/grpc/client/config/GrpcChannelPropertiesGivenUnitTest.java
+++ b/grpc-client-spring-boot-autoconfigure/src/test/java/net/devh/boot/grpc/client/config/GrpcChannelPropertiesGivenUnitTest.java
@@ -29,7 +29,7 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.util.unit.DataSize;
 
 /**
- * Tests whether the property resolution using suffixes works.
+ * Tests whether the property resolution works when using suffixes.
  */
 @ExtendWith(SpringExtension.class)
 @SpringBootTest(properties = {

--- a/grpc-client-spring-boot-autoconfigure/src/test/java/net/devh/boot/grpc/client/config/GrpcChannelPropertiesNegativeGivenUnitTest.java
+++ b/grpc-client-spring-boot-autoconfigure/src/test/java/net/devh/boot/grpc/client/config/GrpcChannelPropertiesNegativeGivenUnitTest.java
@@ -15,7 +15,7 @@
  * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package net.devh.boot.grpc.server.config;
+package net.devh.boot.grpc.client.config;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -26,27 +26,23 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
-import org.springframework.util.unit.DataSize;
 
 /**
- * Tests whether the property resolution works when using suffixes.
+ * Tests whether the property resolution works with negative values and when using suffixes.
  */
 @ExtendWith(SpringExtension.class)
 @SpringBootTest(properties = {
-        "grpc.server.keepAliveTime=42m",
-        "grpc.server.maxInboundMessageSize=5MB",
-        "grpc.server.maxInboundMetadataSize=10KB"
+        "grpc.client.test.shutdownGracePeriod=-1ms"
 })
-class GrpcServerPropertiesGivenUnitTest {
+class GrpcChannelPropertiesNegativeGivenUnitTest {
 
     @Autowired
-    private GrpcServerProperties grpcServerProperties;
+    private GrpcChannelsProperties grpcChannelsProperties;
 
     @Test
     void test() {
-        assertEquals(Duration.ofMinutes(42), this.grpcServerProperties.getKeepAliveTime());
-        assertEquals(DataSize.ofMegabytes(5), this.grpcServerProperties.getMaxInboundMessageSize());
-        assertEquals(DataSize.ofKilobytes(10), this.grpcServerProperties.getMaxInboundMetadataSize());
+        final GrpcChannelProperties properties = this.grpcChannelsProperties.getChannel("test");
+        assertEquals(Duration.ofMillis(-1), properties.getShutdownGracePeriod());
     }
 
 }

--- a/grpc-client-spring-boot-autoconfigure/src/test/java/net/devh/boot/grpc/client/config/GrpcChannelPropertiesNegativeNoUnitTest.java
+++ b/grpc-client-spring-boot-autoconfigure/src/test/java/net/devh/boot/grpc/client/config/GrpcChannelPropertiesNegativeNoUnitTest.java
@@ -15,7 +15,7 @@
  * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package net.devh.boot.grpc.server.config;
+package net.devh.boot.grpc.client.config;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -26,27 +26,23 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
-import org.springframework.util.unit.DataSize;
 
 /**
- * Tests whether the property resolution works when using suffixes.
+ * Tests whether the property resolution works with negative values and without suffixes.
  */
 @ExtendWith(SpringExtension.class)
 @SpringBootTest(properties = {
-        "grpc.server.keepAliveTime=42m",
-        "grpc.server.maxInboundMessageSize=5MB",
-        "grpc.server.maxInboundMetadataSize=10KB"
+        "grpc.client.test.shutdownGracePeriod=-1"
 })
-class GrpcServerPropertiesGivenUnitTest {
+class GrpcChannelPropertiesNegativeNoUnitTest {
 
     @Autowired
-    private GrpcServerProperties grpcServerProperties;
+    private GrpcChannelsProperties grpcChannelsProperties;
 
     @Test
     void test() {
-        assertEquals(Duration.ofMinutes(42), this.grpcServerProperties.getKeepAliveTime());
-        assertEquals(DataSize.ofMegabytes(5), this.grpcServerProperties.getMaxInboundMessageSize());
-        assertEquals(DataSize.ofKilobytes(10), this.grpcServerProperties.getMaxInboundMetadataSize());
+        final GrpcChannelProperties properties = this.grpcChannelsProperties.getChannel("test");
+        assertEquals(Duration.ofSeconds(-1), properties.getShutdownGracePeriod());
     }
 
 }

--- a/grpc-client-spring-boot-autoconfigure/src/test/java/net/devh/boot/grpc/client/config/GrpcChannelPropertiesNoUnitTest.java
+++ b/grpc-client-spring-boot-autoconfigure/src/test/java/net/devh/boot/grpc/client/config/GrpcChannelPropertiesNoUnitTest.java
@@ -29,7 +29,7 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.util.unit.DataSize;
 
 /**
- * Tests whether the property resolution without suffixes works (backwards compatibility).
+ * Tests whether the property resolution works without suffixes (backwards compatibility).
  */
 @ExtendWith(SpringExtension.class)
 @SpringBootTest(properties = {

--- a/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/autoconfigure/GrpcServerAutoConfiguration.java
+++ b/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/autoconfigure/GrpcServerAutoConfiguration.java
@@ -135,8 +135,8 @@ public class GrpcServerAutoConfiguration {
     @ConditionalOnMissingBean
     @ConditionalOnBean(GrpcServerFactory.class)
     @Bean
-    public GrpcServerLifecycle grpcServerLifecycle(final GrpcServerFactory factory) {
-        return new GrpcServerLifecycle(factory);
+    public GrpcServerLifecycle grpcServerLifecycle(final GrpcServerFactory factory, GrpcServerProperties properties) {
+        return new GrpcServerLifecycle(factory, properties.getGracefullShutdownTimeout());
     }
 
 }

--- a/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/autoconfigure/GrpcServerAutoConfiguration.java
+++ b/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/autoconfigure/GrpcServerAutoConfiguration.java
@@ -136,7 +136,7 @@ public class GrpcServerAutoConfiguration {
     @ConditionalOnBean(GrpcServerFactory.class)
     @Bean
     public GrpcServerLifecycle grpcServerLifecycle(final GrpcServerFactory factory, GrpcServerProperties properties) {
-        return new GrpcServerLifecycle(factory, properties.getGracefullShutdownTimeout());
+        return new GrpcServerLifecycle(factory, properties.getShutdownGracePeriod());
     }
 
 }

--- a/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/autoconfigure/GrpcServerFactoryAutoConfiguration.java
+++ b/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/autoconfigure/GrpcServerFactoryAutoConfiguration.java
@@ -82,12 +82,16 @@ public class GrpcServerFactoryAutoConfiguration {
      * The server lifecycle bean for a shaded netty based server.
      *
      * @param factory The factory used to create the lifecycle.
+     * @param properties The server properties to use.
      * @return The inter-process server lifecycle bean.
      */
     @ConditionalOnBean(ShadedNettyGrpcServerFactory.class)
     @Bean
-    public GrpcServerLifecycle shadedNettyGrpcServerLifecycle(final ShadedNettyGrpcServerFactory factory) {
-        return new GrpcServerLifecycle(factory);
+    public GrpcServerLifecycle shadedNettyGrpcServerLifecycle(
+            final ShadedNettyGrpcServerFactory factory,
+            final GrpcServerProperties properties) {
+
+        return new GrpcServerLifecycle(factory, properties.getGracefullShutdownTimeout());
     }
 
     // Then try the normal netty server
@@ -120,12 +124,16 @@ public class GrpcServerFactoryAutoConfiguration {
      * The server lifecycle bean for netty based server.
      *
      * @param factory The factory used to create the lifecycle.
+     * @param properties The server properties to use.
      * @return The inter-process server lifecycle bean.
      */
     @ConditionalOnBean(NettyGrpcServerFactory.class)
     @Bean
-    public GrpcServerLifecycle nettyGrpcServerLifecycle(final NettyGrpcServerFactory factory) {
-        return new GrpcServerLifecycle(factory);
+    public GrpcServerLifecycle nettyGrpcServerLifecycle(
+            final NettyGrpcServerFactory factory,
+            final GrpcServerProperties properties) {
+
+        return new GrpcServerLifecycle(factory, properties.getGracefullShutdownTimeout());
     }
 
     /**
@@ -153,12 +161,16 @@ public class GrpcServerFactoryAutoConfiguration {
      * The server lifecycle bean for the in-process-server.
      *
      * @param factory The factory used to create the lifecycle.
+     * @param properties The server properties to use.
      * @return The in-process server lifecycle bean.
      */
     @ConditionalOnBean(InProcessGrpcServerFactory.class)
     @Bean
-    public GrpcServerLifecycle inProcessGrpcServerLifecycle(final InProcessGrpcServerFactory factory) {
-        return new GrpcServerLifecycle(factory);
+    public GrpcServerLifecycle inProcessGrpcServerLifecycle(
+            final InProcessGrpcServerFactory factory,
+            final GrpcServerProperties properties) {
+
+        return new GrpcServerLifecycle(factory, properties.getGracefullShutdownTimeout());
     }
 
 }

--- a/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/autoconfigure/GrpcServerFactoryAutoConfiguration.java
+++ b/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/autoconfigure/GrpcServerFactoryAutoConfiguration.java
@@ -91,7 +91,7 @@ public class GrpcServerFactoryAutoConfiguration {
             final ShadedNettyGrpcServerFactory factory,
             final GrpcServerProperties properties) {
 
-        return new GrpcServerLifecycle(factory, properties.getGracefullShutdownTimeout());
+        return new GrpcServerLifecycle(factory, properties.getShutdownGracePeriod());
     }
 
     // Then try the normal netty server
@@ -133,7 +133,7 @@ public class GrpcServerFactoryAutoConfiguration {
             final NettyGrpcServerFactory factory,
             final GrpcServerProperties properties) {
 
-        return new GrpcServerLifecycle(factory, properties.getGracefullShutdownTimeout());
+        return new GrpcServerLifecycle(factory, properties.getShutdownGracePeriod());
     }
 
     /**
@@ -170,7 +170,7 @@ public class GrpcServerFactoryAutoConfiguration {
             final InProcessGrpcServerFactory factory,
             final GrpcServerProperties properties) {
 
-        return new GrpcServerLifecycle(factory, properties.getGracefullShutdownTimeout());
+        return new GrpcServerLifecycle(factory, properties.getShutdownGracePeriod());
     }
 
 }

--- a/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/config/GrpcServerProperties.java
+++ b/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/config/GrpcServerProperties.java
@@ -94,6 +94,17 @@ public class GrpcServerProperties {
     private String inProcessName;
 
     /**
+     * The time to wait for the server to gracefully shutdown (completing all requests after the server started to
+     * shutdown). If set to {@code -1} the server waits forever. If set to {@code 0} the server will force shutdown
+     * immediately. Defaults to {@code 30s}.
+     * 
+     * @param gracefullShutdownTimeout The time to wait for a graceful shutdown.
+     * @return The time to wait for a graceful shutdown.
+     */
+    @DurationUnit(ChronoUnit.SECONDS)
+    private Duration gracefullShutdownTimeout = Duration.of(30, ChronoUnit.SECONDS);
+
+    /**
      * Setting to enable keepAlive. Default to {@code false}.
      *
      * @param enableKeepAlive Whether keep alive should be enabled.

--- a/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/config/GrpcServerProperties.java
+++ b/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/config/GrpcServerProperties.java
@@ -102,7 +102,7 @@ public class GrpcServerProperties {
      * @return The time to wait for a graceful shutdown.
      */
     @DurationUnit(ChronoUnit.SECONDS)
-    private Duration gracefullShutdownTimeout = Duration.of(30, ChronoUnit.SECONDS);
+    private Duration shutdownGracePeriod = Duration.of(30, ChronoUnit.SECONDS);
 
     /**
      * Setting to enable keepAlive. Default to {@code false}.

--- a/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/config/GrpcServerProperties.java
+++ b/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/config/GrpcServerProperties.java
@@ -95,8 +95,8 @@ public class GrpcServerProperties {
 
     /**
      * The time to wait for the server to gracefully shutdown (completing all requests after the server started to
-     * shutdown). If set to {@code -1} the server waits forever. If set to {@code 0} the server will force shutdown
-     * immediately. Defaults to {@code 30s}.
+     * shutdown). If set to a negative value, the server waits forever. If set to {@code 0} the server will force
+     * shutdown immediately. Defaults to {@code 30s}.
      * 
      * @param gracefullShutdownTimeout The time to wait for a graceful shutdown.
      * @return The time to wait for a graceful shutdown.

--- a/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/serverfactory/GrpcServerLifecycle.java
+++ b/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/serverfactory/GrpcServerLifecycle.java
@@ -112,6 +112,11 @@ public class GrpcServerLifecycle implements SmartLifecycle {
         final Server localServer = this.server;
         if (localServer != null) {
             localServer.shutdown();
+            try {
+                this.server.awaitTermination();
+            } catch (final InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
             this.server = null;
             log.info("gRPC server shutdown.");
         }

--- a/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/serverfactory/GrpcServerLifecycle.java
+++ b/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/serverfactory/GrpcServerLifecycle.java
@@ -40,7 +40,7 @@ public class GrpcServerLifecycle implements SmartLifecycle {
     private static AtomicInteger serverCounter = new AtomicInteger(-1);
 
     private final GrpcServerFactory factory;
-    private final Duration gracefulShutdownTimeout;
+    private final Duration shutdownGracePeriod;
 
     private Server server;
 
@@ -48,11 +48,11 @@ public class GrpcServerLifecycle implements SmartLifecycle {
      * Creates a new GrpcServerLifecycle
      *
      * @param factory The server factory to use.
-     * @param gracefulShutdownTimeout The time to wait for the server to gracefully shut down.
+     * @param shutdownGracePeriod The time to wait for the server to gracefully shut down.
      */
-    public GrpcServerLifecycle(final GrpcServerFactory factory, final Duration gracefulShutdownTimeout) {
+    public GrpcServerLifecycle(final GrpcServerFactory factory, final Duration shutdownGracePeriod) {
         this.factory = requireNonNull(factory, "factory");
-        this.gracefulShutdownTimeout = requireNonNull(gracefulShutdownTimeout, "gracefulShutdownTimeout");
+        this.shutdownGracePeriod = requireNonNull(shutdownGracePeriod, "shutdownGracePeriod");
     }
 
     @Override
@@ -124,7 +124,7 @@ public class GrpcServerLifecycle implements SmartLifecycle {
     protected void stopAndReleaseGrpcServer() {
         final Server localServer = this.server;
         if (localServer != null) {
-            final long millis = this.gracefulShutdownTimeout.toMillis();
+            final long millis = this.shutdownGracePeriod.toMillis();
             log.debug("Initiating gRPC server shutdown");
             localServer.shutdown();
             // Wait for the server to shutdown completely before continuing with destroying the spring context

--- a/grpc-server-spring-boot-autoconfigure/src/test/java/net/devh/boot/grpc/server/config/GrpcServerPropertiesNegativeGivenUnitTest.java
+++ b/grpc-server-spring-boot-autoconfigure/src/test/java/net/devh/boot/grpc/server/config/GrpcServerPropertiesNegativeGivenUnitTest.java
@@ -26,27 +26,22 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
-import org.springframework.util.unit.DataSize;
 
 /**
- * Tests whether the property resolution works when using suffixes.
+ * Tests whether the property resolution works with negative values and suffixes.
  */
 @ExtendWith(SpringExtension.class)
 @SpringBootTest(properties = {
-        "grpc.server.keepAliveTime=42m",
-        "grpc.server.maxInboundMessageSize=5MB",
-        "grpc.server.maxInboundMetadataSize=10KB"
+        "grpc.server.shutdownGracePeriod=-1ms"
 })
-class GrpcServerPropertiesGivenUnitTest {
+class GrpcServerPropertiesNegativeGivenUnitTest {
 
     @Autowired
     private GrpcServerProperties grpcServerProperties;
 
     @Test
     void test() {
-        assertEquals(Duration.ofMinutes(42), this.grpcServerProperties.getKeepAliveTime());
-        assertEquals(DataSize.ofMegabytes(5), this.grpcServerProperties.getMaxInboundMessageSize());
-        assertEquals(DataSize.ofKilobytes(10), this.grpcServerProperties.getMaxInboundMetadataSize());
+        assertEquals(Duration.ofMillis(-1), this.grpcServerProperties.getShutdownGracePeriod());
     }
 
 }

--- a/grpc-server-spring-boot-autoconfigure/src/test/java/net/devh/boot/grpc/server/config/GrpcServerPropertiesNegativeNoUnitTest.java
+++ b/grpc-server-spring-boot-autoconfigure/src/test/java/net/devh/boot/grpc/server/config/GrpcServerPropertiesNegativeNoUnitTest.java
@@ -26,27 +26,22 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
-import org.springframework.util.unit.DataSize;
 
 /**
- * Tests whether the property resolution works when using suffixes.
+ * Tests whether the property resolution works with negative values and without suffixes.
  */
 @ExtendWith(SpringExtension.class)
 @SpringBootTest(properties = {
-        "grpc.server.keepAliveTime=42m",
-        "grpc.server.maxInboundMessageSize=5MB",
-        "grpc.server.maxInboundMetadataSize=10KB"
+        "grpc.server.shutdownGracePeriod=-1"
 })
-class GrpcServerPropertiesGivenUnitTest {
+class GrpcServerPropertiesNegativeNoUnitTest {
 
     @Autowired
     private GrpcServerProperties grpcServerProperties;
 
     @Test
     void test() {
-        assertEquals(Duration.ofMinutes(42), this.grpcServerProperties.getKeepAliveTime());
-        assertEquals(DataSize.ofMegabytes(5), this.grpcServerProperties.getMaxInboundMessageSize());
-        assertEquals(DataSize.ofKilobytes(10), this.grpcServerProperties.getMaxInboundMetadataSize());
+        assertEquals(Duration.ofSeconds(-1), this.grpcServerProperties.getShutdownGracePeriod());
     }
 
 }

--- a/grpc-server-spring-boot-autoconfigure/src/test/java/net/devh/boot/grpc/server/config/GrpcServerPropertiesNoUnitTest.java
+++ b/grpc-server-spring-boot-autoconfigure/src/test/java/net/devh/boot/grpc/server/config/GrpcServerPropertiesNoUnitTest.java
@@ -29,7 +29,7 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.util.unit.DataSize;
 
 /**
- * Tests whether the property resolution without suffixes works (backwards compatibility).
+ * Tests whether the property resolution works without suffixes (backwards compatibility).
  */
 @ExtendWith(SpringExtension.class)
 @SpringBootTest(properties = {

--- a/grpc-server-spring-boot-autoconfigure/src/test/java/net/devh/boot/grpc/server/serverfactory/GrpcServerLifecycleTest.java
+++ b/grpc-server-spring-boot-autoconfigure/src/test/java/net/devh/boot/grpc/server/serverfactory/GrpcServerLifecycleTest.java
@@ -1,0 +1,229 @@
+/*
+ * Copyright (c) 2016-2021 Michael Zhang <yidongnan@gmail.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package net.devh.boot.grpc.server.serverfactory;
+
+import static java.time.Duration.ZERO;
+import static java.time.Duration.ofMillis;
+import static java.time.Duration.ofSeconds;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTimeout;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
+import org.opentest4j.AssertionFailedError;
+
+import io.grpc.Server;
+
+/**
+ * Tests for {@link GrpcServerLifecycle}.
+ */
+class GrpcServerLifecycleTest {
+
+    private final GrpcServerFactory factory = mock(GrpcServerFactory.class);
+
+    @BeforeEach
+    void beforeEach() {
+        reset(this.factory);
+        when(this.factory.getAddress()).thenReturn("test");
+        when(this.factory.getPort()).thenReturn(-1);
+
+    }
+
+    @Test
+    void testNoGraceShutdown() {
+        // The server takes 5s seconds to shutdown
+        final TestServer server = new TestServer(5000);
+        when(this.factory.createServer()).thenReturn(server);
+
+        // But we won't wait
+        final GrpcServerLifecycle lifecycle = new GrpcServerLifecycle(this.factory, ZERO);
+
+        lifecycle.start();
+
+        assertFalse(server.isShutdown());
+        assertFalse(server.isTerminated());
+
+        // So the shutdown should complete near instantly
+        assertTimeoutPreemptively(ofMillis(100), (Executable) lifecycle::stop);
+
+        assertTrue(server.isShutdown());
+        assertTrue(server.isTerminated());
+    }
+
+    @Test
+    void testGracefulShutdown() {
+
+        // The server takes 2s seconds to shutdown
+        final TestServer server = new TestServer(2000);
+        when(this.factory.createServer()).thenReturn(server);
+
+        // And we give it 5s to shutdown
+        final GrpcServerLifecycle lifecycle = new GrpcServerLifecycle(this.factory, ofMillis(5000));
+
+        lifecycle.start();
+
+        assertFalse(server.isShutdown());
+        assertFalse(server.isTerminated());
+
+        // So it should finish within 5.1 seconds
+        assertTimeout(ofMillis(5100), (Executable) lifecycle::stop);
+
+        assertTrue(server.isShutdown());
+        assertTrue(server.isTerminated());
+
+    }
+
+    @Test
+    void testAwaitShutdown() {
+
+        // The server takes 2s seconds to shutdown
+        final TestServer server = new TestServer(5000);
+        when(this.factory.createServer()).thenReturn(server);
+
+        // And we give it infinite time to shutdown
+        final GrpcServerLifecycle lifecycle = new GrpcServerLifecycle(this.factory, ofSeconds(-1));
+
+        lifecycle.start();
+
+        assertFalse(server.isShutdown());
+        assertFalse(server.isTerminated());
+
+        final long start = System.currentTimeMillis();
+
+        lifecycle.stop();
+
+        final long duration = System.currentTimeMillis() - start;
+        // We waited for the entire duration
+        assertThat(duration).isBetween(5000L, 5100L);
+
+        assertTrue(server.isShutdown());
+        assertTrue(server.isTerminated());
+
+    }
+
+    @Test
+    void testInterruptShutdown() {
+
+        // The server takes 60s seconds to shutdown
+        final TestServer server = new TestServer(60000);
+        when(this.factory.createServer()).thenReturn(server);
+
+        // And we give it infinite time to shutdown
+        final GrpcServerLifecycle lifecycle = new GrpcServerLifecycle(this.factory, ofSeconds(-1));
+
+        lifecycle.start();
+
+        assertFalse(server.isShutdown());
+        assertFalse(server.isTerminated());
+
+        try {
+            // But we are in a hurry, so we interrupt it after 2s
+            assertTimeoutPreemptively(ofMillis(2000), (Executable) lifecycle::stop);
+            fail("Did not wait for shutdown to complete");
+        } catch (final AssertionFailedError e) {
+            // We failed due to the timeout/interrupt
+            assertThat(e).getCause().matches(t -> "ExecutionTimeoutException".equals(t.getClass().getSimpleName()));
+        }
+
+        // But the server is still properly terminated
+        assertTrue(server.isShutdown());
+        assertTrue(server.isTerminated());
+
+    }
+
+    public class TestServer extends Server {
+
+        private final long shutdownDelayMillis;
+
+        private boolean isShutdown = true;
+        private CountDownLatch countDown = null;
+
+        public TestServer(final long shutdownDelayMillis) {
+            this.shutdownDelayMillis = shutdownDelayMillis;
+        }
+
+        @Override
+        public Server start() throws IOException {
+            this.countDown = new CountDownLatch(1);
+            this.isShutdown = false;
+            return this;
+        }
+
+        @Override
+        public Server shutdown() {
+            this.isShutdown = true;
+            final Thread t = new Thread(() -> {
+                try {
+                    Thread.sleep(this.shutdownDelayMillis);
+                } catch (final InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+                shutdownNow();
+            });
+            t.setName("test-server-shutdown-delay");
+            t.setDaemon(true);
+            t.start();
+            return this;
+        }
+
+        @Override
+        public Server shutdownNow() {
+            this.isShutdown = true;
+            final CountDownLatch localCountDown = this.countDown;
+            this.countDown = null;
+            if (localCountDown != null) {
+                localCountDown.countDown();
+            }
+            return this;
+        }
+
+        @Override
+        public boolean isShutdown() {
+            return this.isShutdown;
+        }
+
+        @Override
+        public boolean isTerminated() {
+            return this.countDown == null;
+        }
+
+        @Override
+        public boolean awaitTermination(final long timeout, final TimeUnit unit) throws InterruptedException {
+            return this.countDown.await(timeout, unit);
+        }
+
+        @Override
+        public void awaitTermination() throws InterruptedException {
+            this.countDown.await();
+        }
+
+    }
+
+}

--- a/tests/src/test/java/net/devh/boot/grpc/test/server/WaitingTestService.java
+++ b/tests/src/test/java/net/devh/boot/grpc/test/server/WaitingTestService.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2016-2021 Michael Zhang <yidongnan@gmail.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package net.devh.boot.grpc.test.server;
+
+import static java.time.Duration.ofMillis;
+import static java.time.Duration.ofSeconds;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
+
+import java.time.Duration;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+
+import com.google.protobuf.Empty;
+
+import io.grpc.stub.StreamObserver;
+import net.devh.boot.grpc.test.proto.SomeType;
+import net.devh.boot.grpc.test.proto.TestServiceGrpc.TestServiceImplBase;
+
+/**
+ * A test service implementation that spends a configurable amount of time processing a request.
+ */
+public class WaitingTestService extends TestServiceImplBase {
+
+    // Queue length = 1 -> Ability to control/await server calls
+    private final BlockingQueue<Long> delays = new ArrayBlockingQueue<>(1);
+
+    /**
+     * The next call will wait the configured amount of time before completing. Allows exactly one call to process. May
+     * only queue up to one call.
+     *
+     * @param delay The delay to wait for.
+     */
+    public synchronized void nextDelay(final Duration delay) {
+        assertTimeoutPreemptively(
+                ofSeconds(1),
+                () -> assertDoesNotThrow(() -> this.delays.put(delay.toMillis())),
+                "Failed to queue delay");
+    }
+
+    /**
+     * Waits until all request have started processing on the server.
+     */
+    public synchronized void awaitAllRequestsArrived() {
+        // Just try to set a value
+        nextDelay(ofMillis(-1));
+        this.delays.clear();
+    }
+
+    @Override
+    public void normal(final Empty request, final StreamObserver<SomeType> responseObserver) {
+        // Simulate processing time
+        assertDoesNotThrow(this::sleep);
+        responseObserver.onNext(SomeType.getDefaultInstance());
+        responseObserver.onCompleted();
+    }
+
+    private void sleep() throws InterruptedException {
+        final long delay = assertTimeoutPreemptively(ofSeconds(1), () -> this.delays.take());
+        if (delay <= 0) {
+            throw new IllegalStateException("Bad delay: " + delay);
+        }
+        Thread.sleep(delay);
+    }
+
+}

--- a/tests/src/test/java/net/devh/boot/grpc/test/shutdown/GrpcChannelLifecycleWithCallsTest.java
+++ b/tests/src/test/java/net/devh/boot/grpc/test/shutdown/GrpcChannelLifecycleWithCallsTest.java
@@ -1,0 +1,199 @@
+/*
+ * Copyright (c) 2016-2021 Michael Zhang <yidongnan@gmail.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package net.devh.boot.grpc.test.shutdown;
+
+import static io.grpc.Status.Code.UNAVAILABLE;
+import static java.time.Duration.ZERO;
+import static java.time.Duration.ofMillis;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static net.devh.boot.grpc.test.util.FutureAssertions.assertFutureEquals;
+import static net.devh.boot.grpc.test.util.GrpcAssertions.assertFutureThrowsStatus;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertTimeout;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
+import org.junit.jupiter.api.function.ThrowingConsumer;
+import org.springframework.context.support.GenericApplicationContext;
+
+import com.google.protobuf.Empty;
+
+import io.grpc.Channel;
+import io.grpc.Server;
+import io.grpc.Status;
+import io.grpc.inprocess.InProcessServerBuilder;
+import net.devh.boot.grpc.client.channelfactory.GrpcChannelFactory;
+import net.devh.boot.grpc.client.channelfactory.InProcessChannelFactory;
+import net.devh.boot.grpc.client.config.GrpcChannelsProperties;
+import net.devh.boot.grpc.client.interceptor.GlobalClientInterceptorRegistry;
+import net.devh.boot.grpc.test.proto.SomeType;
+import net.devh.boot.grpc.test.proto.TestServiceGrpc;
+import net.devh.boot.grpc.test.proto.TestServiceGrpc.TestServiceFutureStub;
+import net.devh.boot.grpc.test.server.WaitingTestService;
+
+/**
+ * Tests for {@link InProcessChannelFactory}'s shutdown behavior using an in-process server/channel.
+ */
+class GrpcChannelLifecycleWithCallsTest {
+
+    private static final int A_BIT_TIME = 100;
+    private static final Empty EMPTY = Empty.getDefaultInstance();
+    static final SomeType SOME_TYPE = SomeType.getDefaultInstance();
+
+    private static final WaitingTestService service = new WaitingTestService();
+    private static final Server server = InProcessServerBuilder.forName("test")
+            .addService(service)
+            .build();
+    private static final GenericApplicationContext applicationContext = new GenericApplicationContext();
+
+    @BeforeAll
+    static void beforeAll() throws IOException {
+        applicationContext.refresh();
+        // Init classes before the actual test, because that is somewhat slow
+        applicationContext.start();
+        server.start();
+        withStub(ZERO, stub -> {
+
+            service.nextDelay(ofMillis(1));
+            stub.normal(EMPTY);
+
+            service.awaitAllRequestsArrived();
+
+        });
+    }
+
+    @AfterAll
+    static void afterAll() {
+        server.shutdownNow();
+        applicationContext.close();
+    }
+
+    @Test
+    void testZeroShutdownGracePeriod() {
+
+        final AtomicReference<Future<SomeType>> request = new AtomicReference<>();
+
+        assertTimeoutPreemptively(ofMillis(A_BIT_TIME),
+                runWithStub(ZERO, stub -> {
+
+                    // Send request (Takes 5s)
+                    service.nextDelay(ofMillis(5000));
+                    request.set(stub.normal(EMPTY));
+
+                    service.awaitAllRequestsArrived();
+
+                }));
+
+        // The request did not complete in time
+        assertFailedShutdown(request);
+    }
+
+    @Test
+    void testShortShutdownGracePeriod() {
+
+        final AtomicReference<Future<SomeType>> request1 = new AtomicReference<>();
+        final AtomicReference<Future<SomeType>> request2 = new AtomicReference<>();
+        final AtomicReference<Future<SomeType>> request3 = new AtomicReference<>();
+
+        assertTimeout(ofMillis(2000 + A_BIT_TIME),
+                runWithStub(ofMillis(2000), stub -> {
+
+                    // Send first request (Takes 1s)
+                    service.nextDelay(ofMillis(1000));
+                    request1.set(stub.normal(EMPTY));
+
+                    // Send second request (Takes 5s)
+                    service.nextDelay(ofMillis(5000));
+                    request2.set(stub.normal(EMPTY));
+
+                    // Send last request (Takes 1s)
+                    service.nextDelay(ofMillis(1000));
+                    request3.set(stub.normal(EMPTY));
+
+                    service.awaitAllRequestsArrived();
+
+                }));
+
+        // First one completed
+        assertCompleted(request1);
+
+        // The second one did not complete in time
+        assertFailedShutdown(request2);
+
+        // Last one completed
+        assertCompleted(request3);
+    }
+
+    @Test
+    void testInfiniteShutdownGracePeriod() {
+
+        final AtomicReference<Future<SomeType>> request = new AtomicReference<>();
+
+        assertTimeoutPreemptively(ofMillis(1000 + A_BIT_TIME),
+                runWithStub(ofMillis(-1), stub -> {
+
+                    // Send request (Takes 1s)
+                    service.nextDelay(ofMillis(1000));
+                    request.set(stub.normal(EMPTY));
+
+                    service.awaitAllRequestsArrived();
+
+                }));
+
+        // Request completed
+        assertCompleted(request);
+    }
+
+    static Executable runWithStub(final Duration shutdownGracePeriod,
+            final ThrowingConsumer<TestServiceFutureStub> executuable) {
+        return () -> withStub(shutdownGracePeriod, executuable);
+    }
+
+    static void withStub(final Duration shutdownGracePeriod,
+            final ThrowingConsumer<TestServiceFutureStub> executuable) {
+
+        final GrpcChannelsProperties properties = new GrpcChannelsProperties();
+        properties.getGlobalChannel().setShutdownGracePeriod(shutdownGracePeriod);
+        try (final GrpcChannelFactory factory = new InProcessChannelFactory(properties,
+                new GlobalClientInterceptorRegistry(applicationContext))) {
+
+            final Channel channel = factory.createChannel("test");
+            final TestServiceFutureStub stub = TestServiceGrpc.newFutureStub(channel);
+            assertDoesNotThrow(() -> executuable.accept(stub));
+        }
+    }
+
+    private <T> void assertFailedShutdown(final AtomicReference<Future<T>> request) {
+        final Status status = assertFutureThrowsStatus(UNAVAILABLE, request.get(), A_BIT_TIME, MILLISECONDS);
+        assertThat(status.getDescription()).contains("shutdownNow");
+    }
+
+    private void assertCompleted(final AtomicReference<Future<SomeType>> request) {
+        assertFutureEquals(SOME_TYPE, request.get(), A_BIT_TIME, MILLISECONDS);
+    }
+
+}

--- a/tests/src/test/java/net/devh/boot/grpc/test/shutdown/GrpcServerLifecycleWithCallsTest.java
+++ b/tests/src/test/java/net/devh/boot/grpc/test/shutdown/GrpcServerLifecycleWithCallsTest.java
@@ -1,0 +1,191 @@
+/*
+ * Copyright (c) 2016-2021 Michael Zhang <yidongnan@gmail.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package net.devh.boot.grpc.test.shutdown;
+
+import static io.grpc.Status.Code.UNAVAILABLE;
+import static java.time.Duration.ZERO;
+import static java.time.Duration.ofMillis;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static net.devh.boot.grpc.test.util.FutureAssertions.assertFutureEquals;
+import static net.devh.boot.grpc.test.util.GrpcAssertions.assertFutureThrowsStatus;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
+
+import java.lang.reflect.Field;
+import java.time.Duration;
+import java.util.concurrent.Future;
+import java.util.function.BiConsumer;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
+
+import com.google.protobuf.Empty;
+
+import io.grpc.ManagedChannel;
+import io.grpc.Status;
+import io.grpc.inprocess.InProcessChannelBuilder;
+import io.grpc.services.HealthStatusManager;
+import net.devh.boot.grpc.server.config.GrpcServerProperties;
+import net.devh.boot.grpc.server.serverfactory.AbstractGrpcServerFactory;
+import net.devh.boot.grpc.server.serverfactory.GrpcServerFactory;
+import net.devh.boot.grpc.server.serverfactory.GrpcServerLifecycle;
+import net.devh.boot.grpc.server.serverfactory.InProcessGrpcServerFactory;
+import net.devh.boot.grpc.server.service.GrpcServiceDefinition;
+import net.devh.boot.grpc.test.proto.SomeType;
+import net.devh.boot.grpc.test.proto.TestServiceGrpc;
+import net.devh.boot.grpc.test.proto.TestServiceGrpc.TestServiceFutureStub;
+import net.devh.boot.grpc.test.server.WaitingTestService;
+
+/**
+ * Tests for {@link GrpcServerLifecycle}'s shutdown behavior using an in-process server/channel.
+ */
+class GrpcServerLifecycleWithCallsTest {
+
+    private static final int A_BIT_TIME = 100;
+    private static final Empty EMPTY = Empty.getDefaultInstance();
+    private static final SomeType SOME_TYPE = SomeType.getDefaultInstance();
+
+    private static ManagedChannel channel;
+    private static TestServiceFutureStub stub;
+
+    @BeforeAll
+    static void beforeAll() {
+        channel = InProcessChannelBuilder.forName("test").build();
+        stub = TestServiceGrpc.newFutureStub(channel);
+    }
+
+    @AfterAll
+    static void afterAll() {
+        channel.shutdownNow();
+    }
+
+    @Test
+    void testZeroShutdownGracePeriod() {
+
+        withServer(ZERO, (service, lifecycle) -> {
+            // Start server
+            lifecycle.start();
+
+            // Send request (Takes 5s)
+            service.nextDelay(ofMillis(5000));
+            final Future<SomeType> request = stub.normal(EMPTY);
+
+            service.awaitAllRequestsArrived();
+
+            // Shutdown and don't wait for graceful shutdown (we give it a short time to finish shutting down)
+            assertTimeoutPreemptively(ofMillis(A_BIT_TIME), (Executable) lifecycle::stop);
+
+            // The request did not complete in time
+            assertFailedShutdown(request);
+        });
+    }
+
+    @Test
+    void testShortShutdownGracePeriod() {
+
+        withServer(ofMillis(2000), (service, lifecycle) -> {
+            // Start server
+            lifecycle.start();
+
+            // Send first request (Takes 1s)
+            service.nextDelay(ofMillis(1000));
+            final Future<SomeType> request1 = stub.normal(EMPTY);
+
+            // Send second request (Takes 5s)
+            service.nextDelay(ofMillis(5000));
+            final Future<SomeType> request2 = stub.normal(EMPTY);
+
+            // Send last request (Takes 1s)
+            service.nextDelay(ofMillis(1000));
+            final Future<SomeType> request3 = stub.normal(EMPTY);
+
+            service.awaitAllRequestsArrived();
+
+            // Shutdown and wait a short amount of time to shutdown gracefully
+            assertTimeoutPreemptively(ofMillis(2000 + A_BIT_TIME), (Executable) lifecycle::stop);
+
+            // First one completed
+            assertCompleted(request1);
+
+            // The second one did not complete in time
+            assertFailedShutdown(request2);
+
+            // Last one completed
+            assertCompleted(request3);
+        });
+    }
+
+    @Test
+    void testInfiniteShutdownGracePeriod() {
+
+        withServer(ofMillis(-1), (service, lifecycle) -> {
+            // Start server
+            lifecycle.start();
+
+            // Send request (Takes 1s)
+            service.nextDelay(ofMillis(1000));
+            final Future<SomeType> request = stub.normal(EMPTY);
+
+            service.awaitAllRequestsArrived();
+
+            // Shutdown and wait for the server to shutdown gracefully
+            assertTimeoutPreemptively(ofMillis(1000 + A_BIT_TIME), (Executable) lifecycle::stop);
+
+            // Request completed
+            assertCompleted(request);
+        });
+    }
+
+    void withServer(final Duration gracefulShutdownTimeout,
+            final BiConsumer<WaitingTestService, GrpcServerLifecycle> executuable) {
+        final GrpcServerFactory factory = new InProcessGrpcServerFactory("test", new GrpcServerProperties());
+        assertDoesNotThrow(() -> {
+            // TODO: Remove that field
+            final Field healthStatusManager = AbstractGrpcServerFactory.class.getDeclaredField("healthStatusManager");
+            healthStatusManager.setAccessible(true);
+            healthStatusManager.set(factory, new HealthStatusManager());
+        });
+        try {
+            final WaitingTestService service = new WaitingTestService();
+
+            factory.addService(new GrpcServiceDefinition("service", WaitingTestService.class, service.bindService()));
+
+            final GrpcServerLifecycle lifecycle = new GrpcServerLifecycle(factory, gracefulShutdownTimeout);
+            try {
+                assertDoesNotThrow(() -> executuable.accept(service, lifecycle));
+            } finally {
+                lifecycle.stop();
+            }
+        } finally {
+            factory.destroy();
+        }
+    }
+
+    private <T> void assertFailedShutdown(final Future<T> request) {
+        final Status status = assertFutureThrowsStatus(UNAVAILABLE, request, A_BIT_TIME, MILLISECONDS);
+        assertThat(status.getDescription()).contains("shutdownNow");
+    }
+
+    private void assertCompleted(final Future<SomeType> request) {
+        assertFutureEquals(SOME_TYPE, request, A_BIT_TIME, MILLISECONDS);
+    }
+
+}

--- a/tests/src/test/java/net/devh/boot/grpc/test/util/GrpcAssertions.java
+++ b/tests/src/test/java/net/devh/boot/grpc/test/util/GrpcAssertions.java
@@ -22,50 +22,110 @@ import static net.devh.boot.grpc.test.util.FutureAssertions.assertFutureThrows;
 import static org.junit.Assert.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.function.UnaryOperator;
 
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.function.Executable;
-
-import com.google.common.util.concurrent.ListenableFuture;
 
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 import io.grpc.internal.testing.StreamRecorder;
 
+/**
+ * Assertions related to gRPC client calls.
+ */
 public final class GrpcAssertions {
 
+    /**
+     * Asserts that the first value in the {@link StreamRecorder} equals the expected value.
+     *
+     * @param <T> The type of the observer's content.
+     * @param expected The expected content.
+     * @param responseObserver The observer to check for the expected content.
+     * @param timeout The maximum time to wait for the result.
+     * @param timeoutUnit The time unit of the {@code timeout} argument.
+     */
     public static <T> void assertFutureFirstEquals(final T expected, final StreamRecorder<T> responseObserver,
             final int timeout, final TimeUnit timeoutUnit) {
         assertFutureFirstEquals(expected, responseObserver, UnaryOperator.identity(), timeout, timeoutUnit);
     }
 
+    /**
+     * Asserts that the first value in the {@link StreamRecorder} equals the expected value.
+     *
+     * @param <T> The type of the unwrapped/expected content.
+     * @param <R> The type of the observer's content.
+     * @param expected The expected content.
+     * @param responseObserver The observer to check for the expected content.
+     * @param unwrapper The function used to extract the content.
+     * @param timeout The maximum time to wait for the result.
+     * @param timeoutUnit The time unit of the {@code timeout} argument.
+     */
     public static <T, R> void assertFutureFirstEquals(final T expected, final StreamRecorder<R> responseObserver,
             final Function<R, T> unwrapper, final int timeout, final TimeUnit timeoutUnit) {
         assertFutureEquals(expected, responseObserver.firstValue(), unwrapper, timeout, timeoutUnit);
     }
 
-    public static Status assertThrowsStatus(final Status.Code code, final Executable executable) {
+    /**
+     * Assert that the given {@link Executable} throws a {@link StatusRuntimeException} with the expected status code.
+     *
+     * @param expectedCode The expected status code.
+     * @param executable The executable to run.
+     * @return The status contained in the exception.
+     * @see Assertions#assertThrows(Class, Executable)
+     */
+    public static Status assertThrowsStatus(final Status.Code expectedCode, final Executable executable) {
         final StatusRuntimeException exception = assertThrows(StatusRuntimeException.class, executable);
-        return assertStatus(code, exception);
+        return assertStatus(expectedCode, exception);
     }
 
-    public static Status assertFutureThrowsStatus(final Status.Code code, final StreamRecorder<?> recorder,
+    /**
+     * Asserts that the given {@link StreamRecorder} throws an {@link ExecutionException} caused by a
+     * {@link StatusRuntimeException} with the expected status code.
+     *
+     * @param expectedCode The expected status code.
+     * @param recorder The recorder expected to throw.
+     * @param timeout The maximum time to wait for the result.
+     * @param timeoutUnit The time unit of the {@code timeout} argument.
+     * @return The status contained in the exception.
+     * @see #assertFutureThrowsStatus(io.grpc.Status.Code, Future, int, TimeUnit)
+     */
+    public static Status assertFutureThrowsStatus(final Status.Code expectedCode, final StreamRecorder<?> recorder,
             final int timeout, final TimeUnit timeoutUnit) {
-        return assertFutureThrowsStatus(code, recorder.firstValue(), timeout, timeoutUnit);
+        return assertFutureThrowsStatus(expectedCode, recorder.firstValue(), timeout, timeoutUnit);
     }
 
-    public static Status assertFutureThrowsStatus(final Status.Code code, final ListenableFuture<?> future,
+    /**
+     * Asserts that the given {@link Future} throws an {@link ExecutionException} caused by a
+     * {@link StatusRuntimeException} with the expected status code.
+     *
+     * @param expectedCode The expected status code.
+     * @param future The future expected to throw.
+     * @param timeout The maximum time to wait for the result.
+     * @param timeoutUnit The time unit of the {@code timeout} argument.
+     * @return The status contained in the exception.
+     */
+    public static Status assertFutureThrowsStatus(final Status.Code expectedCode, final Future<?> future,
             final int timeout, final TimeUnit timeoutUnit) {
         final StatusRuntimeException exception =
                 assertFutureThrows(StatusRuntimeException.class, future, timeout, timeoutUnit);
-        return assertStatus(code, exception);
+        return assertStatus(expectedCode, exception);
     }
 
-    public static Status assertStatus(final Status.Code code, final StatusRuntimeException exception) {
+    /**
+     * Asserts that the given {@link StatusRuntimeException} uses the expected status code.
+     *
+     * @param expectedCode The expected status code.
+     * @param exception The exception to check for the status code.
+     * @return The status contained in the exception.
+     */
+    public static Status assertStatus(final Status.Code expectedCode, final StatusRuntimeException exception) {
         final Status status = exception.getStatus();
-        assertEquals(code, status.getCode());
+        assertEquals(expectedCode, status.getCode());
         return status;
     }
 


### PR DESCRIPTION
Supersedes #454 (Based on @klboke's PR)
Adds #396

Otherwise the spring context might already be shutdown and the calls
fail, because other components are already shutdown.