### PR TITLE
Improve build to benefit from incremental builds

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,7 +41,7 @@ plugins {
     id 'com.google.protobuf' version '0.8.14'
     id 'io.franzbecker.gradle-lombok' version '4.0.0' apply false
     id 'com.github.ben-manes.versions' version '0.36.0' // gradle dependencyUpdates
-    id 'com.diffplug.spotless' version '5.9.0'
+    id 'com.diffplug.spotless' version '5.11.0'
 }
 
 // If you attempt to build without the `--scan` parameter in `gradle 6.0+` it will cause a build error that it can't find
@@ -95,8 +95,17 @@ allprojects {
         }
         format('misc') {
             target('**/*.gradle', '**/*.md', '**/*.yml')
+            targetExclude('**/build/**/*.*')
             trimTrailingWhitespace()
             endWithNewline()
+        }
+    }
+
+    normalization {
+        runtimeClasspath {
+            metaInf{
+                ignoreAttribute('Build-Time')
+            }
         }
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -57,7 +57,7 @@ if (hasProperty('buildScan')) {
 wrapper {
     // Update using:
     // ./gradlew wrapper --gradle-version=6.5 --distribution-type=bin
-    gradleVersion = '6.7.1'
+    gradleVersion = '6.8.3'
 }
 
 def buildTimeAndDate = OffsetDateTime.now()

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,5 @@
+org.gradle.caching=true
+org.gradle.parallel=true
+org.gradle.vfs.watch=true
+org.gradle.daemon=true
+

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
1. Enable caching, parallel execution, file system watching and the gradle daemon in `gradle.properties` file. For a better understanding of what each does see [gradle configuration properties](https://docs.gradle.org/current/userguide/build_environment.html#sec:gradle_configuration_properties)
2. Ignore the `'Build-Time'` attribute in manifest files that is always changing. See [normalization](https://docs.gradle.org/current/userguide/more_about_tasks.html#sec:meta_inf_normalization)
3. Exclude all build folders and files from spotless