### PR TITLE
BREAKING: Add support for call attribute based authorization checks

### DIFF
--- a/docs/en/server/security.md
+++ b/docs/en/server/security.md
@@ -232,7 +232,7 @@ GrpcSecurityMetadataSource grpcSecurityMetadataSource() {
     source.set(MyServiceGrpc.getMethodA(), AccessPredicate.authenticated());
     source.set(MyServiceGrpc.getMethodB(), AccessPredicate.hasRole("ROLE_USER"));
     source.set(MyServiceGrpc.getMethodC(), AccessPredicate.hasAllRole("ROLE_FOO", "ROLE_BAR"));
-    source.set(MyServiceGrpc.getMethodD(), auth -> "admin".equals(auth.getName()));
+    source.set(MyServiceGrpc.getMethodD(), (auth, call) -> "admin".equals(auth.getName()));
     source.setDefault(AccessPredicate.denyAll());
     return source;
 }

--- a/docs/zh-CN/server/security.md
+++ b/docs/zh-CN/server/security.md
@@ -202,7 +202,7 @@ GrpcSecurityMetadataSource grpcSecurityMetadataSource() {
     source.set(MyServiceGrpc.getMethodA(), AccessPredicate.authenticated());
     source.set(MyServiceGrpc.getMethodB(), AccessPredicate.hasRole("ROLE_USER"));
     source.set(MyServiceGrpc.getMethodC(), AccessPredicate.hasAllRole("ROLE_FOO", "ROLE_BAR"));
-    source.set(MyServiceGrpc.getMethodD(), auth -> "admin".equals(auth.getName()));
+    source.set(MyServiceGrpc.getMethodD(), (auth, call) -> "admin".equals(auth.getName()));
     source.setDefault(AccessPredicate.denyAll());
     return source;
 }

--- a/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/security/check/AbstractGrpcSecurityMetadataSource.java
+++ b/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/security/check/AbstractGrpcSecurityMetadataSource.java
@@ -21,27 +21,27 @@ import java.util.Collection;
 
 import org.springframework.security.access.ConfigAttribute;
 
