### PR TITLE
If the grpc client is unavailable then the service is "out of service"

### DIFF
--- a/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/autoconfigure/GrpcClientHealthAutoConfiguration.java
+++ b/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/autoconfigure/GrpcClientHealthAutoConfiguration.java
@@ -55,7 +55,7 @@ public class GrpcClientHealthAutoConfiguration {
             final ImmutableMap<String, ConnectivityState> states = ImmutableMap.copyOf(factory.getConnectivityState());
             final Health.Builder health;
             if (states.containsValue(ConnectivityState.TRANSIENT_FAILURE)) {
-                health = Health.down();
+                health = Health.outOfService();
             } else {
                 health = Health.up();
             }


### PR DESCRIPTION
Instead of being completely down (broken).

Fixes #432