### PR TITLE
Support max connection idle and age limits

### DIFF
--- a/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/config/GrpcServerProperties.java
+++ b/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/config/GrpcServerProperties.java
@@ -163,6 +163,40 @@ public class GrpcServerProperties {
     private boolean permitKeepAliveWithoutCalls = false;
 
     /**
+     * Specify a max connection idle time. Defaults to disabled. Default unit {@link ChronoUnit#SECONDS SECONDS}.
+     *
+     * @see NettyServerBuilder#maxConnectionIdle(long, TimeUnit)
+     *
+     * @param maxConnectionIdle The max connection idle time.
+     * @return The max connection idle time.
+     */
+    @DurationUnit(ChronoUnit.SECONDS)
+    private Duration maxConnectionIdle = null;
+
+    /**
+     * Specify a max connection age. Defaults to disabled. Default unit {@link ChronoUnit#SECONDS SECONDS}.
+     *
+     * @see NettyServerBuilder#maxConnectionAge(long, TimeUnit)
+     *
+     * @param maxConnectionAge The max connection age.
+     * @return The max connection age.
+     */
+    @DurationUnit(ChronoUnit.SECONDS)
+    private Duration maxConnectionAge = null;
+
+    /**
+     * Specify a grace time for the graceful max connection age termination. Defaults to disabled. Default unit
+     * {@link ChronoUnit#SECONDS SECONDS}.
+     *
+     * @see NettyServerBuilder#maxConnectionAgeGrace(long, TimeUnit)
+     *
+     * @param maxConnectionAgeGrace The max connection age grace time.
+     * @return The max connection age grace time.
+     */
+    @DurationUnit(ChronoUnit.SECONDS)
+    private Duration maxConnectionAgeGrace = null;
+
+    /**
      * The maximum message size allowed to be received by the server. If not set ({@code null}) then
      * {@link GrpcUtil#DEFAULT_MAX_MESSAGE_SIZE gRPC's default} should be used.
      *

--- a/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/serverfactory/AbstractGrpcServerFactory.java
+++ b/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/serverfactory/AbstractGrpcServerFactory.java
@@ -84,6 +84,7 @@ public abstract class AbstractGrpcServerFactory<T extends ServerBuilder<T>> impl
     protected void configure(final T builder) {
         configureServices(builder);
         configureKeepAlive(builder);
+        configureConnectionLimits(builder);
         configureSecurity(builder);
         configureLimits(builder);
         for (final GrpcServerConfigurer serverConfigurer : this.serverConfigurers) {
@@ -118,6 +119,23 @@ public abstract class AbstractGrpcServerFactory<T extends ServerBuilder<T>> impl
     protected void configureKeepAlive(final T builder) {
         if (this.properties.isEnableKeepAlive()) {
             throw new IllegalStateException("KeepAlive is enabled but this implementation does not support keepAlive!");
+        }
+    }
+
+    /**
+     * Configures the keep alive options that should be used by the server.
+     *
+     * @param builder The server builder to configure.
+     */
+    protected void configureConnectionLimits(final T builder) {
+        if (this.properties.getMaxConnectionIdle() != null) {
+            throw new IllegalStateException("MaxConnectionIdle is set but this implementation does not support maxConnectionIdle!");
+        }
+        if (this.properties.getMaxConnectionAge() != null) {
+            throw new IllegalStateException("MaxConnectionAge is set but this implementation does not support maxConnectionAge!");
+        }
+        if (this.properties.getMaxConnectionAgeGrace() != null) {
+            throw new IllegalStateException("MaxConnectionAgeGrace is set but this implementation does not support maxConnectionAgeGrace!");
         }
     }
 

--- a/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/serverfactory/AbstractGrpcServerFactory.java
+++ b/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/serverfactory/AbstractGrpcServerFactory.java
@@ -129,13 +129,16 @@ public abstract class AbstractGrpcServerFactory<T extends ServerBuilder<T>> impl
      */
     protected void configureConnectionLimits(final T builder) {
         if (this.properties.getMaxConnectionIdle() != null) {
-            throw new IllegalStateException("MaxConnectionIdle is set but this implementation does not support maxConnectionIdle!");
+            throw new IllegalStateException(
+                "MaxConnectionIdle is set but this implementation does not support maxConnectionIdle!");
         }
         if (this.properties.getMaxConnectionAge() != null) {
-            throw new IllegalStateException("MaxConnectionAge is set but this implementation does not support maxConnectionAge!");
+            throw new IllegalStateException(
+                "MaxConnectionAge is set but this implementation does not support maxConnectionAge!");
         }
         if (this.properties.getMaxConnectionAgeGrace() != null) {
-            throw new IllegalStateException("MaxConnectionAgeGrace is set but this implementation does not support maxConnectionAgeGrace!");
+            throw new IllegalStateException(
+                "MaxConnectionAgeGrace is set but this implementation does not support maxConnectionAgeGrace!");
         }
     }
 

--- a/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/serverfactory/AbstractGrpcServerFactory.java
+++ b/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/serverfactory/AbstractGrpcServerFactory.java
@@ -130,15 +130,15 @@ public abstract class AbstractGrpcServerFactory<T extends ServerBuilder<T>> impl
     protected void configureConnectionLimits(final T builder) {
         if (this.properties.getMaxConnectionIdle() != null) {
             throw new IllegalStateException(
-                "MaxConnectionIdle is set but this implementation does not support maxConnectionIdle!");
+                    "MaxConnectionIdle is set but this implementation does not support maxConnectionIdle!");
         }
         if (this.properties.getMaxConnectionAge() != null) {
             throw new IllegalStateException(
-                "MaxConnectionAge is set but this implementation does not support maxConnectionAge!");
+                    "MaxConnectionAge is set but this implementation does not support maxConnectionAge!");
         }
         if (this.properties.getMaxConnectionAgeGrace() != null) {
             throw new IllegalStateException(
-                "MaxConnectionAgeGrace is set but this implementation does not support maxConnectionAgeGrace!");
+                    "MaxConnectionAgeGrace is set but this implementation does not support maxConnectionAgeGrace!");
         }
     }
 

