### PR TITLE
Add logging response messages and other data to ClientLogInterceptor example

### DIFF
--- a/examples/cloud-grpc-client/src/main/java/net/devh/boot/grpc/examples/cloud/client/LogGrpcInterceptor.java
+++ b/examples/cloud-grpc-client/src/main/java/net/devh/boot/grpc/examples/cloud/client/LogGrpcInterceptor.java
@@ -17,18 +17,22 @@
 
 package net.devh.boot.grpc.examples.cloud.client;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import io.grpc.CallOptions;
 import io.grpc.Channel;
 import io.grpc.ClientCall;
 import io.grpc.ClientInterceptor;
+import io.grpc.ForwardingClientCall;
+import io.grpc.ForwardingClientCallListener;
+import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
+import io.grpc.Status;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import net.devh.boot.grpc.client.interceptor.GrpcGlobalClientInterceptor;
 
 /**
- * Example {@link ClientInterceptor} that logs all called methods. In this example it is added to Spring's application
+ * Example {@link ClientInterceptor} that logs all called methods in INFO log level, also request and response messages,
+ * headers, trailers and interaction status in DEBUG log level. In this example it is added to Spring's application
  * context via {@link GlobalInterceptorConfiguration}, but is also possible to directly annotate this class with
  * {@link GrpcGlobalClientInterceptor}.
  */
@@ -44,7 +48,38 @@ public class LogGrpcInterceptor implements ClientInterceptor {
             final Channel next) {
 
         log.info(method.getFullMethodName());
-        return next.newCall(method, callOptions);
+        return new ForwardingClientCall.SimpleForwardingClientCall<ReqT, RespT>(next.newCall(method, callOptions)) {
+
+            @Override
+            public void sendMessage(ReqT message) {
+                log.debug("Request message: \n{}", message.toString());
+                super.sendMessage(message);
+            }
+
+            @Override
+            public void start(Listener<RespT> responseListener, Metadata headers) {
+                super.start(new ForwardingClientCallListener.SimpleForwardingClientCallListener<RespT>(responseListener) {
+                    @Override
+                    public void onMessage(RespT message) {
+                        log.debug("Response message: \n{}", message.toString());
+                        super.onMessage(message);
+                    }
+
+                    @Override
+                    public void onHeaders(Metadata headers) {
+                        log.debug("gRPC headers: \n{}", headers.toString());
+                        super.onHeaders(headers);
+                    }
+
+                    @Override
+                    public void onClose(Status status, Metadata trailers) {
+                        log.info("Interaction ends with status: {}", status.toString());
+                        log.info("Trailers: {}", trailers.toString());
+                        super.onClose(status, trailers);
+                    }
+                }, headers);
+            }
+        };
     }
 
 }

--- a/examples/cloud-grpc-client/src/main/java/net/devh/boot/grpc/examples/cloud/client/LogGrpcInterceptor.java
+++ b/examples/cloud-grpc-client/src/main/java/net/devh/boot/grpc/examples/cloud/client/LogGrpcInterceptor.java
@@ -17,6 +17,9 @@
 
 package net.devh.boot.grpc.examples.cloud.client;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import io.grpc.CallOptions;
 import io.grpc.Channel;
 import io.grpc.ClientCall;
