### PR TITLE
Fix creation of Bearer Token using CallCredentialsHelper.bearerAuth(Supplier<String>)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
         }
     }
     ext {
-        projectVersion = '2.14.0-SNAPSHOT'
+        projectVersion = '2.14.1-SNAPSHOT'
 
         // https://github.com/grpc/grpc-java/releases
         grpcVersion = '1.43.2'

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
         }
     }
     ext {
-        projectVersion = '2.14.1-SNAPSHOT'
+        projectVersion = '2.14.0-SNAPSHOT'
 
         // https://github.com/grpc/grpc-java/releases
         grpcVersion = '1.43.2'

--- a/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/security/CallCredentialsHelper.java
+++ b/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/security/CallCredentialsHelper.java
@@ -192,7 +192,7 @@ public class CallCredentialsHelper {
      * @see #authorizationHeader(Supplier)
      */
     public static CallCredentials bearerAuth(final Supplier<String> tokenSource) {
-        return authorizationHeader(() -> BEARER_AUTH_PREFIX + tokenSource);
+        return authorizationHeader(() -> BEARER_AUTH_PREFIX + tokenSource.get());
     }
 
     /**


### PR DESCRIPTION
Hello fellas, first of all, thanks for this really nice starter for gRPC.

I was going through the documentation about how to secure the gRPC endpoints and there I followed the following code snippet to add the bearer token on clients:

```@Bean
CallCredentials bearerAuthForwardingCredentials() {
    return CallCredentialsHelper.bearerAuth(() -> KeycloakSecurityContext.getTokenString());
}
```

The problem is that inside the `CallCredentialsHelper.bearerAuth` instead of getting the token using the `get` method of the `Supplier` it was simply passing the `Supplier` itself (calling `toString()` implicitly). When I was debugging the server to check if the token was coming correctly and the `AuthenticationProvider` was doing its job I have stumbled upon this.

With that being said, I have committed the fix for this. Please, if possible push it to release version so we all have the fix.

Thanks. :)