### PR TITLE
Remove obsolete excludes for junit vintage

### DIFF
--- a/docs/en/client/testing.md
+++ b/docs/en/client/testing.md
@@ -86,13 +86,6 @@ For Maven add the following dependencies:
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-test</artifactId>
     <scope>test</scope>
-    <!-- Exclude the test engine you don't need -->
-    <exclusions>
-        <exclusion>
-            <groupId>org.junit.vintage</groupId>
-            <artifactId>junit-vintage-engine</artifactId>
-        </exclusion>
-    </exclusions>
 </dependency>
 <!-- Mocking Framework (Optional) -->
 <dependency>
@@ -111,10 +104,7 @@ testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
 // Grpc-Test-Support
 testImplementation("io.grpc:grpc-testing")
 // Spring-Test-Support (Optional)
-testImplementation("org.springframework.boot:spring-boot-starter-test") {
-    // Exclude the test engine you don't need
-    exclude group: 'org.junit.vintage', module: 'junit-vintage-engine'
-}
+testImplementation("org.springframework.boot:spring-boot-starter-test")
 // Mocking Framework (Optional)
 testImplementation("org.mockito:mockito-all")
 ````

--- a/docs/en/server/testing.md
+++ b/docs/en/server/testing.md
@@ -101,13 +101,6 @@ For Maven add the following dependencies:
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-test</artifactId>
     <scope>test</scope>
-    <!-- Exclude the test engine you don't need -->
-    <exclusions>
-        <exclusion>
-            <groupId>org.junit.vintage</groupId>
-            <artifactId>junit-vintage-engine</artifactId>
-        </exclusion>
-    </exclusions>
 </dependency>
 ````
 
@@ -120,10 +113,7 @@ testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
 // Grpc-Test-Support
 testImplementation("io.grpc:grpc-testing")
 // Spring-Test-Support (Optional)
-testImplementation("org.springframework.boot:spring-boot-starter-test") {
-    // Exclude the test engine you don't need
-    exclude group: 'org.junit.vintage', module: 'junit-vintage-engine'
-}
+testImplementation("org.springframework.boot:spring-boot-starter-test")
 ````
 
 ## Unit Tests

--- a/docs/zh-CN/client/testing.md
+++ b/docs/zh-CN/client/testing.md
@@ -85,13 +85,6 @@ public class MyComponent {
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-test</artifactId>
     <scope>test</scope>
-    <!-- Exclude the test engine you don't need -->
-    <exclusions>
-        <exclusion>
-            <groupId>org.junit.vintage</groupId>
-            <artifactId>junit-vintage-engine</artifactId>
-        </exclusion>
-    </exclusions>
 </dependency>
 <!-- Mocking Framework (Optional) -->
 <dependency>
@@ -110,10 +103,7 @@ testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
 // Grpc-Test-Support
 testImplementation("io.grpc:grpc-testing")
 // Spring-Test-Support (Optional)
-testImplementation("org.springframework.boot:spring-boot-starter-test") {
-    // Exclude the test engine you don't need
-    exclude group: 'org.junit.vintage', module: 'junit-vintage-engine'
-}
+testImplementation("org.springframework.boot:spring-boot-starter-test")
 // Mocking Framework (Optional)
 testImplementation("org.mockito:mockito-all")
 ````

--- a/docs/zh-CN/server/testing.md
+++ b/docs/zh-CN/server/testing.md
@@ -100,13 +100,6 @@ public class MyServiceImpl extends MyServiceGrpc.MyServiceImplBase {
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-test</artifactId>
     <scope>test</scope>
-    <!-- Exclude the test engine you don't need -->
-    <exclusions>
-        <exclusion>
-            <groupId>org.junit.vintage</groupId>
-            <artifactId>junit-vintage-engine</artifactId>
-        </exclusion>
-    </exclusions>
 </dependency>
 ````
 
@@ -119,10 +112,7 @@ testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
 // Grpc-Test-Support
 testImplementation("io.grpc:grpc-testing")
 // Spring-Test-Support (Optional)
-testImplementation("org.springframework.boot:spring-boot-starter-test") {
-    // Exclude the test engine you don't need
-    exclude group: 'org.junit.vintage', module: 'junit-vintage-engine'
-}
+testImplementation("org.springframework.boot:spring-boot-starter-test")
 ````
 
 ## 单元测试

--- a/examples/cloud-eureka-server/build.gradle
+++ b/examples/cloud-eureka-server/build.gradle
@@ -6,8 +6,5 @@ dependencies {
     implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-server'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
 
-    testImplementation('org.springframework.boot:spring-boot-starter-test'){
-        exclude module: 'junit-vintage-engine'
-        exclude module: 'junit'
-    }
+    testImplementation('org.springframework.boot:spring-boot-starter-test')
 }

--- a/grpc-client-spring-boot-autoconfigure/build.gradle
+++ b/grpc-client-spring-boot-autoconfigure/build.gradle
@@ -30,12 +30,5 @@ dependencies {
     api 'io.grpc:grpc-stub'
 
     testImplementation 'io.grpc:grpc-testing'
-    testImplementation('org.springframework.boot:spring-boot-starter-test') {
-        exclude module: 'junit-vintage-engine'
-        exclude module: 'junit'
-    }
-
-    testImplementation 'org.junit.jupiter:junit-jupiter-api'
-
-    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine'
+    testImplementation('org.springframework.boot:spring-boot-starter-test')
 }

--- a/grpc-server-spring-boot-autoconfigure/build.gradle
+++ b/grpc-server-spring-boot-autoconfigure/build.gradle
@@ -31,11 +31,5 @@ dependencies {
     api 'io.grpc:grpc-api'
 
     testImplementation 'io.grpc:grpc-testing'
-    testImplementation 'org.junit.jupiter:junit-jupiter-api'
-    testImplementation('org.springframework.boot:spring-boot-starter-test') {
-        exclude module: 'junit-vintage-engine'
-        exclude module: 'junit'
-    }
-
-    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine'
+    testImplementation('org.springframework.boot:spring-boot-starter-test')
 }

--- a/tests/build.gradle
+++ b/tests/build.gradle
@@ -71,10 +71,7 @@ dependencies {
         implementation 'jakarta.annotation:jakarta.annotation-api'
     }
     testImplementation 'io.grpc:grpc-testing'
-    testImplementation('org.springframework.boot:spring-boot-starter-test') {
-        exclude module: 'junit-vintage-engine'
-        exclude module: 'junit'
-    }
+    testImplementation('org.springframework.boot:spring-boot-starter-test')
 
     testImplementation 'org.springframework.boot:spring-boot-starter-actuator'
     testImplementation 'org.springframework.security:spring-security-config'


### PR DESCRIPTION
Spring Boot 2.7 does not have the vintage engine dependency
so it is being excluded in a bunch of places for no reason.