### PR TITLE
Replace deprecated io.grpc.services.HealthStatusManager

### DIFF
--- a/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/autoconfigure/GrpcHealthServiceAutoConfiguration.java
+++ b/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/autoconfigure/GrpcHealthServiceAutoConfiguration.java
@@ -25,7 +25,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 import io.grpc.BindableService;
-import io.grpc.services.HealthStatusManager;
+import io.grpc.protobuf.services.HealthStatusManager;
 import net.devh.boot.grpc.server.service.GrpcService;
 
 /**


### PR DESCRIPTION
io.grpc.services.HealthStatusManager is deprecated and io.grpc.protobuf.services.HealthStatusManager should be used instead