-import io.grpc.MethodDescriptor;
+import io.grpc.ServerCall;
 
 /**
  * Abstract implementation of {@link GrpcSecurityMetadataSource} which resolves the secured object type to a
- * {@link MethodDescriptor}.
+ * {@link ServerCall}.
  *
- * @author Daniel Theuke (daniel.theuke@heuboe.de)
+ * @author Daniel Theuke (daniel.theuke@aequitas-software.de)
  */
 public abstract class AbstractGrpcSecurityMetadataSource implements GrpcSecurityMetadataSource {
 
     @Override
     public final Collection<ConfigAttribute> getAttributes(final Object object) throws IllegalArgumentException {
-        if (object instanceof MethodDescriptor) {
-            return getAttributes((MethodDescriptor<?, ?>) object);
+        if (object instanceof ServerCall) {
+            return getAttributes((ServerCall<?, ?>) object);
         }
-        throw new IllegalArgumentException("Object must be a non-null MethodDescriptor");
+        throw new IllegalArgumentException("Object must be a ServerCall");
     }
 
     @Override
     public final boolean supports(final Class<?> clazz) {
-        return MethodDescriptor.class.equals(clazz);
+        return ServerCall.class.isAssignableFrom(clazz);
     }
 
 }

--- a/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/security/check/AccessPredicateVoter.java
+++ b/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/security/check/AccessPredicateVoter.java
@@ -23,12 +23,14 @@ import org.springframework.security.access.AccessDecisionVoter;
 import org.springframework.security.access.ConfigAttribute;
 import org.springframework.security.core.Authentication;
 
+import io.grpc.ServerCall;
+
 /**
  * An {@link AccessDecisionVoter} that checks for {@link AccessPredicateConfigAttribute}s.
  *
- * @author Daniel Theuke (daniel.theuke@heuboe.de)
+ * @author Daniel Theuke (daniel.theuke@aequitas-software.de)
  */
-public class AccessPredicateVoter implements AccessDecisionVoter<Object> {
+public class AccessPredicateVoter implements AccessDecisionVoter<ServerCall<?, ?>> {
 
     @Override
     public boolean supports(final ConfigAttribute attribute) {
@@ -37,17 +39,17 @@ public class AccessPredicateVoter implements AccessDecisionVoter<Object> {
 
     @Override
     public boolean supports(final Class<?> clazz) {
-        return true;
+        return ServerCall.class.isAssignableFrom(clazz);
     }
 
     @Override
-    public int vote(final Authentication authentication, final Object object,
+    public int vote(final Authentication authentication, final ServerCall<?, ?> serverCall,
             final Collection<ConfigAttribute> attributes) {
         final AccessPredicateConfigAttribute attr = find(attributes);
         if (attr == null) {
             return ACCESS_ABSTAIN;
         }
-        final boolean allowed = attr.getAccessPredicate().test(authentication);
+        final boolean allowed = attr.getAccessPredicate().test(authentication, serverCall);
         return allowed ? ACCESS_GRANTED : ACCESS_DENIED;
     }
 

--- a/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/security/check/AccessPredicates.java
+++ b/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/security/check/AccessPredicates.java
@@ -22,6 +22,8 @@ import java.util.function.Predicate;
 import org.springframework.security.authentication.InternalAuthenticationServiceException;
 import org.springframework.security.core.Authentication;
 
+import io.grpc.ServerCall;
+
 /**
  * Helper class that contains some internal constants for {@link AccessPredicate}s.
  *
@@ -40,7 +42,7 @@ final class AccessPredicates {
          */
         @Override
         @Deprecated // Should never be called
-        public boolean test(final Authentication t) {
+        public boolean test(final Authentication t, ServerCall<?, ?> serverCall) {
             throw new InternalAuthenticationServiceException(
                     "Tried to execute the 'permit-all' access predicate. The server's security configuration is broken.");
         }

--- a/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/security/check/GrpcSecurityMetadataSource.java
+++ b/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/security/check/GrpcSecurityMetadataSource.java
@@ -23,7 +23,7 @@ import org.springframework.security.access.AccessDecisionVoter;
 import org.springframework.security.access.ConfigAttribute;
 import org.springframework.security.access.SecurityMetadataSource;
 
-import io.grpc.MethodDescriptor;
+import io.grpc.ServerCall;
 
 /**
  * A {@link SecurityMetadataSource} for grpc requests.
@@ -33,17 +33,17 @@ import io.grpc.MethodDescriptor;
  * {@link AccessDecisionVoter} and a {@link GrpcSecurityMetadataSource} are present in the application context.
  * </p>
  *
- * @author Daniel Theuke (daniel.theuke@heuboe.de)
+ * @author Daniel Theuke (daniel.theuke@aequitas-software.de)
  */
 public interface GrpcSecurityMetadataSource extends SecurityMetadataSource {
 
     /**
      * Accesses the {@code ConfigAttribute}s that apply to a given secure object.
      *
-     * @param method The grpc method being secured.
+     * @param call The grpc call being secured.
      * @return The attributes that apply to the passed in secured object. Should return an empty collection if there are
      *         no applicable attributes.
      */
-    Collection<ConfigAttribute> getAttributes(final MethodDescriptor<?, ?> method);
+    Collection<ConfigAttribute> getAttributes(final ServerCall<?, ?> call);
 
 }

--- a/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/security/check/ManualGrpcSecurityMetadataSource.java
+++ b/grpc-server-spring-boot-autoconfigure/src/main/java/net/devh/boot/grpc/server/security/check/ManualGrpcSecurityMetadataSource.java
@@ -30,6 +30,7 @@ import org.springframework.security.access.ConfigAttribute;
 import org.springframework.security.core.Authentication;
 
 import io.grpc.MethodDescriptor;
+import io.grpc.ServerCall;
 import io.grpc.ServiceDescriptor;
 
 /**
@@ -41,16 +42,20 @@ import io.grpc.ServiceDescriptor;
  * <b>Note:</b> This instance is initialized with {@link AccessPredicate#denyAll() deny all} as default.
  * </p>
  *
- * @author Daniel Theuke (daniel.theuke@heuboe.de)
+ * @author Daniel Theuke (daniel.theuke@aequitas-software.de)
  */
 public final class ManualGrpcSecurityMetadataSource extends AbstractGrpcSecurityMetadataSource {
 
     private final Map<MethodDescriptor<?, ?>, Collection<ConfigAttribute>> accessMap = new HashMap<>();
     private Collection<ConfigAttribute> defaultAttributes = wrap(AccessPredicate.denyAll());
 
-    @Override
-    public Collection<ConfigAttribute> getAttributes(final MethodDescriptor<?, ?> method) {
+    private Collection<ConfigAttribute> getAttributes(final MethodDescriptor<?, ?> method) {
         return this.accessMap.getOrDefault(method, this.defaultAttributes);
+    }
+
+    @Override
+    public Collection<ConfigAttribute> getAttributes(final ServerCall<?, ?> call) {
+        return getAttributes(call.getMethodDescriptor());
     }
 
     @Override

--- a/tests/src/test/java/net/devh/boot/grpc/test/config/DualInProcessConfiguration.java
+++ b/tests/src/test/java/net/devh/boot/grpc/test/config/DualInProcessConfiguration.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2016-2021 Michael Zhang <yidongnan@gmail.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package net.devh.boot.grpc.test.config;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import io.grpc.inprocess.InProcessChannelBuilder;
+import net.devh.boot.grpc.client.channelfactory.GrpcChannelFactory;
+import net.devh.boot.grpc.client.channelfactory.InProcessChannelFactory;
+import net.devh.boot.grpc.client.config.GrpcChannelsProperties;
+import net.devh.boot.grpc.client.interceptor.GlobalClientInterceptorRegistry;
+import net.devh.boot.grpc.server.config.GrpcServerProperties;
+import net.devh.boot.grpc.server.serverfactory.GrpcServerFactory;
+import net.devh.boot.grpc.server.serverfactory.GrpcServerLifecycle;
+import net.devh.boot.grpc.server.serverfactory.InProcessGrpcServerFactory;
+import net.devh.boot.grpc.server.service.GrpcServiceDefinition;
+import net.devh.boot.grpc.server.service.GrpcServiceDiscoverer;
+
+@Configuration
+public class DualInProcessConfiguration {
+
+    @Bean
+    GrpcChannelFactory grpcChannelFactory(final GrpcChannelsProperties properties,
+            final GlobalClientInterceptorRegistry globalClientInterceptorRegistry) {
+        return new InProcessChannelFactory(properties, globalClientInterceptorRegistry) {
+
+            @Override
+            protected InProcessChannelBuilder newChannelBuilder(final String name) {
+                if (name.endsWith("-secondary")) {
+                    return super.newChannelBuilder("test-secondary");
+                }
+                return super.newChannelBuilder("test"); // Use fixed inMemory channel name: test
+            }
+
+        };
+    }
+
+    @Bean
+    GrpcServerFactory grpcServerFactory(final GrpcServerProperties properties,
+            final GrpcServiceDiscoverer discoverer) {
+        final InProcessGrpcServerFactory factory = new InProcessGrpcServerFactory("test", properties);
+        for (final GrpcServiceDefinition service : discoverer.findGrpcServices()) {
+            factory.addService(service);
+        }
+        return factory;
+    }
+
+
+    @Bean
+    GrpcServerFactory grpcServerFactorySecondary(final GrpcServerProperties properties,
+            final GrpcServiceDiscoverer discoverer) {
+        final InProcessGrpcServerFactory factory = new InProcessGrpcServerFactory("test-secondary", properties);
+        for (final GrpcServiceDefinition service : discoverer.findGrpcServices()) {
+            factory.addService(service);
+        }
+        return factory;
+    }
+
+    @Bean
+    GrpcServerLifecycle grpcServerLifecycle(
+            @Qualifier("grpcServerFactory") final GrpcServerFactory grpcServerFactory,
+            final GrpcServerProperties properties,
+            final ApplicationEventPublisher eventPublisher) {
+        return new GrpcServerLifecycle(grpcServerFactory, properties.getShutdownGracePeriod(), eventPublisher);
+    }
+
+    @Bean
+    GrpcServerLifecycle grpcServerLifecycleSecondary(
+            @Qualifier("grpcServerFactorySecondary") final GrpcServerFactory grpcServerFactory,
+            final GrpcServerProperties properties,
+            final ApplicationEventPublisher eventPublisher) {
+        return new GrpcServerLifecycle(grpcServerFactory, properties.getShutdownGracePeriod(), eventPublisher);
+    }
+
+}

--- a/tests/src/test/java/net/devh/boot/grpc/test/config/WithBasicAuthSecurityConfiguration.java
+++ b/tests/src/test/java/net/devh/boot/grpc/test/config/WithBasicAuthSecurityConfiguration.java
@@ -107,7 +107,9 @@ public class WithBasicAuthSecurityConfiguration {
     StubTransformer mappedCredentialsStubTransformer() {
         return CallCredentialsHelper.mappedCredentialsStubTransformer(ImmutableMap.<String, CallCredentials>builder()
                 .put("test", testCallCredentials("client1"))
+                .put("test-secondary", testCallCredentials("client1"))
                 .put("noPerm", testCallCredentials("client2"))
+                .put("noPerm-secondary", testCallCredentials("client2"))
                 .put("unknownUser", testCallCredentials("unknownUser"))
                 // .put("noAuth", null)
                 .build());

--- a/tests/src/test/java/net/devh/boot/grpc/test/security/AbstractSecurityTest.java
+++ b/tests/src/test/java/net/devh/boot/grpc/test/security/AbstractSecurityTest.java
@@ -28,7 +28,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BiFunction;
 
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestFactory;
 import org.springframework.test.annotation.DirtiesContext;
 
@@ -46,7 +45,7 @@ import net.devh.boot.grpc.test.proto.TestServiceGrpc.TestServiceStub;
 import net.devh.boot.grpc.test.util.DynamicTestCollection;
 import net.devh.boot.grpc.test.util.TriConsumer;
 
-public abstract class AbstractSecurityTest {
+abstract class AbstractSecurityTest {
 
     protected static final Empty EMPTY = Empty.getDefaultInstance();
 
@@ -69,10 +68,9 @@ public abstract class AbstractSecurityTest {
      *
      * @return The tests.
      */
-    @Test
     @DirtiesContext
     @TestFactory
-    public DynamicTestCollection unprotectedCallTests() {
+    DynamicTestCollection unprotectedCallTests() {
         return DynamicTestCollection.create()
                 .add("unprotected-default",
                         () -> assertNormalCallSuccess(this.serviceStub, this.blockingStub, this.futureStub))
@@ -104,10 +102,9 @@ public abstract class AbstractSecurityTest {
      *
      * @return The tests.
      */
-    @Test
     @DirtiesContext
     @TestFactory
-    public DynamicTestCollection unaryCallTest() {
+    DynamicTestCollection unaryCallTest() {
         return DynamicTestCollection.create()
                 .add("unary-default",
                         () -> assertUnaryCallSuccess(this.serviceStub, this.blockingStub, this.futureStub))
@@ -140,10 +137,9 @@ public abstract class AbstractSecurityTest {
      *
      * @return The tests.
      */
-    @Test
     @DirtiesContext
     @TestFactory
-    public DynamicTestCollection clientStreamingCallTests() {
+    DynamicTestCollection clientStreamingCallTests() {
         return DynamicTestCollection.create()
                 .add("clientStreaming-default", () -> assertClientStreamingCallSuccess(this.serviceStub))
                 .add("clientStreaming-noPerm",
@@ -170,9 +166,9 @@ public abstract class AbstractSecurityTest {
      *
      * @return The tests.
      */
-    @Test
     @DirtiesContext
-    public DynamicTestCollection serverStreamingCallTests() {
+    @TestFactory
+    DynamicTestCollection serverStreamingCallTests() {
         return DynamicTestCollection.create()
                 .add("serverStreaming-default",
                         () -> assertServerStreamingCallSuccess(this.serviceStub))
@@ -197,9 +193,9 @@ public abstract class AbstractSecurityTest {
      *
      * @return The tests.
      */
-    @Test
     @DirtiesContext
-    public DynamicTestCollection bidiStreamingCallTests() {
+    @TestFactory
+    DynamicTestCollection bidiStreamingCallTests() {
         return DynamicTestCollection.create()
                 .add("bidiStreaming-default", () -> assertBidiCallSuccess(this.serviceStub))
                 .add("bidiStreaming-noPerm", () -> assertBidiCallFailure(this.noPermStub, PERMISSION_DENIED));

--- a/tests/src/test/java/net/devh/boot/grpc/test/security/AbstractSecurityWithBasicAuthTest.java
+++ b/tests/src/test/java/net/devh/boot/grpc/test/security/AbstractSecurityWithBasicAuthTest.java
@@ -19,7 +19,6 @@ package net.devh.boot.grpc.test.security;
 
 import static io.grpc.Status.Code.UNAUTHENTICATED;
 
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestFactory;
 import org.springframework.test.annotation.DirtiesContext;
 
@@ -29,7 +28,7 @@ import net.devh.boot.grpc.test.proto.TestServiceGrpc.TestServiceFutureStub;
 import net.devh.boot.grpc.test.proto.TestServiceGrpc.TestServiceStub;
 import net.devh.boot.grpc.test.util.DynamicTestCollection;
 
-public abstract class AbstractSecurityWithBasicAuthTest extends AbstractSecurityTest {
+abstract class AbstractSecurityWithBasicAuthTest extends AbstractSecurityTest {
 
     @GrpcClient("unknownUser")
     protected TestServiceStub unknownUserStub;
@@ -46,10 +45,9 @@ public abstract class AbstractSecurityWithBasicAuthTest extends AbstractSecurity
     protected TestServiceFutureStub noAuthFutureStub;
 
     @Override
-    @Test
     @DirtiesContext
     @TestFactory
-    public DynamicTestCollection unprotectedCallTests() {
+    DynamicTestCollection unprotectedCallTests() {
         return super.unprotectedCallTests()
                 .add("unprotected-unknownUser",
                         () -> assertNormalCallFailure(this.unknownUserStub, this.unknownUserBlockingStub,
@@ -59,10 +57,9 @@ public abstract class AbstractSecurityWithBasicAuthTest extends AbstractSecurity
     }
 
     @Override
-    @Test
     @DirtiesContext
     @TestFactory
-    public DynamicTestCollection unaryCallTest() {
+    DynamicTestCollection unaryCallTest() {
         return super.unaryCallTest()
                 .add("unary-unknownUser",
                         () -> assertUnaryCallFailure(this.unknownUserStub, this.unknownUserBlockingStub,
@@ -73,10 +70,9 @@ public abstract class AbstractSecurityWithBasicAuthTest extends AbstractSecurity
     }
 
     @Override
-    @Test
     @DirtiesContext
     @TestFactory
-    public DynamicTestCollection clientStreamingCallTests() {
+    DynamicTestCollection clientStreamingCallTests() {
         return super.clientStreamingCallTests()
                 .add("clientStreaming-unknownUser",
                         () -> assertClientStreamingCallFailure(this.unknownUserStub, UNAUTHENTICATED))
@@ -85,10 +81,9 @@ public abstract class AbstractSecurityWithBasicAuthTest extends AbstractSecurity
     }
 
     @Override
-    @Test
     @DirtiesContext
     @TestFactory
-    public DynamicTestCollection serverStreamingCallTests() {
+    DynamicTestCollection serverStreamingCallTests() {
         return super.serverStreamingCallTests()
                 .add("serverStreaming-unknownUser",
                         () -> assertServerStreamingCallFailure(this.unknownUserStub, UNAUTHENTICATED))
@@ -97,10 +92,9 @@ public abstract class AbstractSecurityWithBasicAuthTest extends AbstractSecurity
     }
 
     @Override
-    @Test
     @DirtiesContext
     @TestFactory
-    public DynamicTestCollection bidiStreamingCallTests() {
+    DynamicTestCollection bidiStreamingCallTests() {
         return super.bidiStreamingCallTests()
                 .add("bidiStreaming-unknownUser",
                         () -> assertServerStreamingCallFailure(this.unknownUserStub, UNAUTHENTICATED))

--- a/tests/src/test/java/net/devh/boot/grpc/test/security/ManualSecurityWithBasicAuthTest.java
+++ b/tests/src/test/java/net/devh/boot/grpc/test/security/ManualSecurityWithBasicAuthTest.java
@@ -17,32 +17,113 @@
 
 package net.devh.boot.grpc.test.security;
 
+import static io.grpc.Status.Code.PERMISSION_DENIED;
+
+import org.junit.jupiter.api.TestFactory;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
 import lombok.extern.slf4j.Slf4j;
+import net.devh.boot.grpc.client.inject.GrpcClient;
 import net.devh.boot.grpc.test.config.BaseAutoConfiguration;
-import net.devh.boot.grpc.test.config.InProcessConfiguration;
+import net.devh.boot.grpc.test.config.DualInProcessConfiguration;
 import net.devh.boot.grpc.test.config.ManualSecurityConfiguration;
 import net.devh.boot.grpc.test.config.ServiceConfiguration;
 import net.devh.boot.grpc.test.config.WithBasicAuthSecurityConfiguration;
+import net.devh.boot.grpc.test.proto.TestServiceGrpc.TestServiceBlockingStub;
+import net.devh.boot.grpc.test.proto.TestServiceGrpc.TestServiceFutureStub;
+import net.devh.boot.grpc.test.proto.TestServiceGrpc.TestServiceStub;
+import net.devh.boot.grpc.test.util.DynamicTestCollection;
 
 /**
  * A test checking that the server and client can start and connect to each other with minimal config.
- *
- * @author Daniel Theuke (daniel.theuke@heuboe.de)
  */
 @Slf4j
 @SpringBootTest
 @SpringJUnitConfig(
-        classes = {ServiceConfiguration.class, InProcessConfiguration.class, BaseAutoConfiguration.class,
+        classes = {ServiceConfiguration.class, DualInProcessConfiguration.class, BaseAutoConfiguration.class,
                 ManualSecurityConfiguration.class, WithBasicAuthSecurityConfiguration.class})
 @DirtiesContext
-public class ManualSecurityWithBasicAuthTest extends AbstractSecurityWithBasicAuthTest {
+class ManualSecurityWithBasicAuthTest extends AbstractSecurityWithBasicAuthTest {
 
-    public ManualSecurityWithBasicAuthTest() {
+    // The secondary stubs use the secondary server
+
+    @GrpcClient("test-secondary")
+    protected TestServiceStub serviceStubSecondary;
+    @GrpcClient("test-secondary")
+    protected TestServiceBlockingStub blockingStubSecondary;
+    @GrpcClient("test-secondary")
+    protected TestServiceFutureStub futureStubSecondary;
+
+    @GrpcClient("noPerm-secondary")
+    protected TestServiceStub noPermStubSecondary;
+    @GrpcClient("noPerm-secondary")
+    protected TestServiceBlockingStub noPermBlockingStubSecondary;
+    @GrpcClient("noPerm-secondary")
+    protected TestServiceFutureStub noPermFutureStubSecondary;
+
+    ManualSecurityWithBasicAuthTest() {
         log.info("--- ManualSecurityWithBasicAuthTest ---");
+    }
+
+    @Override
+    @DirtiesContext
+    @TestFactory
+    DynamicTestCollection unprotectedCallTests() {
+        return super.unprotectedCallTests()
+                .add("unprotected-secondary",
+                        () -> assertNormalCallSuccess(this.serviceStubSecondary, this.blockingStubSecondary,
+                                this.futureStubSecondary))
+                .add("unprotected-noPerm-secondary",
+                        () -> assertNormalCallSuccess(this.noPermStubSecondary, this.noPermBlockingStubSecondary,
+                                this.noPermFutureStubSecondary));
+    }
+
+    @Override
+    @DirtiesContext
+    @TestFactory
+    DynamicTestCollection unaryCallTest() {
+        return super.unaryCallTest()
+                .add("unary-secondary",
+                        () -> assertUnaryCallSuccess(this.serviceStubSecondary, this.blockingStubSecondary,
+                                this.futureStubSecondary))
+                .add("unary-noPerm-secondary",
+                        () -> assertUnaryCallFailure(this.noPermStubSecondary, this.noPermBlockingStubSecondary,
+                                this.noPermFutureStubSecondary, PERMISSION_DENIED));
+    }
+
+    @Override
+    @DirtiesContext
+    @TestFactory
+    DynamicTestCollection clientStreamingCallTests() {
+        return super.clientStreamingCallTests()
+                .add("clientStreaming-secondary",
+                        () -> assertClientStreamingCallFailure(this.serviceStubSecondary, PERMISSION_DENIED))
+                .add("clientStreaming-noPerm-secondary",
+                        () -> assertClientStreamingCallFailure(this.noPermStubSecondary, PERMISSION_DENIED));
+    }
+
+    @Override
+    @DirtiesContext
+    @TestFactory
+    DynamicTestCollection serverStreamingCallTests() {
+        return super.serverStreamingCallTests()
+                .add("serverStreaming-secondary",
+                        () -> assertServerStreamingCallSuccess(this.serviceStubSecondary))
+                .add("serverStreaming-noPerm-secondary",
+                        () -> assertServerStreamingCallSuccess(this.noPermStubSecondary));
+    }
+
+    @Override
+    @DirtiesContext
+    @TestFactory
+    DynamicTestCollection bidiStreamingCallTests() {
+        return super.bidiStreamingCallTests()
+                .add("bidiStreaming-secondary",
+                        () -> assertServerStreamingCallSuccess(this.serviceStubSecondary))
+                .add("bidiStreaming-noPerm-secondary",
+                        () -> assertServerStreamingCallSuccess(this.noPermStubSecondary));
     }
 
 }

--- a/tests/src/test/java/net/devh/boot/grpc/test/security/ManualSecurityWithCertificateTest.java
+++ b/tests/src/test/java/net/devh/boot/grpc/test/security/ManualSecurityWithCertificateTest.java
@@ -50,9 +50,9 @@ import net.devh.boot.grpc.test.config.WithCertificateSecurityConfiguration;
         classes = {ServiceConfiguration.class, BaseAutoConfiguration.class, ManualSecurityConfiguration.class,
                 WithCertificateSecurityConfiguration.class})
 @DirtiesContext
-public class ManualSecurityWithCertificateTest extends AbstractSecurityTest {
+class ManualSecurityWithCertificateTest extends AbstractSecurityTest {
 
-    public ManualSecurityWithCertificateTest() {
+    ManualSecurityWithCertificateTest() {
         log.info("--- ManualSecurityWithCertificateTest ---");
     }
 


### PR DESCRIPTION
This PR is breaking, if you implemented the `AccessPredicate` or `GrpcSecurityMetadataSource` interface yourself or extend `AbstractGrpcSecurityMetadataSource`, this should be a very rare usecase. Migration is very easy, as only a new parameter has to be added.

Now, it is possible to use the `ManualGrpcSecurityMetadataSource` to grant or deny access based on call attributes such as the client address in addition to the `Authentication` and `GrpcContext` based checks.

Example configuration:

````java
 GrpcSecurityMetadataSource grpcSecurityMetadataSource() {
        ManualGrpcSecurityMetadataSource source = new ManualGrpcSecurityMetadataSource();

        source.set(TestServiceGrpc.onlyWithRoleIfAccessedViaIP(),
                hasRole("ROLE_CLIENT1").and(fromClientAddress(inet())));

        source.set(TestServiceGrpc.authenticatedOrViaInProcessServer(),
                hasRole("ROLE_CLIENT1").or(toServerAddress(inProcess("my-service"))));

        source.setDefault(permitAll());
        return source;
    }
````

Implements suggestion from: https://github.com/yidongnan/grpc-spring-boot-starter/issues/682#issuecomment-1146471401