### PR TITLE
Update spring boot to 2.4.x

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,6 +13,9 @@ buildscript {
 
         // https://github.com/grpc/grpc-java/releases
         grpcVersion = '1.35.0'
+
+        // https://github.com/google/guava/releases
+        guavaVersion = '30.1-jre'
         // https://github.com/protocolbuffers/protobuf/releases
         protobufVersion = '3.14.0'
         protobufGradlePluginVersion = '0.8.12'
@@ -156,6 +159,7 @@ allprojects { project ->
                 mavenBom "org.springframework.boot:spring-boot-starter-parent:${springBootVersion}"
                 mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
                 mavenBom "com.google.protobuf:protobuf-bom:${protobufVersion}"
+                mavenBom "com.google.guava:guava-bom:${guavaVersion}"
                 mavenBom "io.grpc:grpc-bom:${grpcVersion}"
                 mavenBom "org.junit:junit-bom:5.7.0"
             }

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ buildscript {
         }
     }
     ext {
-        projectVersion = '2.11.0.RELEASE'
+        projectVersion = '2.12.0-SNAPSHOT'
 
         // https://github.com/grpc/grpc-java/releases
         grpcVersion = '1.35.0'

--- a/build.gradle
+++ b/build.gradle
@@ -18,9 +18,9 @@ buildscript {
         protobufGradlePluginVersion = '0.8.12'
 
         // https://github.com/spring-projects/spring-boot/releases
-        springBootVersion = '2.3.8.RELEASE'
+        springBootVersion = '2.4.3'
         // https://github.com/spring-cloud/spring-cloud-release/releases
-        springCloudVersion = 'Hoxton.SR9'
+        springCloudVersion = '2020.0.1'
         // https://github.com/alibaba/spring-cloud-alibaba/releases
         springCloudAlibabaNacosVersion = '2.2.3.RELEASE'
         // https://github.com/spring-projects/spring-security-oauth/releases

--- a/examples/cloud-eureka-server/src/main/resources/application.yml
+++ b/examples/cloud-eureka-server/src/main/resources/application.yml
@@ -17,10 +17,11 @@ eureka:
     registerWithEureka: false
     fetchRegistry: false
     serviceUrl:
-            defaultZone: http://localhost:8761/eureka/
+      defaultZone: http://localhost:8761/eureka/
   server:
     enable-self-preservation: false
 
-endpoints:
- shutdown:
-  enabled: true
+management:
+  endpoint:
+    shutdown:
+      enabled: true

--- a/examples/cloud-grpc-client/build.gradle
+++ b/examples/cloud-grpc-client/build.gradle
@@ -6,7 +6,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
-    implementation 'org.springframework.cloud:spring-cloud-starter-zipkin'
+    implementation 'org.springframework.cloud:spring-cloud-sleuth-zipkin'
     implementation 'io.zipkin.brave:brave-instrumentation-grpc'
     implementation project(':grpc-client-spring-boot-starter') // replace to implementation("net.devh:grpc-client-spring-boot-starter:${springBootGrpcVersion}")
     implementation project(':examples:grpc-lib')

--- a/examples/cloud-grpc-client/build.gradle
+++ b/examples/cloud-grpc-client/build.gradle
@@ -6,8 +6,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
-    implementation 'org.springframework.cloud:spring-cloud-sleuth-zipkin'
-    implementation 'io.zipkin.brave:brave-instrumentation-grpc'
+    implementation 'org.springframework.cloud:spring-cloud-starter-sleuth'
     implementation project(':grpc-client-spring-boot-starter') // replace to implementation("net.devh:grpc-client-spring-boot-starter:${springBootGrpcVersion}")
     implementation project(':examples:grpc-lib')
 }

--- a/examples/cloud-grpc-server/build.gradle
+++ b/examples/cloud-grpc-server/build.gradle
@@ -6,8 +6,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
-    implementation 'org.springframework.cloud:spring-cloud-sleuth-zipkin'
-    implementation 'io.zipkin.brave:brave-instrumentation-grpc'
+    implementation 'org.springframework.cloud:spring-cloud-starter-sleuth'
     implementation project(':grpc-server-spring-boot-starter') // replace to implementation "net.devh:grpc-server-spring-boot-starter:${springBootGrpcVersion}"
     implementation project(':examples:grpc-lib')
 }

