### PR TITLE
Make grpc-services.jar optional + remove grpc health service setup

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -79,11 +79,11 @@ allprojects {
     apply plugin: 'com.diffplug.spotless'
     apply plugin: 'io.franzbecker.gradle-lombok'
 
-	java {
-	    toolchain {
-	        languageVersion = JavaLanguageVersion.of(8)
-	    }
-	}
+    java {
+        toolchain {
+            languageVersion = JavaLanguageVersion.of(8)
+        }
+    }
 
     compileJava {
         sourceCompatibility = JavaVersion.VERSION_1_8

--- a/build.gradle
+++ b/build.gradle
@@ -79,6 +79,12 @@ allprojects {
     apply plugin: 'com.diffplug.spotless'
     apply plugin: 'io.franzbecker.gradle-lombok'
 
+	java {
+	    toolchain {
+	        languageVersion = JavaLanguageVersion.of(8)
+	    }
+	}
+
     compileJava {
         sourceCompatibility = JavaVersion.VERSION_1_8
         targetCompatibility = JavaVersion.VERSION_1_8
@@ -88,6 +94,13 @@ allprojects {
     compileJava.options*.compilerArgs = [
         '-Xlint:all', '-Xlint:-processing'
     ]
+
+    eclipse {
+        classpath {
+            downloadJavadoc = true
+            downloadSources = true
+        }
+    }
 
     spotless {
         java {

--- a/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/autoconfigure/GrpcHealthServiceAutoConfiguration.java
+++ b/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/autoconfigure/GrpcHealthServiceAutoConfiguration.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2016-2021 Michael Zhang <yidongnan@gmail.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package net.devh.boot.grpc.server.autoconfigure;
+
+import org.springframework.boot.autoconfigure.AutoConfigureBefore;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import io.grpc.BindableService;
+import io.grpc.protobuf.services.ProtoReflectionService;
+import io.grpc.services.HealthStatusManager;
+import net.devh.boot.grpc.server.service.GrpcService;
+
+/**
+ * Auto configuration that sets up the grpc health service.
+ *
+ * @author Daniel Theuke (daniel.theuke@heuboe.de)
+ */
+@Configuration
+@ConditionalOnClass(ProtoReflectionService.class)
+@ConditionalOnProperty(prefix = "grpc.server", name = "health-service-enabled", matchIfMissing = true)
+@AutoConfigureBefore(GrpcServerFactoryAutoConfiguration.class)
+public class GrpcHealthServiceAutoConfiguration {
+
+    /**
+     * Creates a new HealthStatusManager instance.
+     *
+     * @return The newly created bean.
+     */
+    @Bean
+    @ConditionalOnMissingBean
+    HealthStatusManager healthStatusManager() {
+        return new HealthStatusManager();
+    }
+
+    @Bean
+    @GrpcService
+    BindableService grpcHealthService(final HealthStatusManager healthStatusManager) {
+        return healthStatusManager.getHealthService();
+    }
+
+}

--- a/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/autoconfigure/GrpcReflectionServiceAutoConfiguration.java
+++ b/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/autoconfigure/GrpcReflectionServiceAutoConfiguration.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2016-2021 Michael Zhang <yidongnan@gmail.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package net.devh.boot.grpc.server.autoconfigure;
+
+import org.springframework.boot.autoconfigure.AutoConfigureBefore;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import io.grpc.BindableService;
+import io.grpc.protobuf.services.ProtoReflectionService;
+import net.devh.boot.grpc.server.service.GrpcService;
+
+/**
+ * Auto configuration that sets up the proto reflection service.
+ *
+ * @author Daniel Theuke (daniel.theuke@heuboe.de)
+ */
+@Configuration
+@ConditionalOnClass(ProtoReflectionService.class)
+@ConditionalOnProperty(prefix = "grpc.server", name = "reflection-service-enabled", matchIfMissing = true)
+@AutoConfigureBefore(GrpcServerFactoryAutoConfiguration.class)
+public class GrpcReflectionServiceAutoConfiguration {
+
+    /**
+     * Creates a new ProtoReflectionService instance.
+     *
+     * @return The newly created bean.
+     */
+    @Bean
+    @GrpcService
+    BindableService protoReflectionService() {
+        return ProtoReflectionService.newInstance();
+    }
+
+}

--- a/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/autoconfigure/GrpcServerAutoConfiguration.java
+++ b/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/autoconfigure/GrpcServerAutoConfiguration.java
@@ -33,7 +33,6 @@ import org.springframework.context.annotation.Lazy;
 import io.grpc.CompressorRegistry;
 import io.grpc.DecompressorRegistry;
 import io.grpc.Server;
-import io.grpc.services.HealthStatusManager;
 import net.devh.boot.grpc.common.autoconfigure.GrpcCommonCodecAutoConfiguration;
 import net.devh.boot.grpc.server.config.GrpcServerProperties;
 import net.devh.boot.grpc.server.interceptor.AnnotationGlobalServerInterceptorConfigurer;
@@ -108,12 +107,6 @@ public class GrpcServerAutoConfiguration {
         return new AnnotationGrpcServiceDiscoverer();
     }
 
-    @ConditionalOnMissingBean
-    @Bean
-    public HealthStatusManager healthStatusManager() {
-        return new HealthStatusManager();
-    }
-
     @ConditionalOnBean(CompressorRegistry.class)
     @Bean
     public GrpcServerConfigurer compressionServerConfigurer(final CompressorRegistry registry) {
@@ -135,7 +128,8 @@ public class GrpcServerAutoConfiguration {
     @ConditionalOnMissingBean
     @ConditionalOnBean(GrpcServerFactory.class)
     @Bean
-    public GrpcServerLifecycle grpcServerLifecycle(final GrpcServerFactory factory, GrpcServerProperties properties) {
+    public GrpcServerLifecycle grpcServerLifecycle(final GrpcServerFactory factory,
+            final GrpcServerProperties properties) {
         return new GrpcServerLifecycle(factory, properties.getShutdownGracePeriod());
     }
 

--- a/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/autoconfigure/GrpcServerAutoConfiguration.java
+++ b/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/autoconfigure/GrpcServerAutoConfiguration.java
@@ -128,7 +128,8 @@ public class GrpcServerAutoConfiguration {
     @ConditionalOnMissingBean
     @ConditionalOnBean(GrpcServerFactory.class)
     @Bean
-    public GrpcServerLifecycle grpcServerLifecycle(final GrpcServerFactory factory,
+    public GrpcServerLifecycle grpcServerLifecycle(
+            final GrpcServerFactory factory,
             final GrpcServerProperties properties) {
         return new GrpcServerLifecycle(factory, properties.getShutdownGracePeriod());
     }

--- a/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/autoconfigure/GrpcServerMetricAutoConfiguration.java
+++ b/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/autoconfigure/GrpcServerMetricAutoConfiguration.java
@@ -40,8 +40,6 @@ import org.springframework.context.annotation.Lazy;
 import io.grpc.BindableService;
 import io.grpc.MethodDescriptor;
 import io.grpc.ServiceDescriptor;
-import io.grpc.protobuf.services.ProtoReflectionService;
-import io.grpc.services.HealthStatusManager;
 import io.micrometer.core.instrument.MeterRegistry;
 import lombok.extern.slf4j.Slf4j;
 import net.devh.boot.grpc.server.config.GrpcServerProperties;
@@ -75,7 +73,7 @@ public class GrpcServerMetricAutoConfiguration {
     @Bean
     @Lazy
     InfoContributor grpcInfoContributor(final GrpcServerProperties properties,
-            final Collection<BindableService> grpcServices, final HealthStatusManager healthStatusManager) {
+            final Collection<BindableService> grpcServices) {
         final Map<String, Object> details = new LinkedHashMap<>();
         details.put("port", properties.getPort());
 
@@ -83,12 +81,7 @@ public class GrpcServerMetricAutoConfiguration {
             // Only expose services via web-info if we do the same via grpc.
             final Map<String, List<String>> services = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
             details.put("services", services);
-            final List<BindableService> mutableGrpcServiceList = new ArrayList<>(grpcServices);
-            mutableGrpcServiceList.add(ProtoReflectionService.newInstance());
-            if (properties.isHealthServiceEnabled()) {
-                mutableGrpcServiceList.add(healthStatusManager.getHealthService());
-            }
-            for (final BindableService grpcService : mutableGrpcServiceList) {
+            for (final BindableService grpcService : grpcServices) {
                 final ServiceDescriptor serviceDescriptor = grpcService.bindService().getServiceDescriptor();
 
                 final List<String> methods = collectMethodNamesForService(serviceDescriptor);

--- a/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/config/GrpcServerProperties.java
+++ b/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/config/GrpcServerProperties.java
@@ -181,14 +181,6 @@ public class GrpcServerProperties {
     private DataSize maxInboundMetadataSize = null;
 
     /**
-     * Whether gRPC health service is enabled or not. Defaults to {@code true}.
-     *
-     * @param healthServiceEnabled Whether gRPC health service is enabled.
-     * @return True, if the health service is enabled. False otherwise.
-     */
-    private boolean healthServiceEnabled = true;
-
-    /**
      * Whether proto reflection service is enabled or not. Defaults to {@code true}.
      *
      * @param reflectionServiceEnabled Whether gRPC reflection service is enabled.

--- a/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/config/GrpcServerProperties.java
+++ b/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/config/GrpcServerProperties.java
@@ -181,6 +181,14 @@ public class GrpcServerProperties {
     private DataSize maxInboundMetadataSize = null;
 
     /**
+     * Whether gRPC health service is enabled or not. Defaults to {@code true}.
+     *
+     * @param healthServiceEnabled Whether gRPC health service is enabled.
+     * @return True, if the health service is enabled. False otherwise.
+     */
+    private boolean healthServiceEnabled = true;
+
+    /**
      * Whether proto reflection service is enabled or not. Defaults to {@code true}.
      *
      * @param reflectionServiceEnabled Whether gRPC reflection service is enabled.

--- a/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/serverfactory/AbstractGrpcServerFactory.java
+++ b/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/serverfactory/AbstractGrpcServerFactory.java
@@ -23,19 +23,12 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.util.unit.DataSize;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Lists;
 
 import io.grpc.Server;
 import io.grpc.ServerBuilder;
-import io.grpc.health.v1.HealthCheckResponse;
-import io.grpc.health.v1.HealthGrpc;
-import io.grpc.protobuf.services.ProtoReflectionService;
-import io.grpc.reflection.v1alpha.ServerReflectionGrpc;
-import io.grpc.services.HealthStatusManager;
 import lombok.extern.slf4j.Slf4j;
 import net.devh.boot.grpc.server.config.GrpcServerProperties;
 import net.devh.boot.grpc.server.service.GrpcServiceDefinition;
@@ -56,17 +49,13 @@ public abstract class AbstractGrpcServerFactory<T extends ServerBuilder<T>> impl
     protected final GrpcServerProperties properties;
     protected final List<GrpcServerConfigurer> serverConfigurers;
 
-    @Autowired
-    @VisibleForTesting
-    HealthStatusManager healthStatusManager;
-
     /**
      * Creates a new server factory with the given properties.
      *
      * @param properties The properties used to configure the server.
      * @param serverConfigurers The server configurers to use. Can be empty.
      */
-    public AbstractGrpcServerFactory(final GrpcServerProperties properties,
+    protected AbstractGrpcServerFactory(final GrpcServerProperties properties,
             final List<GrpcServerConfigurer> serverConfigurers) {
         this.properties = requireNonNull(properties, "properties");
         this.serverConfigurers = requireNonNull(serverConfigurers, "serverConfigurers");
@@ -110,17 +99,6 @@ public abstract class AbstractGrpcServerFactory<T extends ServerBuilder<T>> impl
     protected void configureServices(final T builder) {
         final Set<String> serviceNames = new LinkedHashSet<>();
 
-        // support health check
-        if (this.properties.isHealthServiceEnabled()) {
-            builder.addService(this.healthStatusManager.getHealthService());
-            serviceNames.add(HealthGrpc.getServiceDescriptor().getName());
-        }
-        // gRPC reflection
-        if (this.properties.isReflectionServiceEnabled()) {
-            builder.addService(ProtoReflectionService.newInstance());
-            serviceNames.add(ServerReflectionGrpc.getServiceDescriptor().getName());
-        }
-
         for (final GrpcServiceDefinition service : this.serviceList) {
             final String serviceName = service.getDefinition().getServiceDescriptor().getName();
             if (!serviceNames.add(serviceName)) {
@@ -129,7 +107,6 @@ public abstract class AbstractGrpcServerFactory<T extends ServerBuilder<T>> impl
             log.info("Registered gRPC service: " + serviceName + ", bean: " + service.getBeanName() + ", class: "
                     + service.getBeanClazz().getName());
             builder.addService(service.getDefinition());
-            this.healthStatusManager.setStatus(serviceName, HealthCheckResponse.ServingStatus.SERVING);
         }
     }
 
@@ -184,14 +161,6 @@ public abstract class AbstractGrpcServerFactory<T extends ServerBuilder<T>> impl
     @Override
     public void addService(final GrpcServiceDefinition service) {
         this.serviceList.add(service);
-    }
-
-    @Override
-    public void destroy() {
-        for (final GrpcServiceDefinition grpcServiceDefinition : this.serviceList) {
-            final String serviceName = grpcServiceDefinition.getDefinition().getServiceDescriptor().getName();
-            this.healthStatusManager.clearStatus(serviceName);
-        }
     }
 
 }

--- a/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/serverfactory/GrpcServerFactory.java
+++ b/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/serverfactory/GrpcServerFactory.java
@@ -17,8 +17,6 @@
 
 package net.devh.boot.grpc.server.serverfactory;
 
-import org.springframework.beans.factory.DisposableBean;
-
 import io.grpc.Server;
 import net.devh.boot.grpc.server.service.GrpcServiceDefinition;
 
@@ -28,7 +26,7 @@ import net.devh.boot.grpc.server.service.GrpcServiceDefinition;
  * @author Michael (yidongnan@gmail.com)
  * @since 5/17/16
  */
-public interface GrpcServerFactory extends DisposableBean {
+public interface GrpcServerFactory {
 
     /**
      * Creates a new grpc server with the stored options. The entire lifecycle management of the server should be
@@ -63,11 +61,5 @@ public interface GrpcServerFactory extends DisposableBean {
      * @param service The service to add to the grpc server.
      */
     void addService(GrpcServiceDefinition service);
-
-    /**
-     * Destroys this factory. This does not destroy or shutdown any server that was created using this factory.
-     */
-    @Override
-    void destroy();
 
 }

--- a/grpc-server-spring-boot-autoconfigure/src/main/resources/META-INF/spring.factories
+++ b/grpc-server-spring-boot-autoconfigure/src/main/resources/META-INF/spring.factories
@@ -1,6 +1,7 @@
 # AutoConfiguration
 org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
 net.devh.boot.grpc.server.autoconfigure.GrpcAdviceAutoConfiguration,\
+net.devh.boot.grpc.server.autoconfigure.GrpcHealthServiceAutoConfiguration,\
 net.devh.boot.grpc.server.autoconfigure.GrpcMetadataConsulConfiguration,\
 net.devh.boot.grpc.server.autoconfigure.GrpcMetadataEurekaConfiguration,\
 net.devh.boot.grpc.server.autoconfigure.GrpcMetadataNacosConfiguration,\

--- a/grpc-server-spring-boot-autoconfigure/src/main/resources/META-INF/spring.factories
+++ b/grpc-server-spring-boot-autoconfigure/src/main/resources/META-INF/spring.factories
@@ -1,12 +1,13 @@
 # AutoConfiguration
 org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
+net.devh.boot.grpc.server.autoconfigure.GrpcAdviceAutoConfiguration,\
 net.devh.boot.grpc.server.autoconfigure.GrpcMetadataConsulConfiguration,\
 net.devh.boot.grpc.server.autoconfigure.GrpcMetadataEurekaConfiguration,\
 net.devh.boot.grpc.server.autoconfigure.GrpcMetadataNacosConfiguration,\
 net.devh.boot.grpc.server.autoconfigure.GrpcMetadataZookeeperConfiguration,\
+net.devh.boot.grpc.server.autoconfigure.GrpcReflectionServiceAutoConfiguration,\
 net.devh.boot.grpc.server.autoconfigure.GrpcServerAutoConfiguration,\
 net.devh.boot.grpc.server.autoconfigure.GrpcServerFactoryAutoConfiguration,\
-net.devh.boot.grpc.server.autoconfigure.GrpcServerSecurityAutoConfiguration,\
 net.devh.boot.grpc.server.autoconfigure.GrpcServerMetricAutoConfiguration,\
-net.devh.boot.grpc.server.autoconfigure.GrpcServerTraceAutoConfiguration,\
-net.devh.boot.grpc.server.autoconfigure.GrpcAdviceAutoConfiguration
+net.devh.boot.grpc.server.autoconfigure.GrpcServerSecurityAutoConfiguration,\
+net.devh.boot.grpc.server.autoconfigure.GrpcServerTraceAutoConfiguration

--- a/grpc-server-spring-boot-autoconfigure/src/test/java/net/devh/boot/grpc/server/autoconfigure/AwaitableStreamObserver.java
+++ b/grpc-server-spring-boot-autoconfigure/src/test/java/net/devh/boot/grpc/server/autoconfigure/AwaitableStreamObserver.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2016-2021 Michael Zhang <yidongnan@gmail.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package net.devh.boot.grpc.server.autoconfigure;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+
+import io.grpc.stub.StreamObserver;
+
+class AwaitableStreamObserver<V> implements StreamObserver<V> {
+
+    private final CountDownLatch doneLatch = new CountDownLatch(1);
+    private final List<V> results = new ArrayList<>();
+    private volatile Throwable error;
+
+    @Override
+    public void onNext(final V value) {
+        this.results.add(value);
+    }
+
+    @Override
+    public void onError(final Throwable t) {
+        this.error = t;
+        this.doneLatch.countDown();
+    }
+
+    @Override
+    public void onCompleted() {
+        this.doneLatch.countDown();
+    }
+
+    public V getFirst() throws InterruptedException {
+        this.doneLatch.await();
+        if (this.error != null) {
+            throw new IllegalStateException("Request failed with unexpected error", this.error);
+        }
+        if (this.results.isEmpty()) {
+            throw new IllegalStateException("Requested completed without response");
+        }
+        return this.results.get(0);
+    }
+
+    public V getSingle() throws InterruptedException {
+        this.doneLatch.await();
+        if (this.error != null) {
+            throw new IllegalStateException("Request failed with unexpected error", this.error);
+        }
+        if (this.results.isEmpty()) {
+            throw new IllegalStateException("Requested completed without response");
+        }
+        if (this.results.size() != 1) {
+            throw new IllegalStateException(
+                    "Request completed with more than one response - Got " + this.results.size());
+        }
+        return this.results.get(0);
+    }
+
+    public List<V> getAll() throws InterruptedException {
+        this.doneLatch.await();
+        if (this.error != null) {
+            throw new IllegalStateException("Request failed with unexpected error", this.error);
+        }
+        return this.results;
+    }
+
+    public Throwable getError() throws InterruptedException {
+        this.doneLatch.await();
+        if (this.error == null) {
+            throw new IllegalStateException("Request completed without error");
+        }
+        return this.error;
+    }
+
+}

--- a/grpc-server-spring-boot-autoconfigure/src/test/java/net/devh/boot/grpc/server/autoconfigure/GrpcHealthServiceFalseAutoConfigurationTest.java
+++ b/grpc-server-spring-boot-autoconfigure/src/test/java/net/devh/boot/grpc/server/autoconfigure/GrpcHealthServiceFalseAutoConfigurationTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2016-2021 Michael Zhang <yidongnan@gmail.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package net.devh.boot.grpc.server.autoconfigure;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.InstanceOfAssertFactories.type;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
+
+import io.grpc.Status;
+import io.grpc.Status.Code;
+import io.grpc.StatusRuntimeException;
+import io.grpc.health.v1.HealthCheckResponse;
+
+@SpringBootTest(classes = GrpcHealthServiceDefaultAutoConfigurationTest.TestConfig.class,
+        properties = "grpc.server.health-service-enabled=false")
+@ImportAutoConfiguration({
+        GrpcServerAutoConfiguration.class,
+        GrpcServerFactoryAutoConfiguration.class,
+        GrpcHealthServiceAutoConfiguration.class})
+@DirtiesContext
+class GrpcHealthServiceFalseAutoConfigurationTest extends GrpcHealthServiceDefaultAutoConfigurationTest {
+
+    @Override
+    void checkResult(final AwaitableStreamObserver<HealthCheckResponse> resultObserver) {
+        final Throwable error = assertDoesNotThrow(resultObserver::getError);
+        assertThat(error).asInstanceOf(type(StatusRuntimeException.class))
+                .extracting(StatusRuntimeException::getStatus)
+                .extracting(Status::getCode)
+                .isEqualTo(Code.UNIMPLEMENTED);
+    }
+
+}

--- a/grpc-server-spring-boot-autoconfigure/src/test/java/net/devh/boot/grpc/server/autoconfigure/GrpcHealthServiceTrueAutoConfigurationTest.java
+++ b/grpc-server-spring-boot-autoconfigure/src/test/java/net/devh/boot/grpc/server/autoconfigure/GrpcHealthServiceTrueAutoConfigurationTest.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2016-2021 Michael Zhang <yidongnan@gmail.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package net.devh.boot.grpc.server.autoconfigure;
+
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
+
+@SpringBootTest(classes = GrpcHealthServiceDefaultAutoConfigurationTest.TestConfig.class,
+        properties = "grpc.server.health-service-enabled=true")
+@ImportAutoConfiguration({
+        GrpcServerAutoConfiguration.class,
+        GrpcServerFactoryAutoConfiguration.class,
+        GrpcHealthServiceAutoConfiguration.class})
+@DirtiesContext
+class GrpcHealthServiceTrueAutoConfigurationTest extends GrpcHealthServiceDefaultAutoConfigurationTest {
+}

--- a/grpc-server-spring-boot-autoconfigure/src/test/java/net/devh/boot/grpc/server/autoconfigure/GrpcReflectionServiceDefaultAutoConfigurationTest.java
+++ b/grpc-server-spring-boot-autoconfigure/src/test/java/net/devh/boot/grpc/server/autoconfigure/GrpcReflectionServiceDefaultAutoConfigurationTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2016-2021 Michael Zhang <yidongnan@gmail.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package net.devh.boot.grpc.server.autoconfigure;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
+
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+import io.grpc.reflection.v1alpha.ServerReflectionGrpc;
+import io.grpc.reflection.v1alpha.ServerReflectionGrpc.ServerReflectionStub;
+import io.grpc.reflection.v1alpha.ServerReflectionRequest;
+import io.grpc.reflection.v1alpha.ServerReflectionResponse;
+import io.grpc.stub.StreamObserver;
+import net.devh.boot.grpc.server.autoconfigure.GrpcReflectionServiceDefaultAutoConfigurationTest.TestConfig;
+
+@SpringBootTest(classes = TestConfig.class)
+@ImportAutoConfiguration({
+        GrpcServerAutoConfiguration.class,
+        GrpcServerFactoryAutoConfiguration.class,
+        GrpcReflectionServiceAutoConfiguration.class})
+@DirtiesContext
+class GrpcReflectionServiceDefaultAutoConfigurationTest {
+
+    @Test
+    void testReflectionService() {
+        final ManagedChannel channel = ManagedChannelBuilder.forTarget("localhost:9090").usePlaintext().build();
+        final ServerReflectionStub stub = ServerReflectionGrpc.newStub(channel);
+
+        final AwaitableStreamObserver<ServerReflectionResponse> resultObserver = new AwaitableStreamObserver<>();
+        final StreamObserver<ServerReflectionRequest> requestObserver = stub.serverReflectionInfo(resultObserver);
+        requestObserver.onNext(ServerReflectionRequest.newBuilder()
+                .setListServices("")
+                .build());
+        requestObserver.onCompleted();
+        checkResult(resultObserver);
+    }
+
+    void checkResult(final AwaitableStreamObserver<ServerReflectionResponse> resultObserver) {
+        final ServerReflectionResponse response = assertDoesNotThrow(resultObserver::getSingle);
+        assertEquals("grpc.reflection.v1alpha.ServerReflection",
+                response.getListServicesResponse().getServiceList().get(0).getName());
+    }
+
+    static class TestConfig {
+    }
+
+}

--- a/grpc-server-spring-boot-autoconfigure/src/test/java/net/devh/boot/grpc/server/autoconfigure/GrpcReflectionServiceFalseAutoConfigurationTest.java
+++ b/grpc-server-spring-boot-autoconfigure/src/test/java/net/devh/boot/grpc/server/autoconfigure/GrpcReflectionServiceFalseAutoConfigurationTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2016-2021 Michael Zhang <yidongnan@gmail.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package net.devh.boot.grpc.server.autoconfigure;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.InstanceOfAssertFactories.type;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
+
+import io.grpc.Status;
+import io.grpc.Status.Code;
+import io.grpc.StatusRuntimeException;
+import io.grpc.reflection.v1alpha.ServerReflectionResponse;
+
+@SpringBootTest(classes = GrpcReflectionServiceDefaultAutoConfigurationTest.TestConfig.class,
+        properties = "grpc.server.reflection-service-enabled=false")
+@ImportAutoConfiguration({
+        GrpcServerAutoConfiguration.class,
+        GrpcServerFactoryAutoConfiguration.class,
+        GrpcReflectionServiceAutoConfiguration.class})
+@DirtiesContext
+class GrpcReflectionServiceFalseAutoConfigurationTest extends GrpcReflectionServiceDefaultAutoConfigurationTest {
+
+    @Override
+    void checkResult(final AwaitableStreamObserver<ServerReflectionResponse> resultObserver) {
+        final Throwable error = assertDoesNotThrow(resultObserver::getError);
+        assertThat(error).asInstanceOf(type(StatusRuntimeException.class))
+                .extracting(StatusRuntimeException::getStatus)
+                .extracting(Status::getCode)
+                .isEqualTo(Code.UNIMPLEMENTED);
+    }
+
+}

--- a/grpc-server-spring-boot-autoconfigure/src/test/java/net/devh/boot/grpc/server/autoconfigure/GrpcReflectionServiceTrueAutoConfigurationTest.java
+++ b/grpc-server-spring-boot-autoconfigure/src/test/java/net/devh/boot/grpc/server/autoconfigure/GrpcReflectionServiceTrueAutoConfigurationTest.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2016-2021 Michael Zhang <yidongnan@gmail.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package net.devh.boot.grpc.server.autoconfigure;
+
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
+
+@SpringBootTest(classes = GrpcReflectionServiceDefaultAutoConfigurationTest.TestConfig.class,
+        properties = "grpc.server.reflection-service-enabled=true")
+@ImportAutoConfiguration({
+        GrpcServerAutoConfiguration.class,
+        GrpcServerFactoryAutoConfiguration.class,
+        GrpcReflectionServiceAutoConfiguration.class})
+@DirtiesContext
+class GrpcReflectionServiceTrueAutoConfigurationTest extends GrpcReflectionServiceDefaultAutoConfigurationTest {
+}

--- a/grpc-server-spring-boot-autoconfigure/src/test/java/net/devh/boot/grpc/server/serverfactory/AbstractGrpcServerFactoryTest.java
+++ b/grpc-server-spring-boot-autoconfigure/src/test/java/net/devh/boot/grpc/server/serverfactory/AbstractGrpcServerFactoryTest.java
@@ -27,7 +27,6 @@ import io.grpc.ServerBuilder;
 import io.grpc.netty.NettyServerBuilder;
 import io.grpc.protobuf.services.ProtoReflectionService;
 import io.grpc.reflection.v1alpha.ServerReflectionGrpc;
-import io.grpc.services.HealthStatusManager;
 import net.devh.boot.grpc.server.config.GrpcServerProperties;
 import net.devh.boot.grpc.server.service.GrpcServiceDefinition;
 
@@ -45,7 +44,6 @@ class AbstractGrpcServerFactoryTest {
         properties.setReflectionServiceEnabled(false);
 
         final NettyGrpcServerFactory serverFactory = new NettyGrpcServerFactory(properties, emptyList());
-        serverFactory.healthStatusManager = new HealthStatusManager();
 
         serverFactory.addService(new GrpcServiceDefinition("test1", ProtoReflectionService.class,
                 ProtoReflectionService.newInstance().bindService()));

--- a/grpc-server-spring-boot-autoconfigure/src/test/resources/logback-test.xml
+++ b/grpc-server-spring-boot-autoconfigure/src/test/resources/logback-test.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE xml>
+<configuration packagingData="true">
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%highlight(%d{HH:mm:ss.SSS} [%10thread] %-5level %logger{36} - %msg%n)</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="net.devh.boot.grpc.common" level="debug" />
+    <logger name="net.devh.boot.grpc.server" level="debug" />
+    <root level="info">
+        <appender-ref ref="STDOUT" />
+    </root>
+
+</configuration>

--- a/tests/src/test/java/net/devh/boot/grpc/test/metric/MetricFullAutoConfigurationTest.java
+++ b/tests/src/test/java/net/devh/boot/grpc/test/metric/MetricFullAutoConfigurationTest.java
@@ -27,6 +27,8 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
+import io.grpc.health.v1.HealthGrpc;
+import io.grpc.reflection.v1alpha.ServerReflectionGrpc;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
@@ -48,8 +50,12 @@ class MetricFullAutoConfigurationTest {
     @Autowired
     private MeterRegistry meterRegistry;
 
-    private static final int REFLECTION_SERVER_METHOD_COUNT = 1;
-    private static final int TOTAL_METHOD_COUNT = REFLECTION_SERVER_METHOD_COUNT + METHOD_COUNT;
+    private static final int HEALTH_SERVICE_METHOD_COUNT =
+            HealthGrpc.getServiceDescriptor().getMethods().size();
+    private static final int REFLECTION_SERVICE_METHOD_COUNT =
+            ServerReflectionGrpc.getServiceDescriptor().getMethods().size();
+    private static final int TOTAL_METHOD_COUNT =
+            HEALTH_SERVICE_METHOD_COUNT + REFLECTION_SERVICE_METHOD_COUNT + METHOD_COUNT;
 
     @Test
     @DirtiesContext

--- a/tests/src/test/java/net/devh/boot/grpc/test/metric/MetricFullAutoConfigurationTest.java
+++ b/tests/src/test/java/net/devh/boot/grpc/test/metric/MetricFullAutoConfigurationTest.java
@@ -48,15 +48,19 @@ class MetricFullAutoConfigurationTest {
     @Autowired
     private MeterRegistry meterRegistry;
 
+    private static final int REFLECTION_SERVER_METHOD_COUNT = 1;
+    private static final int TOTAL_METHOD_COUNT = REFLECTION_SERVER_METHOD_COUNT + METHOD_COUNT;
+
     @Test
     @DirtiesContext
     void testAutoDiscovery() {
         log.info("--- Starting tests with full auto discovery ---");
-        assertEquals(METHOD_COUNT * 2, this.meterRegistry.getMeters().stream()
+        MetricTestHelper.logMeters(this.meterRegistry.getMeters());
+        assertEquals(TOTAL_METHOD_COUNT * 2, this.meterRegistry.getMeters().stream()
                 .filter(Counter.class::isInstance)
                 .filter(m -> m.getId().getName().startsWith("grpc.")) // Only count grpc metrics
                 .count());
-        assertEquals(METHOD_COUNT, this.meterRegistry.getMeters().stream()
+        assertEquals(TOTAL_METHOD_COUNT, this.meterRegistry.getMeters().stream()
                 .filter(Timer.class::isInstance)
                 .filter(m -> m.getId().getName().startsWith("grpc.")) // Only count grpc metrics
                 .count());

--- a/tests/src/test/java/net/devh/boot/grpc/test/server/TestServiceImpl.java
+++ b/tests/src/test/java/net/devh/boot/grpc/test/server/TestServiceImpl.java
@@ -36,13 +36,14 @@ import lombok.extern.slf4j.Slf4j;
 import net.devh.boot.grpc.server.security.interceptors.AuthenticatingServerInterceptor;
 import net.devh.boot.grpc.server.service.GrpcService;
 import net.devh.boot.grpc.test.proto.SomeType;
+import net.devh.boot.grpc.test.proto.TestServiceGrpc;
 import net.devh.boot.grpc.test.proto.TestServiceGrpc.TestServiceImplBase;
 
 @Slf4j
 @GrpcService
 public class TestServiceImpl extends TestServiceImplBase {
 
-    public static final int METHOD_COUNT = 8;
+    public static final int METHOD_COUNT = TestServiceGrpc.getServiceDescriptor().getMethods().size();
 
     public TestServiceImpl() {
         log.info("Created TestServiceImpl");


### PR DESCRIPTION
Fixes #411 , #501

Remove the grpc-service setup from the server factory making the library optional.

Fixed potential sensitive data exposure vulnerability.