@@ -26,8 +29,6 @@ import io.grpc.ForwardingClientCallListener;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
 import io.grpc.Status;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import net.devh.boot.grpc.client.interceptor.GrpcGlobalClientInterceptor;
 
 /**
@@ -58,26 +59,27 @@ public class LogGrpcInterceptor implements ClientInterceptor {
 
             @Override
             public void start(Listener<RespT> responseListener, Metadata headers) {
-                super.start(new ForwardingClientCallListener.SimpleForwardingClientCallListener<RespT>(responseListener) {
-                    @Override
-                    public void onMessage(RespT message) {
-                        log.debug("Response message: \n{}", message.toString());
-                        super.onMessage(message);
-                    }
+                super.start(
+                        new ForwardingClientCallListener.SimpleForwardingClientCallListener<RespT>(responseListener) {
+                            @Override
+                            public void onMessage(RespT message) {
+                                log.debug("Response message: \n{}", message.toString());
+                                super.onMessage(message);
+                            }
 
-                    @Override
-                    public void onHeaders(Metadata headers) {
-                        log.debug("gRPC headers: \n{}", headers.toString());
-                        super.onHeaders(headers);
-                    }
+                            @Override
+                            public void onHeaders(Metadata headers) {
+                                log.debug("gRPC headers: \n{}", headers.toString());
+                                super.onHeaders(headers);
+                            }
 
-                    @Override
-                    public void onClose(Status status, Metadata trailers) {
-                        log.info("Interaction ends with status: {}", status.toString());
-                        log.info("Trailers: {}", trailers.toString());
-                        super.onClose(status, trailers);
-                    }
-                }, headers);
+                            @Override
+                            public void onClose(Status status, Metadata trailers) {
+                                log.info("Interaction ends with status: {}", status.toString());
+                                log.info("Trailers: {}", trailers.toString());
+                                super.onClose(status, trailers);
+                            }
+                        }, headers);
             }
         };
     }

--- a/examples/cloud-grpc-client/src/main/java/net/devh/boot/grpc/examples/cloud/client/LogGrpcInterceptor.java
+++ b/examples/cloud-grpc-client/src/main/java/net/devh/boot/grpc/examples/cloud/client/LogGrpcInterceptor.java
@@ -48,12 +48,12 @@ public class LogGrpcInterceptor implements ClientInterceptor {
             final CallOptions callOptions,
             final Channel next) {
 
-        log.info(method.getFullMethodName());
+        log.info("Received call to {}", method.getFullMethodName());
         return new ForwardingClientCall.SimpleForwardingClientCall<ReqT, RespT>(next.newCall(method, callOptions)) {
 
             @Override
             public void sendMessage(ReqT message) {
-                log.debug("Request message: \n{}", message.toString());
+                log.debug("Request message: {}", message);
                 super.sendMessage(message);
             }
 
@@ -63,20 +63,20 @@ public class LogGrpcInterceptor implements ClientInterceptor {
                         new ForwardingClientCallListener.SimpleForwardingClientCallListener<RespT>(responseListener) {
                             @Override
                             public void onMessage(RespT message) {
-                                log.debug("Response message: \n{}", message.toString());
+                                log.debug("Response message: {}", message);
                                 super.onMessage(message);
                             }
 
                             @Override
                             public void onHeaders(Metadata headers) {
-                                log.debug("gRPC headers: \n{}", headers.toString());
+                                log.debug("gRPC headers: {}", headers);
                                 super.onHeaders(headers);
                             }
 
                             @Override
                             public void onClose(Status status, Metadata trailers) {
-                                log.info("Interaction ends with status: {}", status.toString());
-                                log.info("Trailers: {}", trailers.toString());
+                                log.info("Interaction ends with status: {}", status);
+                                log.info("Trailers: {}", trailers);
                                 super.onClose(status, trailers);
                             }
                         }, headers);

--- a/examples/local-grpc-client/src/main/java/net/devh/boot/grpc/examples/local/client/LogGrpcInterceptor.java
+++ b/examples/local-grpc-client/src/main/java/net/devh/boot/grpc/examples/local/client/LogGrpcInterceptor.java
@@ -17,16 +17,25 @@
 
 package net.devh.boot.grpc.examples.local.client;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import io.grpc.CallOptions;
 import io.grpc.Channel;
 import io.grpc.ClientCall;
 import io.grpc.ClientInterceptor;
+import io.grpc.ForwardingClientCall;
+import io.grpc.ForwardingClientCallListener;
+import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
+import io.grpc.Status;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import net.devh.boot.grpc.client.interceptor.GrpcGlobalClientInterceptor;
 
 /**
+ * Example {@link ClientInterceptor} that logs all called methods in INFO log level, also request and response messages,
+ * headers, trailers and interaction status in DEBUG log level. In this example it is added to Spring's application
+ * context via {@link GlobalClientInterceptorConfiguration}, but is also possible to directly annotate this class with
+ * {@link GrpcGlobalClientInterceptor}.
+ *
  * @author Michael (yidongnan@gmail.com)
  * @since 2016/12/8
  */
