### PR TITLE
Fix kubernetes config doc

### DIFF
--- a/docs/en/kubernetes.md
+++ b/docs/en/kubernetes.md
@@ -51,15 +51,15 @@ spec:
 ````properties
 ## Choose your matching variant
 # Same namespace (target port=80 or derived by DNS-SVC)
-grpc.clients.my-grpc-server-app.address=dns:///my-grpc-server-app
+grpc.client.my-grpc-server-app.address=dns:///my-grpc-server-app
 # Same namespace (different port)
-grpc.clients.my-grpc-server-app.address=dns:///my-grpc-server-app:1234
+grpc.client.my-grpc-server-app.address=dns:///my-grpc-server-app:1234
 # Different namespace
-grpc.clients.my-grpc-server-app.address=dns:///my-grpc-server-app.example:1234
+grpc.client.my-grpc-server-app.address=dns:///my-grpc-server-app.example:1234
 # Different cluster
-grpc.clients.my-grpc-server-app.address=dns:///my-grpc-server-app.example.svc.cluster.local:1234
+grpc.client.my-grpc-server-app.address=dns:///my-grpc-server-app.example.svc.cluster.local:1234
 # Format
-grpc.clients.my-grpc-server-app.address=dns:///<serviceName>[.<namespace>[.<clusterAddress>]][:<service-port>]
+grpc.client.my-grpc-server-app.address=dns:///<serviceName>[.<namespace>[.<clusterAddress>]][:<service-port>]
 ````
 
 > **Note:** DNS-SVC lookups require the `grpclb` dependency to be present and the service's port name to be `grpclb`.


### PR DESCRIPTION
[This member variable](https://github.com/yidongnan/grpc-spring-boot-starter/blob/master/grpc-client-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/client/config/GrpcChannelsProperties.java#L48) is called "client" (not "clients") so spring will fail to populate the values as documented. 

Locally I tried:
```
grpc:
  client:
    my-server:
      address: dns:///my-server-using-client
  clients:
    my-server:
      address: dns:///my-server-using-client-with-s
```
And confirmed that the address is not populated with an "s" provided.
