### PR TITLE
Fix GrpcClient#interceptors bean lookup + improve examples

### DIFF
--- a/docs/en/client/configuration.md
+++ b/docs/en/client/configuration.md
@@ -154,7 +154,7 @@ The following examples demonstrate how to use annotations to create a global cli
 public class ThirdPartyInterceptorConfig {}
 
     @GrpcGlobalServerInterceptor
-    ServerInterceptor logServerInterceptor() {
+    LogGrpcInterceptor logServerInterceptor() {
         return new LogGrpcInterceptor();
     }
 

--- a/examples/cloud-grpc-client/src/main/java/net/devh/boot/grpc/examples/cloud/client/GlobalClientInterceptorConfiguration.java
+++ b/examples/cloud-grpc-client/src/main/java/net/devh/boot/grpc/examples/cloud/client/GlobalClientInterceptorConfiguration.java
@@ -21,7 +21,6 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
 
-import io.grpc.ClientInterceptor;
 import net.devh.boot.grpc.client.interceptor.GrpcGlobalClientInterceptor;
 
 @Order(Ordered.LOWEST_PRECEDENCE)
@@ -29,7 +28,7 @@ import net.devh.boot.grpc.client.interceptor.GrpcGlobalClientInterceptor;
 public class GlobalClientInterceptorConfiguration {
 
     @GrpcGlobalClientInterceptor
-    ClientInterceptor logClientInterceptor() {
+    LogGrpcInterceptor logClientInterceptor() {
         return new LogGrpcInterceptor();
     }
 

--- a/examples/cloud-grpc-server/src/main/java/net/devh/boot/grpc/examples/cloud/server/GlobalInterceptorConfiguration.java
+++ b/examples/cloud-grpc-server/src/main/java/net/devh/boot/grpc/examples/cloud/server/GlobalInterceptorConfiguration.java
@@ -19,14 +19,13 @@ package net.devh.boot.grpc.examples.cloud.server;
 
 import org.springframework.context.annotation.Configuration;
 
-import io.grpc.ServerInterceptor;
 import net.devh.boot.grpc.server.interceptor.GrpcGlobalServerInterceptor;
 
 @Configuration(proxyBeanMethods = false)
 public class GlobalInterceptorConfiguration {
 
     @GrpcGlobalServerInterceptor
-    ServerInterceptor logServerInterceptor() {
+    LogGrpcInterceptor logServerInterceptor() {
         return new LogGrpcInterceptor();
     }
 

--- a/examples/local-grpc-client/src/main/java/net/devh/boot/grpc/examples/local/client/GlobalClientInterceptorConfiguration.java
+++ b/examples/local-grpc-client/src/main/java/net/devh/boot/grpc/examples/local/client/GlobalClientInterceptorConfiguration.java
@@ -21,7 +21,6 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
 
-import io.grpc.ClientInterceptor;
 import net.devh.boot.grpc.client.interceptor.GrpcGlobalClientInterceptor;
 
 @Order(Ordered.LOWEST_PRECEDENCE)
@@ -29,7 +28,7 @@ import net.devh.boot.grpc.client.interceptor.GrpcGlobalClientInterceptor;
 public class GlobalClientInterceptorConfiguration {
 
     @GrpcGlobalClientInterceptor
-    ClientInterceptor logClientInterceptor() {
+    LogGrpcInterceptor logClientInterceptor() {
         return new LogGrpcInterceptor();
     }
 

--- a/examples/local-grpc-server/src/main/java/net/devh/boot/grpc/examples/local/server/GlobalInterceptorConfiguration.java
+++ b/examples/local-grpc-server/src/main/java/net/devh/boot/grpc/examples/local/server/GlobalInterceptorConfiguration.java
@@ -19,14 +19,13 @@ package net.devh.boot.grpc.examples.local.server;
 
 import org.springframework.context.annotation.Configuration;
 
-import io.grpc.ServerInterceptor;
 import net.devh.boot.grpc.server.interceptor.GrpcGlobalServerInterceptor;
 
 @Configuration(proxyBeanMethods = false)
 public class GlobalInterceptorConfiguration {
 
     @GrpcGlobalServerInterceptor
-    ServerInterceptor logServerInterceptor() {
+    LogGrpcInterceptor logServerInterceptor() {
         return new LogGrpcInterceptor();
     }
 

--- a/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/inject/GrpcClientBeanPostProcessor.java
+++ b/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/inject/GrpcClientBeanPostProcessor.java
@@ -180,7 +180,7 @@ public class GrpcClientBeanPostProcessor implements BeanPostProcessor {
         final List<ClientInterceptor> list = Lists.newArrayList();
         for (final Class<? extends ClientInterceptor> interceptorClass : annotation.interceptors()) {
             final ClientInterceptor clientInterceptor;
-            if (this.applicationContext.getBeanNamesForType(ClientInterceptor.class).length > 0) {
+            if (this.applicationContext.getBeanNamesForType(interceptorClass).length > 0) {
                 clientInterceptor = this.applicationContext.getBean(interceptorClass);
             } else {
                 try {

--- a/grpc-client-spring-boot-autoconfigure/src/test/java/net/devh/boot/grpc/client/inject/GrpcClientBeanPostProcessorTest.java
+++ b/grpc-client-spring-boot-autoconfigure/src/test/java/net/devh/boot/grpc/client/inject/GrpcClientBeanPostProcessorTest.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright (c) 2016-2021 Michael Zhang <yidongnan@gmail.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package net.devh.boot.grpc.client.inject;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+import java.lang.annotation.Annotation;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.test.annotation.DirtiesContext;
+
+import io.grpc.CallOptions;
+import io.grpc.Channel;
+import io.grpc.ClientCall;
+import io.grpc.ClientInterceptor;
+import io.grpc.MethodDescriptor;
+import net.devh.boot.grpc.client.autoconfigure.GrpcClientAutoConfiguration;
+
+/**
+ * Tests for {@link GrpcClientBeanPostProcessor}.
+ *
+ * @author Daniel Theuke (daniel.theuke@heuboe.de)
+ */
+@SpringBootTest(classes = GrpcClientBeanPostProcessorTest.TestConfig.class)
+@DirtiesContext
+@ImportAutoConfiguration(GrpcClientAutoConfiguration.class)
+class GrpcClientBeanPostProcessorTest {
+
+    @Autowired
+    GrpcClientBeanPostProcessor postProcessor;
+
+    @Autowired
+    Interceptor1 interceptor1;
+
+    @Test
+    void testInterceptorsFromAnnotation1() {
+        final List<ClientInterceptor> beans =
+                assertDoesNotThrow(() -> this.postProcessor.interceptorsFromAnnotation(new GrpcClient() {
+
+                    @Override
+                    public Class<? extends Annotation> annotationType() {
+                        return GrpcClient.class;
+                    }
+
+                    @Override
+                    public String value() {
+                        return "test";
+                    }
+
+                    @Override
+                    public boolean sortInterceptors() {
+                        return false;
+                    }
+
+                    @Override
+                    @SuppressWarnings("unchecked")
+                    public Class<? extends ClientInterceptor>[] interceptors() {
+                        return new Class[] {Interceptor1.class};
+                    }
+
+                    @Override
+                    public String[] interceptorNames() {
+                        return new String[0];
+                    }
+
+                }));
+
+        assertThat(beans).containsExactly(this.interceptor1);
+    }
+
+    @Test
+    void testInterceptorsFromAnnotation2() {
+        final List<ClientInterceptor> beans =
+                assertDoesNotThrow(() -> this.postProcessor.interceptorsFromAnnotation(new GrpcClient() {
+
+                    @Override
+                    public Class<? extends Annotation> annotationType() {
+                        return GrpcClient.class;
+                    }
+
+                    @Override
+                    public String value() {
+                        return "test";
+                    }
+
+                    @Override
+                    public boolean sortInterceptors() {
+                        return false;
+                    }
+
+                    @Override
+                    @SuppressWarnings("unchecked")
+                    public Class<? extends ClientInterceptor>[] interceptors() {
+                        return new Class[] {Interceptor2.class};
+                    }
+
+                    @Override
+                    public String[] interceptorNames() {
+                        return new String[0];
+                    }
+
+                }));
+
+        assertThat(beans).hasSize(1).doesNotContain(this.interceptor1);
+    }
+
+    private static class TestConfig {
+
+        @Bean
+        Interceptor1 interceptor1() {
+            return new Interceptor1();
+        }
+
+
+    }
+
+    public static class Interceptor1 implements ClientInterceptor {
+
+        @Override
+        public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(
+                final MethodDescriptor<ReqT, RespT> method,
+                final CallOptions callOptions, final Channel next) {
+            return next.newCall(null, callOptions);
+        }
+
+    }
+
+    public static class Interceptor2 implements ClientInterceptor {
+
+        @Override
+        public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(
+                final MethodDescriptor<ReqT, RespT> method,
+                final CallOptions callOptions, final Channel next) {
+            return next.newCall(null, callOptions);
+        }
+
+    }
+
+}

--- a/grpc-client-spring-boot-autoconfigure/src/test/java/net/devh/boot/grpc/client/inject/GrpcClientBeanPostProcessorTest.java
+++ b/grpc-client-spring-boot-autoconfigure/src/test/java/net/devh/boot/grpc/client/inject/GrpcClientBeanPostProcessorTest.java
@@ -125,7 +125,7 @@ class GrpcClientBeanPostProcessorTest {
         assertThat(beans).hasSize(1).doesNotContain(this.interceptor1);
     }
 
-    private static class TestConfig {
+    static class TestConfig {
 
         @Bean
         Interceptor1 interceptor1() {

--- a/grpc-client-spring-boot-autoconfigure/src/test/java/net/devh/boot/grpc/client/inject/GrpcClientBeanPostProcessorTest.java
+++ b/grpc-client-spring-boot-autoconfigure/src/test/java/net/devh/boot/grpc/client/inject/GrpcClientBeanPostProcessorTest.java
@@ -141,7 +141,7 @@ class GrpcClientBeanPostProcessorTest {
         public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(
                 final MethodDescriptor<ReqT, RespT> method,
                 final CallOptions callOptions, final Channel next) {
-            return next.newCall(null, callOptions);
+            return next.newCall(method, callOptions);
         }
 
     }
@@ -152,7 +152,7 @@ class GrpcClientBeanPostProcessorTest {
         public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(
                 final MethodDescriptor<ReqT, RespT> method,
                 final CallOptions callOptions, final Channel next) {
-            return next.newCall(null, callOptions);
+            return next.newCall(method, callOptions);
         }
 
     }


### PR DESCRIPTION
Fixes #503 

Due to the broken check in the `GrpcClientBeanPostProcessor` the `GrpcClient#interceptors()` property didn't work if there were at least one `ClientInterceptor`s in the application context, but a constructor based one was intended to be created here.