### PR TITLE
Update client configuration metadata

### DIFF
--- a/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/config/GrpcChannelProperties.java
+++ b/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/config/GrpcChannelProperties.java
@@ -406,7 +406,7 @@ public class GrpcChannelProperties {
      * If set to a positive duration instructs the client to connect to the gRPC endpoint when the GRPC stub is created.
      * As a result the application startup will be slightly slower due to connection process being executed
      * synchronously up to the maximum to connection timeout. If the connection fails, the stub will fail to create with
-     * an exception which in turn causes the application context startup to fail. Defaults to false.
+     * an exception which in turn causes the application context startup to fail. Defaults to {@code 0}.
      *
      * @param immediateConnectTimeout Connection timeout at application startup.
      */

--- a/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/config/GrpcChannelProperties.java
+++ b/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/config/GrpcChannelProperties.java
@@ -403,11 +403,10 @@ public class GrpcChannelProperties {
     }
 
     /**
-     * If set to a positive duration instructs a client to connect to GRPC-endpoint when GRPC stub is created. If it's
-     * set to a positive timeout application startup will be slower due to connection process will be executed
-     * synchronously with maximum to connection timeout. If connection fails stub will fail to create with an exception
-     * which in turn causes context startup to If connection fails stub will fail to create with an exception which in
-     * turn causes context fail. Defaults to false.
+     * If set to a positive duration instructs the client to connect to the gRPC endpoint when the GRPC stub is created.
+     * As a result the application startup will be slightly slower due to connection process being executed
+     * synchronously up to the maximum to connection timeout. If the connection fails, the stub will fail to create with
+     * an exception which in turn causes the application context startup to fail. Defaults to false.
      *
      * @param immediateConnectTimeout Connection timeout at application startup.
      */

--- a/grpc-client-spring-boot-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/grpc-client-spring-boot-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -82,6 +82,13 @@
 			"defaultValue": false
 		},
 		{
+			"name": "grpc.client.GLOBAL.shutdown-grace-period",
+			"type": "java.time.Duration",
+			"sourceType": "net.devh.boot.grpc.client.config.GrpcChannelProperties",
+			"description": "The time to wait for the channel to gracefully shutdown (completing all requests).\nIf set to a negative value, the channel waits forever.\nIf set to 0 the channel will force shutdown immediately.\nDefaults to 30s.",
+			"defaultValue": "30s"
+		},
+		{
 			"name": "grpc.client.GLOBAL.max-inbound-message-size",
 			"type": "org.springframework.util.unit.DataSize",
 			"sourceType": "net.devh.boot.grpc.client.config.GrpcChannelProperties",
@@ -95,7 +102,7 @@
 			"defaultValue": "TLS"
 		},
 		{
-			"name": "grpc.client.GLOBAL.immediate-connection-timeout",
+			"name": "grpc.client.GLOBAL.immediate-connect-timeout",
 			"type": "java.time.Duration",
 			"sourceType": "net.devh.boot.grpc.client.config.GrpcChannelProperties",
 			"description": "Connection timeout at application startup. If set to a positive duration instructs a client to connect to GRPC-endpoint when GRPC stub is created.",
@@ -115,7 +122,7 @@
 		},
 		{
 			"name": "grpc.client.GLOBAL.security.ciphers",
-			"type": "java.lang.String",
+			"type": "java.util.List<java.lang.String>",
 			"sourceType": "net.devh.boot.grpc.client.config.GrpcChannelProperties$Security",
 			"description": "The cipher suite accepted for secure connections (in the order of preference). If not specified (null), then the default suites will be used."
 		},

--- a/grpc-client-spring-boot-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/grpc-client-spring-boot-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -95,6 +95,13 @@
 			"defaultValue": "TLS"
 		},
 		{
+			"name": "grpc.client.GLOBAL.immediate-connection-timeout",
+			"type": "java.time.Duration",
+			"sourceType": "net.devh.boot.grpc.client.config.GrpcChannelProperties",
+			"description": "Connection timeout at application startup. If set to a positive duration instructs a client to connect to GRPC-endpoint when GRPC stub is created.",
+			"defaultValue": 0
+		},
+		{
 			"name": "grpc.client.GLOBAL.security.authority-override",
 			"type": "java.lang.String",
 			"sourceType": "net.devh.boot.grpc.client.config.GrpcChannelProperties$Security",


### PR DESCRIPTION
I was looking for an option to init connection on application startup. This configuration fits perfectly, but I have spent quite a time, since all other options are well described in additional-spring-metadata.