@@ -35,10 +44,44 @@ public class LogGrpcInterceptor implements ClientInterceptor {
     private static final Logger log = LoggerFactory.getLogger(LogGrpcInterceptor.class);
 
     @Override
-    public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(MethodDescriptor<ReqT, RespT> method,
-            CallOptions callOptions, Channel next) {
+    public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(
+            MethodDescriptor<ReqT, RespT> method,
+            CallOptions callOptions,
+            Channel next) {
+
         log.info(method.getFullMethodName());
-        return next.newCall(method, callOptions);
+        return new ForwardingClientCall.SimpleForwardingClientCall<ReqT, RespT>(next.newCall(method, callOptions)) {
+
+            @Override
+            public void sendMessage(ReqT message) {
+                log.debug("Request message: \n{}", message.toString());
+                super.sendMessage(message);
+            }
+
+            @Override
+            public void start(Listener<RespT> responseListener, Metadata headers) {
+                super.start(new ForwardingClientCallListener.SimpleForwardingClientCallListener<RespT>(responseListener) {
+                    @Override
+                    public void onMessage(RespT message) {
+                        log.debug("Response message: \n{}", message.toString());
+                        super.onMessage(message);
+                    }
+
+                    @Override
+                    public void onHeaders(Metadata headers) {
+                        log.debug("gRPC headers: \n{}", headers.toString());
+                        super.onHeaders(headers);
+                    }
+
+                    @Override
+                    public void onClose(Status status, Metadata trailers) {
+                        log.info("Interaction ends with status: {}", status.toString());
+                        log.info("Trailers: {}", trailers.toString());
+                        super.onClose(status, trailers);
+                    }
+                }, headers);
+            }
+        };
     }
 
 }

--- a/examples/local-grpc-client/src/main/java/net/devh/boot/grpc/examples/local/client/LogGrpcInterceptor.java
+++ b/examples/local-grpc-client/src/main/java/net/devh/boot/grpc/examples/local/client/LogGrpcInterceptor.java
@@ -17,6 +17,9 @@
 
 package net.devh.boot.grpc.examples.local.client;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import io.grpc.CallOptions;
 import io.grpc.Channel;
 import io.grpc.ClientCall;
@@ -26,8 +29,6 @@ import io.grpc.ForwardingClientCallListener;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
 import io.grpc.Status;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import net.devh.boot.grpc.client.interceptor.GrpcGlobalClientInterceptor;
 
 /**
@@ -60,26 +61,27 @@ public class LogGrpcInterceptor implements ClientInterceptor {
 
             @Override
             public void start(Listener<RespT> responseListener, Metadata headers) {
-                super.start(new ForwardingClientCallListener.SimpleForwardingClientCallListener<RespT>(responseListener) {
-                    @Override
-                    public void onMessage(RespT message) {
-                        log.debug("Response message: \n{}", message.toString());
-                        super.onMessage(message);
-                    }
+                super.start(
+                        new ForwardingClientCallListener.SimpleForwardingClientCallListener<RespT>(responseListener) {
+                            @Override
+                            public void onMessage(RespT message) {
+                                log.debug("Response message: \n{}", message.toString());
+                                super.onMessage(message);
+                            }
 
-                    @Override
-                    public void onHeaders(Metadata headers) {
-                        log.debug("gRPC headers: \n{}", headers.toString());
-                        super.onHeaders(headers);
-                    }
+                            @Override
+                            public void onHeaders(Metadata headers) {
+                                log.debug("gRPC headers: \n{}", headers.toString());
+                                super.onHeaders(headers);
+                            }
 
-                    @Override
-                    public void onClose(Status status, Metadata trailers) {
-                        log.info("Interaction ends with status: {}", status.toString());
-                        log.info("Trailers: {}", trailers.toString());
-                        super.onClose(status, trailers);
-                    }
-                }, headers);
+                            @Override
+                            public void onClose(Status status, Metadata trailers) {
+                                log.info("Interaction ends with status: {}", status.toString());
+                                log.info("Trailers: {}", trailers.toString());
+                                super.onClose(status, trailers);
+                            }
+                        }, headers);
             }
         };
     }

--- a/examples/local-grpc-client/src/main/java/net/devh/boot/grpc/examples/local/client/LogGrpcInterceptor.java
+++ b/examples/local-grpc-client/src/main/java/net/devh/boot/grpc/examples/local/client/LogGrpcInterceptor.java
@@ -50,12 +50,12 @@ public class LogGrpcInterceptor implements ClientInterceptor {
             CallOptions callOptions,
             Channel next) {
 
-        log.info(method.getFullMethodName());
+        log.info("Received call to {}", method.getFullMethodName());
         return new ForwardingClientCall.SimpleForwardingClientCall<ReqT, RespT>(next.newCall(method, callOptions)) {
 
             @Override
             public void sendMessage(ReqT message) {
-                log.debug("Request message: \n{}", message.toString());
+                log.debug("Request message: {}", message);
                 super.sendMessage(message);
             }
 
@@ -65,20 +65,20 @@ public class LogGrpcInterceptor implements ClientInterceptor {
                         new ForwardingClientCallListener.SimpleForwardingClientCallListener<RespT>(responseListener) {
                             @Override
                             public void onMessage(RespT message) {
-                                log.debug("Response message: \n{}", message.toString());
+                                log.debug("Response message: {}", message);
                                 super.onMessage(message);
                             }
 
                             @Override
                             public void onHeaders(Metadata headers) {
-                                log.debug("gRPC headers: \n{}", headers.toString());
+                                log.debug("gRPC headers: {}", headers);
                                 super.onHeaders(headers);
                             }
 
                             @Override
                             public void onClose(Status status, Metadata trailers) {
-                                log.info("Interaction ends with status: {}", status.toString());
-                                log.info("Trailers: {}", trailers.toString());
+                                log.info("Interaction ends with status: {}", status);
+                                log.info("Trailers: {}", trailers);
                                 super.onClose(status, trailers);
                             }
                         }, headers);


### PR DESCRIPTION
### Context 

Unfortunately on github and in the official documentation there are unfairly few examples on working with intercepting messages, and even less on intercepting data when responding from the server on the client side: response message, headers, status, trailers and other metadata.

I believe it would be a good option to show this work with a simple logging example.