--- a/examples/cloud-grpc-server/build.gradle
+++ b/examples/cloud-grpc-server/build.gradle
@@ -6,7 +6,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
-    implementation 'org.springframework.cloud:spring-cloud-starter-zipkin'
+    implementation 'org.springframework.cloud:spring-cloud-sleuth-zipkin'
     implementation 'io.zipkin.brave:brave-instrumentation-grpc'
     implementation project(':grpc-server-spring-boot-starter') // replace to implementation "net.devh:grpc-server-spring-boot-starter:${springBootGrpcVersion}"
     implementation project(':examples:grpc-lib')

--- a/grpc-common-spring-boot/build.gradle
+++ b/grpc-common-spring-boot/build.gradle
@@ -15,7 +15,7 @@ dependencies {
     api('org.springframework.boot:spring-boot-starter')
     optionalSupportImplementation('org.springframework.boot:spring-boot-starter-actuator')
     api('io.grpc:grpc-core')
-    optionalSupportImplementation('com.google.guava:guava:30.1-jre')
+    optionalSupportImplementation('com.google.guava:guava')
 
     optionalSupportImplementation('org.springframework.cloud:spring-cloud-starter-sleuth')
     optionalSupportImplementation('io.zipkin.brave:brave-instrumentation-grpc')

--- a/grpc-common-spring-boot/build.gradle
+++ b/grpc-common-spring-boot/build.gradle
@@ -15,7 +15,7 @@ dependencies {
     api('org.springframework.boot:spring-boot-starter')
     optionalSupportImplementation('org.springframework.boot:spring-boot-starter-actuator')
     api('io.grpc:grpc-core')
-    optionalSupportImplementation('com.google.guava:guava')
+    optionalSupportImplementation('com.google.guava:guava:30.1-jre')
 
     optionalSupportImplementation('org.springframework.cloud:spring-cloud-starter-sleuth')
     optionalSupportImplementation('io.zipkin.brave:brave-instrumentation-grpc')

--- a/grpc-common-spring-boot/src/main/java/net/devh/boot/grpc/common/autoconfigure/GrpcCommonTraceAutoConfiguration.java
+++ b/grpc-common-spring-boot/src/main/java/net/devh/boot/grpc/common/autoconfigure/GrpcCommonTraceAutoConfiguration.java
@@ -21,7 +21,7 @@ import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.cloud.sleuth.autoconfig.TraceAutoConfiguration;
+import org.springframework.cloud.sleuth.autoconfig.brave.BraveAutoConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -30,7 +30,7 @@ import brave.grpc.GrpcTracing;
 
 @Configuration(proxyBeanMethods = false)
 @ConditionalOnProperty(value = "spring.sleuth.grpc.enabled", matchIfMissing = true)
-@AutoConfigureAfter(TraceAutoConfiguration.class)
+@AutoConfigureAfter(BraveAutoConfiguration.class)
 @ConditionalOnClass(value = {Tracing.class, GrpcTracing.class})
 public class GrpcCommonTraceAutoConfiguration {
 

--- a/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/autoconfigure/GrpcServerSecurityAutoConfiguration.java
+++ b/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/autoconfigure/GrpcServerSecurityAutoConfiguration.java
@@ -20,7 +20,7 @@ package net.devh.boot.grpc.server.autoconfigure;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
-import org.springframework.boot.autoconfigure.security.servlet.WebSecurityEnablerConfiguration;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.access.AccessDecisionManager;
@@ -61,7 +61,7 @@ import net.devh.boot.grpc.server.security.interceptors.ExceptionTranslatingServe
  */
 @Configuration(proxyBeanMethods = false)
 @ConditionalOnBean(AuthenticationManager.class)
-@AutoConfigureAfter(WebSecurityEnablerConfiguration.class)
+@AutoConfigureAfter(SecurityAutoConfiguration.class)
 public class GrpcServerSecurityAutoConfiguration {
 
     /**


### PR DESCRIPTION
Closes #469

As already stated in issue there are mostly renaming in spring boot. Also 2.4.x only supports spring cloud 2020.0 release train so I updated it too.
Highlights:
`TraceAutoConfiguration` -> `BraveAutoConfiguration` as this starter supports only brave tracer
`WebSecurityEnablerConfiguration` became package-private so I changed it to `SecurityAutoConfiguration`. They do basically the same.
Dependency management entry for google libraries is no more in spring cloud so I hardcoded guava version. Maybe we need to use some bom there, I'm not sure.