### PR TITLE
[DOC] update gRPC and protobuf version on docs

### DIFF
--- a/docs/en/server/getting-started.md
+++ b/docs/en/server/getting-started.md
@@ -47,9 +47,9 @@ We recommend splitting your project into 2-3 separate modules.
 
 ````xml
     <properties>
-        <protobuf.version>3.19.1</protobuf.version>
+        <protobuf.version>3.23.4</protobuf.version>
         <protobuf-plugin.version>0.6.1</protobuf-plugin.version>
-        <grpc.version>1.42.1</grpc.version>
+        <grpc.version>1.58.0</grpc.version>
     </properties>
 
     <dependencies>
@@ -109,9 +109,9 @@ We recommend splitting your project into 2-3 separate modules.
 ````gradle
 buildscript {
     ext {
-        protobufVersion = '3.19.1'
+        protobufVersion = '3.23.4'
         protobufPluginVersion = '0.8.18'
-        grpcVersion = '1.42.1'
+        grpcVersion = '1.58.0'
     }
 }
 

--- a/docs/zh-CN/server/getting-started.md
+++ b/docs/zh-CN/server/getting-started.md
@@ -44,9 +44,9 @@
 
 ````xml
     <properties>
-        <protobuf.version>3.19.1</protobuf.version>
+        <protobuf.version>3.23.4</protobuf.version>
         <protobuf-plugin.version>0.6.1</protobuf-plugin.version>
-        <grpc.version>1.42.1</grpc.version>
+        <grpc.version>1.58.0</grpc.version>
     </properties>
 
     <dependencies>
@@ -106,9 +106,9 @@
 ````gradle
 buildscript {
     ext {
-        protobufVersion = '3.19.1'
+        protobufVersion = '3.23.4'
         protobufPluginVersion = '0.8.18'
-        grpcVersion = '1.42.1'
+        grpcVersion = '1.58.0'
     }
 }
 


### PR DESCRIPTION
Hey,
I updated the gRPC and Protobuf version in the documentation to avoid this error:
```
symbol: isstringempty method (java.lang.object)
location: class com.google.protobuf.generatedmessagev3
```
This issue was caused by the older version of Protobuf (3.19.1) and gRPC (1.42.1) contained in the step-by-step configuration
