### PR TITLE
Only create a StubTransformer if it's not already provided

### DIFF
--- a/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/autoconfigure/GrpcClientSecurityAutoConfiguration.java
+++ b/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/autoconfigure/GrpcClientSecurityAutoConfiguration.java
@@ -18,6 +18,7 @@
 package net.devh.boot.grpc.client.autoconfigure;
 
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnSingleCandidate;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -51,7 +52,7 @@ public class GrpcClientSecurityAutoConfiguration {
      *
      * <p>
      * <b>Note:</b> This method will only be applied if exactly one {@link CallCredentials} is in the application
-     * context.
+     * context, and another StubTransformer isn't provided.
      * </p>
      *
      * @param credentials The call credentials to configure in the stubs.
@@ -60,6 +61,7 @@ public class GrpcClientSecurityAutoConfiguration {
      * @sse {@link CallCredentialsHelper#fixedCredentialsStubTransformer(CallCredentials)}
      */
     @ConditionalOnSingleCandidate(CallCredentials.class)
+    @ConditionalOnMissingBean
     @Bean
     StubTransformer stubCallCredentialsTransformer(final CallCredentials credentials) {
         log.info("Found single CallCredentials in the context, automatically using it for all stubs");


### PR DESCRIPTION
We stumbled upon this issue where even though we had a StubTransformer bean, another one was getting created because there was one CallCredential bean in the context.

While I appreciate the easiness of the automation, it should NOT execute if the app is already providing one in it's context.

In the PR added a `@ConditionalOnMissingBean` to skip initialisation if one is already provided in the context.