### PR TITLE
Update GitHub workflows to use the latest actions versions

### DIFF
--- a/.github/workflows/build-master.yml
+++ b/.github/workflows/build-master.yml
@@ -13,32 +13,32 @@ jobs:
       matrix:
         java: ['8', '11']
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Validate Gradle wrapper
+        uses: gradle/wrapper-validation-action@v1
 
       - name: Set up java ${{ matrix.java }}
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
+          distribution: temurin
           java-version: ${{ matrix.java }}
-
-      - name: Cache Gradle packages
-        uses: actions/cache@v2
-        with:
-          path: ~/.gradle/caches
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
-          restore-keys: ${{ runner.os }}-gradle
-
-      - name: Grant execute permission for gradlew
-        run: chmod +x gradlew
+          check-latest: true
 
       - name: Decrypt file
         run: openssl aes-256-cbc -K ${{ secrets.ENCRYPTED_KEY }} -iv ${{ secrets.ENCRYPTED_IV }} -in private.key.enc -out ./private.key -d && gpg --batch --import ./private.key || echo
 
       - name: Build with Gradle
-        run: ./gradlew --scan --stacktrace --warning-mode=all build
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: --scan --stacktrace --warning-mode=all build
 
       - name: Deploy with Gradle
-        run: ./gradlew --scan publish -x check -Psigning.gnupg.executable=gpg -Psigning.gnupg.keyName=${{ secrets.GPG_NAME }} -Psigning.gnupg.passphrase=${{ secrets.GPG_PASSWORD }}
         if: ${{ matrix.java == '8' }}
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: --scan publish -x check -Psigning.gnupg.executable=gpg -Psigning.gnupg.keyName=${{ secrets.GPG_NAME }} -Psigning.gnupg.passphrase=${{ secrets.GPG_PASSWORD }}
         env:
           OSSRH_USER: ${{ secrets.OSSRH_USER }}
           OSSRH_PASS: ${{ secrets.OSSRH_PASS }}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -10,26 +10,26 @@ jobs:
       matrix:
         java: ['8', '11']
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Validate Gradle wrapper
+        uses: gradle/wrapper-validation-action@v1
 
       - name: Set up java ${{ matrix.java }}
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
+          distribution: temurin
           java-version: ${{ matrix.java }}
-
-      - name: Cache Gradle packages
-        uses: actions/cache@v2
-        with:
-          path: ~/.gradle/caches
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
-          restore-keys: ${{ runner.os }}-gradle
-
-      - name: Grant execute permission for gradlew
-        run: chmod +x gradlew
+          check-latest: true
 
       - name: Build with Gradle
-        run: ./gradlew --scan --stacktrace --warning-mode=all build
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: --scan --stacktrace --warning-mode=all build
 
       # Avoid publish errors when upgrading gradle version and dependencyManager plugin
       - name: Try publishToMavenLocal
-        run: ./gradlew publishToMavenLocal
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: publishToMavenLocal


### PR DESCRIPTION
Switch also to https://github.com/gradle/gradle-build-action and Gradle wrapper validation step (to avoid PRs with malicious wrapper jars).

Added dependabot.yml to enable automatic GitHub actions version scanning. Dependabot can be also used to scan Gradle dependencies. But from my experience, Renovatebot is working better with Gradle, and it also supports GitHub actions.
But to enable Renovate you have to do it by yourselves.