--- a/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/serverfactory/NettyGrpcServerFactory.java
+++ b/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/serverfactory/NettyGrpcServerFactory.java
@@ -80,6 +80,20 @@ public class NettyGrpcServerFactory extends AbstractGrpcServerFactory<NettyServe
     }
 
     @Override
+    // Keep this in sync with ShadedNettyGrpcServerFactory#configureConnectionLimits
+    protected void configureConnectionLimits(final NettyServerBuilder builder) {
+        if (this.properties.getMaxConnectionIdle() != null) {
+            builder.maxConnectionIdle(this.properties.getMaxConnectionIdle().toNanos(), TimeUnit.NANOSECONDS);
+        }
+        if (this.properties.getMaxConnectionAge() != null) {
+            builder.maxConnectionAge(this.properties.getMaxConnectionAge().toNanos(), TimeUnit.NANOSECONDS);
+        }
+        if (this.properties.getMaxConnectionAgeGrace() != null) {
+            builder.maxConnectionAgeGrace(this.properties.getMaxConnectionAgeGrace().toNanos(), TimeUnit.NANOSECONDS);
+        }
+    }
+
+    @Override
     // Keep this in sync with ShadedNettyGrpcServerFactory#configureSecurity
     protected void configureSecurity(final NettyServerBuilder builder) {
         final Security security = this.properties.getSecurity();

--- a/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/serverfactory/ShadedNettyGrpcServerFactory.java
+++ b/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/serverfactory/ShadedNettyGrpcServerFactory.java
@@ -70,6 +70,20 @@ public class ShadedNettyGrpcServerFactory
     }
 
     @Override
+    // Keep this in sync with NettyGrpcServerFactory#configureConnectionLimits
+    protected void configureConnectionLimits(final NettyServerBuilder builder) {
+        if (this.properties.getMaxConnectionIdle() != null) {
+            builder.maxConnectionIdle(this.properties.getMaxConnectionIdle().toNanos(), TimeUnit.NANOSECONDS);
+        }
+        if (this.properties.getMaxConnectionAge() != null) {
+            builder.maxConnectionAge(this.properties.getMaxConnectionAge().toNanos(), TimeUnit.NANOSECONDS);
+        }
+        if (this.properties.getMaxConnectionAgeGrace() != null) {
+            builder.maxConnectionAgeGrace(this.properties.getMaxConnectionAgeGrace().toNanos(), TimeUnit.NANOSECONDS);
+        }
+    }
+
+    @Override
     // Keep this in sync with NettyGrpcServerFactory#configureKeepAlive
     protected void configureKeepAlive(final NettyServerBuilder builder) {
         if (this.properties.isEnableKeepAlive()) {


### PR DESCRIPTION
This adds support for specifying max connection idle and age limits in server. This makes clients reconnect periodically which is needed to ensure proper load balancing with sticky connections.