### PR TITLE
Improve authentication capabilities

### DIFF
--- a/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/security/authentication/GrpcAuthenticationReader.java
+++ b/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/security/authentication/GrpcAuthenticationReader.java
@@ -26,10 +26,15 @@ import org.springframework.security.core.AuthenticationException;
 
 import io.grpc.Metadata;
 import io.grpc.ServerCall;
+import io.grpc.Status;
 
 /**
  * Reads the authentication data from the given {@link ServerCall} and {@link Metadata}. The returned
  * {@link Authentication} is not yet validated and needs to be passed to an {@link AuthenticationManager}.
+ *
+ * <p>
+ * This is similar to the {@code org.springframework.security.web.authentication.AuthenticationConverter}.
+ * </p>
  *
  * <p>
  * <b>Note:</b> The authentication manager needs a corresponding {@link AuthenticationProvider} to actually verify the
@@ -47,7 +52,9 @@ public interface GrpcAuthenticationReader {
      * <p>
      * <b>Note:</b> Implementations are free to throw an {@link AuthenticationException} if no credentials could be
      * found in the call. If an exception is thrown by an implementation then the authentication attempt should be
-     * considered as failed and no subsequent {@link GrpcAuthenticationReader}s should be called.
+     * considered as failed and no subsequent {@link GrpcAuthenticationReader}s should be called. Additionally, the call
+     * will fail as {@link Status#UNAUTHENTICATED}. If the call instead returns {@code null}, then the call processing
+     * will proceed unauthenticated.
      * </p>
      *
      * @param call The call to get that send the request.

--- a/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/security/interceptors/AuthenticatingServerInterceptor.java
+++ b/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/security/interceptors/AuthenticatingServerInterceptor.java
@@ -51,7 +51,10 @@ public interface AuthenticatingServerInterceptor extends ServerInterceptor {
 
     /**
      * The context key that can be used to retrieve the originally associated {@link Authentication}.
+     *
+     * @deprecated Use {@link #SECURITY_CONTEXT_KEY} instead.
      */
+    @Deprecated
     Context.Key<Authentication> AUTHENTICATION_CONTEXT_KEY = Context.key("authentication");
 
 }

--- a/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/security/interceptors/AuthenticatingServerInterceptor.java
+++ b/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/security/interceptors/AuthenticatingServerInterceptor.java
@@ -18,6 +18,7 @@
 package net.devh.boot.grpc.server.security.interceptors;
 
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
 
 import io.grpc.Context;
 import io.grpc.Contexts;
@@ -46,6 +47,11 @@ public interface AuthenticatingServerInterceptor extends ServerInterceptor {
     /**
      * The context key that can be used to retrieve the associated {@link Authentication}.
      */
-    public static final Context.Key<Authentication> AUTHENTICATION_CONTEXT_KEY = Context.key("authentication");
+    Context.Key<SecurityContext> SECURITY_CONTEXT_KEY = Context.key("security-context");
+
+    /**
+     * The context key that can be used to retrieve the originally associated {@link Authentication}.
+     */
+    Context.Key<Authentication> AUTHENTICATION_CONTEXT_KEY = Context.key("authentication");
 
 }

--- a/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/security/interceptors/DefaultAuthenticatingServerInterceptor.java
+++ b/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/security/interceptors/DefaultAuthenticatingServerInterceptor.java
@@ -47,6 +47,10 @@ import net.devh.boot.grpc.server.security.authentication.GrpcAuthenticationReade
  * authentication to both grpc's {@link Context} and {@link SecurityContextHolder}.
  *
  * <p>
+ * This works similar to the {@code org.springframework.security.web.authentication.AuthenticationFilter}.
+ * </p>
+ *
+ * <p>
  * <b>Note:</b> This interceptor works similar to
  * {@link Contexts#interceptCall(Context, ServerCall, Metadata, ServerCallHandler)}.
  * </p>

--- a/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/security/interceptors/DefaultAuthenticatingServerInterceptor.java
+++ b/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/security/interceptors/DefaultAuthenticatingServerInterceptor.java
@@ -115,6 +115,7 @@ public class DefaultAuthenticatingServerInterceptor implements AuthenticatingSer
         final SecurityContext securityContext = SecurityContextHolder.createEmptyContext();
         securityContext.setAuthentication(authentication);
         SecurityContextHolder.setContext(securityContext);
+        @SuppressWarnings("deprecation")
         final Context grpcContext = Context.current().withValues(
                 SECURITY_CONTEXT_KEY, securityContext,
                 AUTHENTICATION_CONTEXT_KEY, authentication);

--- a/tests/src/test/java/net/devh/boot/grpc/test/interceptor/DefaultServerInterceptorTest.java
+++ b/tests/src/test/java/net/devh/boot/grpc/test/interceptor/DefaultServerInterceptorTest.java
@@ -48,7 +48,7 @@ import net.devh.boot.grpc.test.config.WithBasicAuthSecurityConfiguration;
         ManualSecurityConfiguration.class})
 @EnableAutoConfiguration
 @DirtiesContext
-public class DefaultServerInterceptorTest {
+class DefaultServerInterceptorTest {
 
     @Autowired
     private ApplicationContext applicationContext;

--- a/tests/src/test/java/net/devh/boot/grpc/test/server/TestServiceImpl.java
+++ b/tests/src/test/java/net/devh/boot/grpc/test/server/TestServiceImpl.java
@@ -184,7 +184,7 @@ public class TestServiceImpl extends TestServiceImplBase {
     protected Authentication assertSameAuthenticatedGrcContextOnly(final String method, final Authentication expected,
             final Context context) {
         return assertSameAuthenticated(method, expected,
-                AuthenticatingServerInterceptor.AUTHENTICATION_CONTEXT_KEY.get(context));
+                AuthenticatingServerInterceptor.SECURITY_CONTEXT_KEY.get(context).getAuthentication());
     }
 
     protected Authentication assertSameAuthenticated(final String method, final Authentication expected) {


### PR DESCRIPTION
This PR improves the authentication process in the following fashion:

- Improve javadocs with references to related spring security web counterparts
- It adds overwriteable hook methods to the authentication process
- Add the `SECURITY_CONTEXT_KEY ` that now stores the entire security context instead of just the authentication, the security context is able to store more than just the authentication and can be used to replace the authentication during a call (e.g. for impersonation by admins or changing the roles of the user on the fly)
- Add the `SecurityContext` to the grpc `Context`
- Deprecate `AUTHENTICATION_CONTEXT_KEY` in favor of `SECURITY_CONTEXT_KEY`