### PR TITLE
Don't try to setup TLS security for in-process-server

### DIFF
--- a/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/serverfactory/InProcessGrpcServerFactory.java
+++ b/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/serverfactory/InProcessGrpcServerFactory.java
@@ -84,7 +84,8 @@ public class InProcessGrpcServerFactory extends AbstractGrpcServerFactory<InProc
 
     @Override
     protected void configureSecurity(final InProcessServerBuilder builder) {
-        // Nothing to configure here
+        // No need to configure security as we are in process only.
+        // There is also no need to throw exceptions if transport security is configured.
     }
 
     @Override

--- a/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/serverfactory/InProcessGrpcServerFactory.java
+++ b/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/serverfactory/InProcessGrpcServerFactory.java
@@ -83,6 +83,11 @@ public class InProcessGrpcServerFactory extends AbstractGrpcServerFactory<InProc
     }
 
     @Override
+    protected void configureSecurity(final InProcessServerBuilder builder) {
+        // Nothing to configure here
+    }
+
+    @Override
     public String getAddress() {
         return "in-process:" + this.name;
     }

--- a/tests/src/test/java/net/devh/boot/grpc/test/setup/SelfSignedInProcessSetupTest.java
+++ b/tests/src/test/java/net/devh/boot/grpc/test/setup/SelfSignedInProcessSetupTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2016-2021 Michael Zhang <yidongnan@gmail.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package net.devh.boot.grpc.test.setup;
+
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+import lombok.extern.slf4j.Slf4j;
+import net.devh.boot.grpc.test.config.BaseAutoConfiguration;
+import net.devh.boot.grpc.test.config.ServiceConfiguration;
+
+/**
+ * A test checking that the server and client can start and connect to each other with minimal config.
+ *
+ * @author Daniel Theuke (daniel.theuke@heuboe.de)
+ */
+@Slf4j
+@SpringBootTest(properties = {
+        "grpc.server.port=-1",
+        "grpc.server.in-process-name=test",
+        "grpc.server.security.enabled=true",
+        "grpc.server.security.certificateChain=file:src/test/resources/certificates/server.crt",
+        "grpc.server.security.privateKey=file:src/test/resources/certificates/server.key",
+        "grpc.server.security.trustCertCollection=file:src/test/resources/certificates/trusted-clients-collection",
+        "grpc.server.security.clientAuth=REQUIRE",
+
+        "grpc.client.test.address=in-process:test",
+        "grpc.client.test.security.authorityOverride=localhost",
+        "grpc.client.test.security.trustCertCollection=file:src/test/resources/certificates/trusted-servers-collection",
+        "grpc.client.test.security.clientAuthEnabled=true",
+        "grpc.client.test.security.certificateChain=file:src/test/resources/certificates/client1.crt",
+        "grpc.client.test.security.privateKey=file:src/test/resources/certificates/client1.key"})
+@SpringJUnitConfig(classes = {ServiceConfiguration.class, BaseAutoConfiguration.class})
+@DirtiesContext
+public class SelfSignedInProcessSetupTest extends AbstractSimpleServerClientTest {
+
+    public SelfSignedInProcessSetupTest() {
+        log.info("--- SelfSignedInProcessSetupTest ---");
+    }
+
+}


### PR DESCRIPTION
Found in https://github.com/yidongnan/grpc-spring-boot-starter/issues/489#issuecomment-776932214

The related [code](https://github.com/yidongnan/grpc-spring-boot-starter/blob/9d8df50cd67fe7fca757390d7ea372cd8a5f5ce8/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/channelfactory/InProcessChannelFactory.java#L70-L74) for the channel factory seems to be present already.