### PR TITLE
Correct tag names according to Micrometer's docs

### DIFF
--- a/docs/en/actuator.md
+++ b/docs/en/actuator.md
@@ -59,7 +59,7 @@ Once the dependencies are added grpc-spring-boot-starter will automatically conf
 
 - `service`: The requested grpc service name (using protobuf name)
 - `method`: The requested grpc method name (using protobuf name)
-- `methodType`: The type of the requested grpc method.
+- `method.type`: The type of the requested grpc method.
 
 ### Timer
 
@@ -70,8 +70,8 @@ Once the dependencies are added grpc-spring-boot-starter will automatically conf
 
 - `service`: The requested grpc service name (using protobuf name)
 - `method`: The requested grpc method name (using protobuf name)
-- `methodType`: The type of the requested grpc method.
-- `statusCode`: Response `Status.Code`
+- `method.type`: The type of the requested grpc method.
+- `status.code`: Response `Status.Code`
 
 ### Viewing the metrics
 

--- a/docs/zh-CN/actuator.md
+++ b/docs/zh-CN/actuator.md
@@ -54,7 +54,7 @@ compile("org.springframework.boot:spring-boot-starter-actuator")
 
 - `service`: 请求的 grpc 服务名称（使用 protubuf 名称）
 - `method`: 请求的 grpc 方法名称（使用 protobuf 名称）
-- `methodType`: 请求的 grpc 方法的类型。
+- `method.type`: 请求的 grpc 方法的类型。
 
 ### 计时器
 
@@ -65,8 +65,8 @@ compile("org.springframework.boot:spring-boot-starter-actuator")
 
 - `service`: 请求的 grpc 服务名称（使用 protobuf 名称）
 - `method`: 请求的 grpc 方法名称（使用 protobuf 名称）
-- `methodType`: 请求的 grpc 方法的类型。
-- `statusCode`: 响应的 `Status.Code`
+- `method.type`: 请求的 grpc 方法的类型。
+- `status.code`: 响应的 `Status.Code`
 
 ### 查看指标
 

--- a/grpc-common-spring-boot/src/main/java/net/devh/boot/grpc/common/metric/MetricConstants.java
+++ b/grpc-common-spring-boot/src/main/java/net/devh/boot/grpc/common/metric/MetricConstants.java
@@ -61,11 +61,11 @@ public final class MetricConstants {
     /**
      * The metrics tag key that belongs to the type of the called method.
      */
-    public static final String TAG_METHOD_TYPE = "methodType";
+    public static final String TAG_METHOD_TYPE = "method.type";
     /**
      * The metrics tag key that belongs to the result status code.
      */
-    public static final String TAG_STATUS_CODE = "statusCode";
+    public static final String TAG_STATUS_CODE = "status.code";
 
     private MetricConstants() {}
 


### PR DESCRIPTION
See. https://micrometer.io/docs/concepts#_tag_naming

With the current implementation and using official prometheus exporter,
we end up with label names `methodType` and `statusCode`. These labels
don't follow the snake_case naming convention that prometheus follows
for labels.
Using dot for word separator makes micrometer automatically convert
label names to snake case out of the box. 
See. https://github.com/micrometer-metrics/micrometer/blob/main/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheus/PrometheusNamingConvention.java
